### PR TITLE
Add support for slicing to Registers class

### DIFF
--- a/cirq_qubitization/gate_with_registers.py
+++ b/cirq_qubitization/gate_with_registers.py
@@ -46,8 +46,10 @@ class Registers:
             return Registers(self._registers[key])
         elif isinstance(key, int):
             return self._registers[key]
-        else:
+        elif isinstance(key, str):
             return self._register_dict[key]
+        else:
+            raise IndexError(f"key {key} must be of the type str/int/slice.")
 
     def __contains__(self, item: str) -> bool:
         return item in self._register_dict

--- a/cirq_qubitization/gates_with_registers_test.py
+++ b/cirq_qubitization/gates_with_registers_test.py
@@ -1,6 +1,7 @@
 from typing import Sequence
 
 import cirq
+import pytest
 
 from cirq_qubitization.gate_with_registers import Register, Registers, GateWithRegisters
 
@@ -52,6 +53,12 @@ def test_registers():
         flat_named_qubits = [q for v in Registers(reg_order).get_named_qubits().values() for q in v]
         expected_qubits = [q for r in reg_order for q in expected_named_qubits[r.name]]
         assert flat_named_qubits == expected_qubits
+
+
+def test_registers_getitem_raises():
+    g = Registers.build(a=4, b=3, c=2)
+    with pytest.raises(IndexError, match="must be of the type"):
+        _ = g[2.5]
 
 
 def test_registers_build():


### PR DESCRIPTION
* Updates `__getitem__` to support integer, slice and string access. The first two behave as a list and the last one behaves as a dictionary. 
* As the number of registers a gate operates on gets larger, slicing is helpful to construct new Registers from existing registers. The `register.at()` semantics already assume that we are preserving insertion ordering and that registers have a well defined order, so it's a natural extension to support slicing on the ordered sequence. 