### PR TITLE
Add `LessThanGate` and `PrepareUniformSuperposition` gate

### DIFF
--- a/cirq_qubitization/__init__.py
+++ b/cirq_qubitization/__init__.py
@@ -1,3 +1,5 @@
 from cirq_qubitization.and_gate import And
+from cirq_qubitization.arithmetic_gates import LessThanGate
+from cirq_qubitization.prepare_uniform_superposition import PrepareUniformSuperposition
 from cirq_qubitization.unary_iteration import UnaryIterationGate
 from cirq_qubitization.qrom import QROM

--- a/cirq_qubitization/arithmetic_gates.py
+++ b/cirq_qubitization/arithmetic_gates.py
@@ -1,0 +1,27 @@
+from typing import Union, Sequence, Iterable
+import cirq
+
+
+class LessThanGate(cirq.ArithmeticGate):
+    """Applies U_a|x>|z> = |x> |z ^ (x < a)>"""
+
+    def __init__(self, input_register: Sequence[int], val: int) -> None:
+        self._input_register = input_register
+        self._val = val
+        self._target_register = [2]
+
+    def registers(self) -> Sequence[Union[int, Sequence[int]]]:
+        return self._input_register, self._val, self._target_register
+
+    def with_registers(
+        self, *new_registers: Union[int, Sequence[int]]
+    ) -> "LessThanGate":
+        return LessThanGate(new_registers[0], new_registers[1])
+
+    def apply(
+        self, input_val, max_val, target_register_val
+    ) -> Union[int, Iterable[int]]:
+        return input_val, max_val, target_register_val ^ (input_val < max_val)
+
+    def __repr__(self):
+        return f"cirq_qubitization.LessThanGate({self._input_register, self._val})"

--- a/cirq_qubitization/arithmetic_gates_test.py
+++ b/cirq_qubitization/arithmetic_gates_test.py
@@ -1,0 +1,27 @@
+import cirq_qubitization
+import cirq
+
+
+def test_less_than_gate():
+    circuit = cirq.Circuit(
+        cirq_qubitization.LessThanGate([2, 2, 2], 5).on(*cirq.LineQubit.range(4))
+    )
+    maps = {
+        0b_000_0: 0b_000_1,
+        0b_000_1: 0b_000_0,
+        0b_001_0: 0b_001_1,
+        0b_001_1: 0b_001_0,
+        0b_010_0: 0b_010_1,
+        0b_010_1: 0b_010_0,
+        0b_011_0: 0b_011_1,
+        0b_011_1: 0b_011_0,
+        0b_100_0: 0b_100_1,
+        0b_100_1: 0b_100_0,
+        0b_101_0: 0b_101_0,
+        0b_101_1: 0b_101_1,
+        0b_110_0: 0b_110_0,
+        0b_110_1: 0b_110_1,
+        0b_111_0: 0b_111_0,
+        0b_111_1: 0b_111_1,
+    }
+    cirq.testing.assert_equivalent_computational_basis_map(maps, circuit)

--- a/cirq_qubitization/prepare_uniform_superposition.py
+++ b/cirq_qubitization/prepare_uniform_superposition.py
@@ -1,0 +1,61 @@
+from typing import List
+
+import numpy as np
+
+from cirq_qubitization.arithmetic_gates import LessThanGate
+import cirq
+
+
+class PrepareUniformSuperposition(cirq.Gate):
+    def __init__(self, n: int, *, num_controls: int = 0):
+        target_register = (n - 1).bit_length()
+        self._K = 0
+        while n > 1 and n % 2 == 0:
+            self._K += 1
+            n = n / 2
+        self._L = n
+        self._logL = target_register - self._K
+        self._num_controls = num_controls
+
+    def _num_qubits_(self) -> int:
+        return self._num_controls + self._K + self._logL + 1
+
+    def __repr__(self) -> str:
+        return (
+            f"cirq_qubitization.PrepareUniformSuperposition("
+            f"{(2**self._K) * self._L}, "
+            f"num_controls={self._num_controls}"
+            f")"
+        )
+
+    def _decompose_(self, qubits: List[cirq.Qid]) -> cirq.OP_TREE:
+        controls = qubits[: self._num_controls]
+        k_qubits = qubits[self._num_controls : self._num_controls + self._K]
+        logL_qubits = qubits[self._num_controls + self._K : -1]
+        ancilla = qubits[-1]
+        yield [
+            op.controlled_by(*controls)
+            for op in cirq.H.on_each(*(k_qubits + logL_qubits))
+        ]
+        if not logL_qubits:
+            return
+        A = (2**self._K) * self._L
+        theta = np.arccos(1 - (2 ** np.floor(np.log2(self._L))) / self._L)
+
+        yield LessThanGate([2] * self._logL, A).on(*logL_qubits, ancilla)
+        yield cirq.Rz(rads=theta)(ancilla)
+        yield LessThanGate([2] * self._logL, A).on(*logL_qubits, ancilla)
+
+        yield cirq.H.on_each(*logL_qubits)
+        yield cirq.X(ancilla).controlled_by(
+            *logL_qubits,
+            *controls,
+            control_values=[0] * self._logL + [1] * self._num_controls,
+        )
+        yield cirq.Rz(rads=theta)(ancilla)
+        yield cirq.X(ancilla).controlled_by(
+            *logL_qubits,
+            *controls,
+            control_values=[0] * self._logL + [1] * self._num_controls,
+        )
+        yield cirq.H.on_each(*logL_qubits)

--- a/cirq_qubitization/prepare_uniform_superposition_test.py
+++ b/cirq_qubitization/prepare_uniform_superposition_test.py
@@ -1,0 +1,30 @@
+import pytest
+import numpy as np
+import cirq
+import cirq_qubitization
+
+
+@pytest.mark.parametrize("n", [3, 5, 8, 9, 16, 17, 25, 41])
+@pytest.mark.parametrize("num_controls", [0, 1])
+def test_prepare_uniform_superposition(n, num_controls):
+    gate = cirq_qubitization.PrepareUniformSuperposition(n, num_controls=num_controls)
+    all_qubits = cirq.LineQubit.range(cirq.num_qubits(gate))
+    control, target, ancilla = (
+        all_qubits[:num_controls],
+        all_qubits[num_controls:-1],
+        all_qubits[-1],
+    )
+    turn_on_controls = [cirq.X(c) for c in control]
+    prepare_uniform_op = gate.on(*control, *target, ancilla)
+    circuit = cirq.Circuit(turn_on_controls, prepare_uniform_op)
+    result = cirq.Simulator().simulate(circuit)
+    final_target_state = cirq.sub_state_vector(
+        result.final_state_vector,
+        keep_indices=list(range(num_controls, num_controls + len(target))),
+    )
+    expected_target_state = np.asarray(
+        [np.sqrt(1.0 / n)] * n + [0] * (2 ** len(target) - n)
+    )
+    cirq.testing.assert_allclose_up_to_global_phase(
+        expected_target_state, final_target_state, atol=1e-6
+    )


### PR DESCRIPTION
Adds `PrepareUniformSuperposition` gate to prepare a uniform superposition on the first $0$ -- $N - 1$ computational basis states using `ceil(log2(N - 1))` qubits in the target register and 1 ancilla qubit.  