### PR TITLE
Make an abstract base class gate for unary iteration, which can be shared across implementations like QROM

### DIFF
--- a/cirq_qubitization/__init__.py
+++ b/cirq_qubitization/__init__.py
@@ -1,1 +1,2 @@
-from cirq_qubitization.unary_iteration import And, unary_iteration
+from cirq_qubitization.and_gate import And
+from cirq_qubitization.unary_iteration import UnaryIterationGate

--- a/cirq_qubitization/and_gate.py
+++ b/cirq_qubitization/and_gate.py
@@ -1,0 +1,64 @@
+from typing import Tuple
+import cirq
+
+
+class And(cirq.Gate):
+    """And gate optimized for T-count.
+
+    See https://arxiv.org/abs/1805.03662 for reference.
+
+    Assumptions:
+        * And(cv).on(c1, c2, target) assumes that target is initially in the |0> state.
+        * And(cv, adjoint=True).on(c1, c2, target) will always leave the target in |0> state.
+    """
+
+    def __init__(self, cv: Tuple[int, int] = (1, 1), *, adjoint: bool = False) -> None:
+        self.cv = cv
+        self.adjoint = adjoint
+
+    def _num_qubits_(self) -> int:
+        return 3
+
+    def __pow__(self, power: int) -> "And":
+        if power == 1:
+            return self
+        if power == -1:
+            return And(self.cv, adjoint=self.adjoint ^ True)
+        return NotImplemented
+
+    def __str__(self) -> str:
+        suffix = "" if self.cv == (1, 1) else str(self.cv)
+        return f"And†{suffix}" if self.adjoint else f"And{suffix}"
+
+    def __repr__(self) -> str:
+        return f"cirq_qubitization.And({self.cv}, adjoint={self.adjoint})"
+
+    def _circuit_diagram_info_(
+        self, args: cirq.CircuitDiagramInfoArgs
+    ) -> cirq.CircuitDiagramInfo:
+        controls = ["(0)", "@"]
+        target = "And†" if self.adjoint else "And"
+        return cirq.CircuitDiagramInfo(
+            wire_symbols=[controls[c] for c in self.cv] + [target]
+        )
+
+    def _has_unitary_(self) -> bool:
+        return not self.adjoint
+
+    def _decompose_(self, qubits) -> cirq.OP_TREE:
+        c1, c2, target = qubits
+        pre_post_ops = [cirq.X(q) for (q, v) in zip([c1, c2], self.cv) if v == 0]
+        yield pre_post_ops
+        if self.adjoint:
+            yield cirq.H(target)
+            yield cirq.measure(target, key=f"{target}")
+            yield cirq.CZ(c1, c2).with_classical_controls(f"{target}")
+            yield cirq.reset(target)
+        else:
+            yield [cirq.H(target), cirq.T(target)]
+            yield [cirq.CNOT(c1, target), cirq.CNOT(c2, target)]
+            yield [cirq.CNOT(target, c1), cirq.CNOT(target, c2)]
+            yield [cirq.T(c1) ** -1, cirq.T(c2) ** -1, cirq.T(target)]
+            yield [cirq.CNOT(target, c1), cirq.CNOT(target, c2)]
+            yield [cirq.H(target), cirq.S(target)]
+        yield pre_post_ops

--- a/cirq_qubitization/and_gate_tests.py
+++ b/cirq_qubitization/and_gate_tests.py
@@ -1,0 +1,29 @@
+from typing import Tuple
+import pytest
+import cirq
+import cirq_qubitization
+
+
+@pytest.mark.parametrize("cv", [(0, 0), (0, 1), (1, 0), (1, 1)])
+def test_and_gate(cv: Tuple[int, int]):
+    c1, c2, t = cirq.LineQubit.range(3)
+    input_states = [(0, 0, 0), (0, 1, 0), (1, 0, 0), (1, 1, 0)]
+    output_states = [inp[:2] + (1 if inp[:2] == cv else 0,) for inp in input_states]
+
+    circuit = cirq.Circuit(cirq_qubitization.And(cv).on(c1, c2, t))
+    for input, output in zip(input_states, output_states):
+        result = cirq.Simulator().simulate(circuit, initial_state=input)
+        assert result.dirac_notation()[1:-1] == "".join(str(x) for x in output)
+
+
+@pytest.mark.parametrize("cv", [(0, 0), (0, 1), (1, 0), (1, 1)])
+def test_and_gate_adjoint(cv: Tuple[int, int]):
+    c1, c2, t = cirq.LineQubit.range(3)
+    all_cvs = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    input_states = [inp + (1 if inp == cv else 0,) for inp in all_cvs]
+    output_states = [inp + (0,) for inp in all_cvs]
+
+    circuit = cirq.Circuit(cirq_qubitization.And(cv, adjoint=True).on(c1, c2, t))
+    for input, output in zip(input_states, output_states):
+        result = cirq.Simulator().simulate(circuit, initial_state=input)
+        assert result.dirac_notation()[1:-1] == "".join(str(x) for x in output)

