### PR TITLE
Add `on_registers` to `GateWithRegisters` base class

### DIFF
--- a/cirq_qubitization/__init__.py
+++ b/cirq_qubitization/__init__.py
@@ -4,6 +4,7 @@ from cirq_qubitization.arithmetic_gates import LessThanGate, LessThanEqualGate
 from cirq_qubitization.prepare_uniform_superposition import PrepareUniformSuperposition
 from cirq_qubitization.multi_target_cnot import MultiTargetCNOT
 from cirq_qubitization.unary_iteration import UnaryIterationGate
+from cirq_qubitization.gate_with_registers import Registers, GateWithRegisters
 from cirq_qubitization.generic_select import GenericSelect
 from cirq_qubitization.generic_subprepare import GenericSubPrepare
 from cirq_qubitization.selected_majorana_fermion import SelectedMajoranaFermionGate

--- a/cirq_qubitization/gate_with_registers.py
+++ b/cirq_qubitization/gate_with_registers.py
@@ -63,6 +63,16 @@ class Registers:
             ret += qubits
         return ret
 
+    def get_named_qubits(self) -> Dict[str, Sequence[cirq.Qid]]:
+        def qubits_for_reg(name: str, bitsize: int):
+            return (
+                [cirq.NamedQubit(f"{name}")]
+                if bitsize == 1
+                else cirq.NamedQubit.range(bitsize, prefix=name)
+            )
+
+        return {reg.name: qubits_for_reg(reg.name, reg.bitsize) for reg in self}
+
 
 class GateWithRegisters(cirq.Gate, metaclass=abc.ABCMeta):
     @property

--- a/cirq_qubitization/gates_with_registers_test.py
+++ b/cirq_qubitization/gates_with_registers_test.py
@@ -36,6 +36,21 @@ def test_registers():
     merged_qregs = regs.merge_qubits(r1=qubits[:5], r2=qubits[5:7], r3=qubits[-1])
     assert merged_qregs == qubits
 
+    expected_named_qubits = {
+        "r1": cirq.NamedQubit.range(5, prefix="r1"),
+        "r2": cirq.NamedQubit.range(2, prefix="r2"),
+        "r3": [cirq.NamedQubit("r3")],
+    }
+    assert regs.get_named_qubits() == expected_named_qubits
+    # Python dictionaries preserve insertion order, which should be same as insertion order of
+    # initial registers.
+    for reg_order in [[r1, r2, r3], [r2, r3, r1]]:
+        flat_named_qubits = [
+            q for v in Registers(reg_order).get_named_qubits().values() for q in v
+        ]
+        expected_qubits = [q for r in reg_order for q in expected_named_qubits[r.name]]
+        assert flat_named_qubits == expected_qubits
+
 
 def test_registers_build():
     regs1 = Registers([Register("r1", 5), Register("r2", 2)])


### PR DESCRIPTION
* `GateWithRegisters` should support creating an operation via `on_registers` which takes qubits corresponding to each register, instead of just consuming a sequence of all qubits like `on()` method. 
* Also added a `get_named_qubits` utility method to `Registers` so that users can create an operation from a gate via `gate.on_registers(**gate.registers.get_named_qubits())`. 