### PR TITLE
Add QROM implementation using unary iteration

### DIFF
--- a/cirq_qubitization/__init__.py
+++ b/cirq_qubitization/__init__.py
@@ -1,2 +1,3 @@
 from cirq_qubitization.and_gate import And
 from cirq_qubitization.unary_iteration import UnaryIterationGate
+from cirq_qubitization.qrom import QROM

--- a/cirq_qubitization/qrom.py
+++ b/cirq_qubitization/qrom.py
@@ -1,0 +1,47 @@
+import cirq
+from typing import Optional, Sequence
+from cirq_qubitization import unary_iteration
+
+
+class QROM(unary_iteration.UnaryIterationGate):
+    """Gate to load data[l] in the target_register when selection_register stores integer l."""
+
+    def __init__(
+        self,
+        data: Sequence[int],
+        *,
+        selection_register: Optional[int] = None,
+        target_register: Optional[int] = None,
+    ):
+        if selection_register is None:
+            selection_register = len(data).bit_length()
+        if target_register is None:
+            target_register = max(data).bit_length()
+        assert 2**selection_register >= len(data)
+        assert 2**target_register >= max(data)
+        self._data = data
+        self._selection_register = selection_register
+        self._target_register = target_register
+
+    @property
+    def control_register(self) -> int:
+        return 1
+
+    @property
+    def selection_register(self) -> int:
+        return self._selection_register
+
+    @property
+    def target_register(self) -> int:
+        return self._target_register
+
+    @property
+    def iteration_length(self) -> int:
+        return len(self._data)
+
+    def nth_operation(
+        self, n: int, control: cirq.Qid, target: Sequence[cirq.Qid]
+    ) -> cirq.OP_TREE:
+        for i, bit in enumerate(format(self._data[n], f"0{len(target)}b")):
+            if bit == "1":
+                yield cirq.CNOT(control, target[i])

--- a/cirq_qubitization/qrom_test.py
+++ b/cirq_qubitization/qrom_test.py
@@ -1,0 +1,32 @@
+import cirq
+import cirq_qubitization
+
+
+def test_qrom():
+    data = [1, 2, 3, 4, 5]
+    qrom = cirq_qubitization.QROM(data)
+    all_qubits = cirq.LineQubit.range(qrom.num_qubits())
+    control, selection, ancilla, target = (
+        all_qubits[0],
+        all_qubits[1 : 2 * qrom.selection_register : 2],
+        all_qubits[2 : 2 * qrom.selection_register + 1 : 2],
+        all_qubits[2 * qrom.selection_register + 1 :],
+    )
+    circuit = cirq.Circuit(qrom.on(control, *selection, *ancilla, *target))
+
+    sim = cirq.Simulator()
+    for selection_integer in range(qrom.iteration_length):
+        svals = [
+            int(x) for x in format(selection_integer, f"0{qrom.selection_register}b")
+        ]
+        qubit_vals = {x: int(x == control) for x in all_qubits}
+        qubit_vals.update({s: sval for s, sval in zip(selection, svals)})
+
+        initial_state = [qubit_vals[x] for x in all_qubits]
+        result = sim.simulate(circuit, initial_state=initial_state)
+        initial_state[2 * qrom.selection_register + 1 :] = [
+            int(x)
+            for x in format(data[selection_integer], f"0{qrom.selection_register}b")
+        ]
+        expected_output = "".join(str(x) for x in initial_state)
+        assert result.dirac_notation()[1:-1] == expected_output


### PR DESCRIPTION
* Adds implementation of `cirq_qubitization.QROM` based on `cirq_qubitization.UnaryIteration`. 
* Currently assumes that the data to be loaded is given as integers. 
* TODO: Support loading floats by automatically converting to integers based on a given target precision. 