--- a/cirq_qubitization/unary_iteration_test.py
+++ b/cirq_qubitization/unary_iteration_test.py
@@ -1,55 +1,56 @@
-from typing import Tuple
-import pytest
+from typing import Sequence
 import cirq
 import cirq_qubitization
 
 
-@pytest.mark.parametrize("cv", [(0, 0), (0, 1), (1, 0), (1, 1)])
-def test_and_gate(cv: Tuple[int, int]):
-    c1, c2, t = cirq.LineQubit.range(3)
-    input_states = [(0, 0, 0), (0, 1, 0), (1, 0, 0), (1, 1, 0)]
-    output_states = [inp[:2] + (1 if inp[:2] == cv else 0,) for inp in input_states]
+class ApplyXToLthQubit(cirq_qubitization.UnaryIterationGate):
+    def __init__(self, selection_length: int, target_length: int):
+        self.selection_length = selection_length
+        self.target_length = target_length
 
-    circuit = cirq.Circuit(cirq_qubitization.And(cv).on(c1, c2, t))
-    for input, output in zip(input_states, output_states):
-        result = cirq.Simulator().simulate(circuit, initial_state=input)
-        assert result.dirac_notation()[1:-1] == "".join(str(x) for x in output)
+    @property
+    def control_register(self) -> int:
+        return 1
 
+    @property
+    def selection_register(self) -> int:
+        return self.selection_length
 
-@pytest.mark.parametrize("cv", [(0, 0), (0, 1), (1, 0), (1, 1)])
-def test_and_gate_adjoint(cv: Tuple[int, int]):
-    c1, c2, t = cirq.LineQubit.range(3)
-    all_cvs = [(0, 0), (0, 1), (1, 0), (1, 1)]
-    input_states = [inp + (1 if inp == cv else 0,) for inp in all_cvs]
-    output_states = [inp + (0,) for inp in all_cvs]
+    @property
+    def target_register(self) -> int:
+        return self.target_length
 
-    circuit = cirq.Circuit(cirq_qubitization.And(cv, adjoint=True).on(c1, c2, t))
-    for input, output in zip(input_states, output_states):
-        result = cirq.Simulator().simulate(circuit, initial_state=input)
-        assert result.dirac_notation()[1:-1] == "".join(str(x) for x in output)
+    @property
+    def iteration_length(self) -> int:
+        return self.target_length
+
+    def nth_operation(
+        self, n: int, control: cirq.Qid, target: Sequence[cirq.Qid]
+    ) -> cirq.OP_TREE:
+        return cirq.CNOT(control, target[-(n + 1)])
 
 
 def test_unary_iteration():
-    def get_qubits(selection_length: int, target_length: int):
-        buffer = cirq.LineQubit.range(2 * selection_length + target_length + 1)
-        return (
-            buffer[0],
-            buffer[1 : 2 * selection_length : 2],
-            buffer[2 : 2 * selection_length + 1 : 2],
-            buffer[2 * selection_length + 1 :],
-        )
+    selection_length = 3
+    target_length = 5
+    all_qubits = cirq.LineQubit.range(2 * selection_length + target_length + 1)
+    control, selection, ancilla, target = (
+        all_qubits[0],
+        all_qubits[1 : 2 * selection_length : 2],
+        all_qubits[2 : 2 * selection_length + 1 : 2],
+        all_qubits[2 * selection_length + 1 :],
+    )
 
-    control, selection, ancilla, target = get_qubits(3, 5)
-    circuit = cirq_qubitization.unary_iteration(
-        control, selection, ancilla, cirq.X.on_each(*target[::-1])
-    ).circuit
+    circuit = cirq.Circuit(
+        ApplyXToLthQubit(3, 5).on(control, *selection, *ancilla, *target)
+    )
     sim = cirq.Simulator()
-    for selection_integer in range(len(target)):
-        svals = [int(x) for x in format(selection_integer, f"0{len(selection)}b")]
-        qubit_vals = {s: sval for s, sval in zip(selection, svals)}
-        qubit_vals.update({control: 1})
-        qubit_vals.update({x: 0 for x in ancilla + target})
-        initial_state = [qubit_vals[x] for x in sorted(circuit.all_qubits())]
+    for selection_integer in range(target_length):
+        svals = [int(x) for x in format(selection_integer, f"0{selection_length}b")]
+        qubit_vals = {x: int(x == control) for x in all_qubits}
+        qubit_vals.update({s: sval for s, sval in zip(selection, svals)})
+
+        initial_state = [qubit_vals[x] for x in all_qubits]
         result = sim.simulate(circuit, initial_state=initial_state)
         initial_state[-(selection_integer + 1)] = 1
         expected_output = "".join(str(x) for x in initial_state)


### PR DESCRIPTION
Refactored unary iteration to create an abstract base class `cirq.Gate` which can be shared across specific implementations like QROM. 

Also moved `And` gate to a separate module. 