### PR TITLE
remove unnecessary/confusing xor operation from unary_iteration.ipynb

### DIFF
--- a/cirq_qubitization/unary_iteration.ipynb
+++ b/cirq_qubitization/unary_iteration.ipynb
@@ -85,11 +85,11 @@
     "    print(f\"Selection is {selection}\")\n",
     "    \n",
     "    for n, trial in enumerate(itertools.product((0, 1), repeat=len(selection))):\n",
-    "        print(f\"Step {n}, apply total control: {trial}\")\n",
-    "        target[n] ^= slb.And(*[slb.Xnor(s, t) for s, t in zip(selection, trial)])\n",
+    "        print(f\"Step {n=}, apply total control: {trial}\")\n",
+    "        target[n] = slb.And(*[slb.Xnor(s, t) for s, t in zip(selection, trial)])\n",
     "          \n",
     "        if target[n] == S.true:\n",
-    "            print(f\"  -> At this stage, {n}= and our output bit is set\")\n",
+    "            print(f\"  -> At this stage, {n=} and our output bit is set\")\n",
     "\n",
     "        \n",
     "selection = [0, 1, 0]\n",
@@ -124,7 +124,7 @@
    "outputs": [],
    "source": [
     "selection = [S.Symbol(f's{i}') for i in range(3)]\n",
-    "target = [S.false for i in range(2**len(selection)) ]\n",
+    "target = [False for i in range(2**len(selection)) ]\n",
     "total_control(selection, target)\n",
     "\n",
     "print()\n",
@@ -168,8 +168,8 @@
     "    \n",
     "    if left == (right - 1):\n",
     "        # Leaf of the recusion.\n",
-    "        print(f'{n}= {ctrl=}')\n",
-    "        target[left] ^= ctrl\n",
+    "        print(f'{n=} {ctrl=}')\n",
+    "        target[left] = ctrl\n",
     "        return \n",
     "    print()\n",
     "    \n",
@@ -198,7 +198,7 @@
    "outputs": [],
    "source": [
     "selection = [S.Symbol(f's{i}') for i in range(3)]\n",
-    "target = [S.false for i in range(2**len(selection)) ]\n",
+    "target = [False for i in range(2**len(selection)) ]\n",
     "segtree(S.true, selection, target, 0, 0, 2**len(selection))\n",
     "\n",
     "print()\n",
@@ -246,6 +246,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b0f909ec",
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# TODO: mpharrigan thinks that UnaryIterationGate should have-a operation rather\n",
@@ -277,13 +284,7 @@
     "        self, control: cirq.Qid, selection: int, target: Sequence[cirq.Qid]\n",
     "    ) -> cirq.OP_TREE:\n",
     "        return cirq.CNOT(control, target[-(selection + 1)])"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -342,7 +343,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.5 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -356,7 +357,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- the xor operation is unncessary and confusing, in both cases of iteration we visit each index exactly once
- I also replaced scipy.False with False just signify that scipy.False is also unnecessary since scipy does the conversion when it needs to