### PR TITLE
Update QROM interface to accept multiple data registers

### DIFF
--- a/cirq_qubitization/qrom.py
+++ b/cirq_qubitization/qrom.py
@@ -1,27 +1,18 @@
 import cirq
-from typing import Optional, Sequence
+from typing import Union, Sequence
 from cirq_qubitization import unary_iteration
 
 
 class QROM(unary_iteration.UnaryIterationGate):
     """Gate to load data[l] in the target_register when selection_register stores integer l."""
 
-    def __init__(
-        self,
-        data: Sequence[int],
-        *,
-        selection_register: Optional[int] = None,
-        target_register: Optional[int] = None,
-    ):
-        if selection_register is None:
-            selection_register = len(data).bit_length()
-        if target_register is None:
-            target_register = max(data).bit_length()
-        assert 2**selection_register >= len(data)
-        assert 2**target_register >= max(data)
+    def __init__(self, *data: Sequence[int]):
+        if len(set(len(d) for d in data)) != 1:
+            raise ValueError("All data sequences to load must be of equal length.")
         self._data = data
-        self._selection_register = selection_register
-        self._target_register = target_register
+        self._selection_register = len(data[0]).bit_length()
+        self._individual_target_registers = [max(d).bit_length() for d in data]
+        self._target_register = sum(self._individual_target_registers)
 
     @property
     def control_register(self) -> int:
@@ -37,11 +28,41 @@ class QROM(unary_iteration.UnaryIterationGate):
 
     @property
     def iteration_length(self) -> int:
-        return len(self._data)
+        return len(self._data[0])
+
+    def on(
+        self,
+        *,
+        control_register: Union[cirq.Qid, Sequence[cirq.Qid]],
+        selection_register: Sequence[cirq.Qid],
+        selection_ancilla: Sequence[cirq.Qid],
+        target_register: Union[Sequence[cirq.Qid], Sequence[Sequence[cirq.Qid]]],
+    ) -> cirq.Operation:
+        if isinstance(control_register, cirq.Qid):
+            control_register = [control_register]
+        if not isinstance(target_register[0], cirq.Qid):
+            assert (
+                len(t) == tr
+                for t, tr in zip(target_register, self._individual_target_registers)
+            ), f"Length of each target register must match {self._individual_target_registers}"
+            flat_target_register = [t for target in target_register for t in target]
+        else:
+            flat_target_register = target_register
+        assert len(flat_target_register) == self.target_register
+        return cirq.GateOperation(
+            self,
+            list(control_register)
+            + list(selection_register)
+            + list(selection_ancilla)
+            + list(flat_target_register),
+        )
 
     def nth_operation(
         self, n: int, control: cirq.Qid, target: Sequence[cirq.Qid]
     ) -> cirq.OP_TREE:
-        for i, bit in enumerate(format(self._data[n], f"0{len(target)}b")):
-            if bit == "1":
-                yield cirq.CNOT(control, target[i])
+        offset = 0
+        for d, target_length in zip(self._data, self._individual_target_registers):
+            for i, bit in enumerate(format(d[n], f"0{target_length}b")):
+                if bit == "1":
+                    yield cirq.CNOT(control, target[offset + i])
+            offset += target_length


### PR DESCRIPTION
* Updates QROM interface to accept multiple data registers, where each of them can be a `Sequence[int]`.
* Note that every data sequence should be of the same length (i.e. the `iteration_length`). 
* `i'th` selection integer will load all integers `data[k][i]` into target register `target[k]`.  
* Automatically computes the length of the individual target registers and the flattened target register needed to load the multiple data entries. 
* Accepts specifying multiple individual target registers, corresponding to each data register, in the `QROM.on()` method.  