### PR TITLE
Jupyter tools

### DIFF
--- a/cirq_qubitization/and_gate_test.py
+++ b/cirq_qubitization/and_gate_test.py
@@ -1,12 +1,9 @@
 import random
-from pathlib import Path
 from typing import Tuple, List
 
 import cirq
-import nbformat
 import numpy as np
 import pytest
-from nbconvert.preprocessors import ExecutePreprocessor
 
 import cirq_qubitization
 import cirq_qubitization.testing as cq_testing
@@ -186,8 +183,4 @@ def test_and_gate_adjoint(cv: Tuple[int, int]):
 
 
 def test_notebook():
-    notebook_path = Path(__file__).parent / "and_gate.ipynb"
-    with notebook_path.open() as f:
-        nb = nbformat.read(f, as_version=4)
-    ep = ExecutePreprocessor(timeout=600, kernel_name="python3")
-    ep.preprocess(nb)
+    cq_testing.execute_notebook('and_gate')

--- a/cirq_qubitization/gate_with_registers.py
+++ b/cirq_qubitization/gate_with_registers.py
@@ -128,3 +128,15 @@ class GateWithRegisters(cirq.Gate, metaclass=abc.ABCMeta):
 
     def on_registers(self, **qubit_regs: Union[cirq.Qid, Sequence[cirq.Qid]]) -> cirq.GateOperation:
         return self.on(*self.registers.merge_qubits(**qubit_regs))
+
+    def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
+        """Default diagram info that uses register names to name the boxes in multi-qubit gates.
+
+        Descendants can override this method with more meaningful circuit diagram information.
+        """
+        wire_symbols = []
+        for reg in self.registers:
+            wire_symbols += [reg.name] * reg.bitsize
+
+        wire_symbols[0] = self.__class__.__name__
+        return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)

--- a/cirq_qubitization/jupyter_tools.py
+++ b/cirq_qubitization/jupyter_tools.py
@@ -1,0 +1,50 @@
+import cirq
+import cirq.contrib.svg.svg as ccsvg
+import ipywidgets
+import IPython.display
+
+import cirq_qubitization.testing as cq_testing
+from cirq_qubitization import Registers
+
+
+def display_gate_and_compilation(g: cq_testing.GateHelper, vertical=False):
+    """Use ipywidgets to display SVG circuits for a `GateHelper` next to each other.
+
+    Args:
+        g: The `GateHelper` to draw
+        vertical: If true, lay-out the original gate and its decomposition vertically
+            rather than side-by-side.
+    """
+    out1 = ipywidgets.Output()
+    out2 = ipywidgets.Output()
+    if vertical:
+        box = ipywidgets.VBox([out1, out2])
+    else:
+        box = ipywidgets.HBox([out1, out2])
+
+    out1.append_display_data(svg_circuit(g.circuit, registers=g.r))
+    out2.append_display_data(
+        svg_circuit(cirq.Circuit(cirq.decompose_once(g.operation)), registers=g.r)
+    )
+
+    IPython.display.display(box)
+
+
+def svg_circuit(circuit: 'cirq.AbstractCircuit', registers: Registers = None):
+    """Return an SVG object representing a circuit.
+
+    Args:
+        circuit: The circuit to draw.
+        registers: Optional `Registers` object to order the qubits.
+    """
+    if len(circuit) == 0:
+        raise ValueError("Circuit is empty.")
+
+    if registers is not None:
+        qubit_order = registers.merge_qubits(**registers.get_named_qubits())
+    else:
+        qubit_order = cirq.QubitOrder.DEFAULT
+    tdd = circuit.to_text_diagram_drawer(transpose=False, qubit_order=qubit_order)
+    if len(tdd.horizontal_lines) == 0:
+        raise ValueError("No non-empty moments.")
+    return IPython.display.SVG(ccsvg.tdd_to_svg(tdd))

--- a/cirq_qubitization/jupyter_tools_test.py
+++ b/cirq_qubitization/jupyter_tools_test.py
@@ -1,0 +1,30 @@
+import IPython.display
+import ipywidgets
+
+import cirq_qubitization.testing as cq_testing
+from cirq_qubitization import And
+from cirq_qubitization.jupyter_tools import svg_circuit, display_gate_and_compilation
+
+
+def test_svg_circuit():
+    g = cq_testing.GateHelper(And(cv=(1, 1, 1)))
+    svg = svg_circuit(g.circuit, g.r)
+    svg_str: str = svg.data
+
+    # check that the order is respected in the svg data.
+    assert svg_str.find('control') < svg_str.find('ancilla') < svg_str.find('target')
+
+
+def test_display_gate_and_compilation(monkeypatch):
+    call_args = []
+
+    def _dummy_display(stuff):
+        call_args.append(stuff)
+
+    monkeypatch.setattr(IPython.display, "display", _dummy_display)
+    g = cq_testing.GateHelper(And(cv=(1, 1, 1)))
+    display_gate_and_compilation(g)
+
+    (display_arg,) = call_args
+    assert isinstance(display_arg, ipywidgets.HBox)
+    assert len(display_arg.children) == 2


### PR DESCRIPTION
Initial commit of tools to easily diagram gates.

 - complete migration of notebook testing to use `cq_testing` helper
 - custom entrypoint to `cirq.contrib.svg` that optionally orders the drawn qubits according to passed-in registers
 - a high-level utility for showing a gate and its decomposition side-by-side with svg widgets
 - better default circuit diagram for `GatesWithRegister` that doesn't make them sooo wide