### PR TITLE
Remove dead code from `UnaryIterationGate`

### DIFF
--- a/cirq_qubitization/unary_iteration.py
+++ b/cirq_qubitization/unary_iteration.py
@@ -43,10 +43,6 @@ class UnaryIterationGate(GateWithRegisters):
         iteration_ancilla_bitsize = self.selection_registers.bitsize
         return Registers.build(ancilla=control_ancilla_bitsize + iteration_ancilla_bitsize)
 
-    @property
-    def ancilla_bitsize(self) -> int:
-        return max(0, self.control_bitsize - 1) + self.selection_bitsize
-
     @cached_property
     def registers(self) -> Registers:
         return Registers(


### PR DESCRIPTION
`ancilla_bitsize` property is not needed anymore and is replaced by the `ancilla_registers` property. This somehow wasn't removed as part of https://github.com/ncrubin/cirq-qubitization/pull/50