### PR TITLE
Add support for zero length selection registers in UnaryIterationGate.

### DIFF
--- a/cirq_qubitization/qrom_test.py
+++ b/cirq_qubitization/qrom_test.py
@@ -6,7 +6,9 @@ from cirq_qubitization import testing as cq_testing
 from cirq_qubitization.bit_tools import iter_bits
 
 
-@pytest.mark.parametrize("data", [[[1, 2, 3, 4, 5]], [[1, 2, 3], [4, 5, 10]]])
+@pytest.mark.parametrize(
+    "data", [[[1, 2, 3, 4, 5]], [[1, 2, 3], [4, 5, 10]], [[1], [2], [3], [4], [5], [6]]]
+)
 def test_qrom(data):
     qrom = cirq_qubitization.QROM(*data)
     qubit_regs = qrom.registers.get_named_qubits()

--- a/cirq_qubitization/unary_iteration.py
+++ b/cirq_qubitization/unary_iteration.py
@@ -81,6 +81,24 @@ class UnaryIterationGate(GateWithRegisters):
             register and represents the sequence of qubits that represent the extra register.
         """
 
+    def decompose_zero_selection(self, **kwargs) -> cirq.OP_TREE:
+        """Specify decomposition of the gate when selection register is empty
+
+        By default, if the selection register is empty, the decomposition will raise a
+        `NotImplementedError`. The derived classes can override this method and specify
+        a custom decomposition that should be used if the selection register is empty,
+        i.e. `self.selection_registers.bitsize == 0`.
+
+        The derived classes should specify the following arguments as `**kwargs`:
+            1) Register names in `self.control_registers`: Each argument corresponds to a
+            control register and represents sequence of qubits that represent the control register.
+            2) Register names in `self.target_registers`: Each argument corresponds to a target
+            register and represents the sequence of qubits that represent the target register.
+            3) Register names in `self.extra_regs`: Each argument corresponds to an extra
+            register and represents the sequence of qubits that represent the extra register.
+        """
+        raise NotImplementedError("Selection register must not be empty.")
+
     def _apply_nth_operation(
         self, n: int, control: cirq.Qid, target: Sequence[cirq.Qid], **extra_regs
     ) -> cirq.OP_TREE:
@@ -138,11 +156,12 @@ class UnaryIterationGate(GateWithRegisters):
     ) -> cirq.OP_TREE:
         assert len(selection) == len(ancilla)
         assert 2 ** len(selection) >= self.iteration_length
+        assert len(selection) > 0
         yield from self._unary_iteration_segtree(
             control, selection, ancilla, target, 0, 0, 2 ** len(selection), **extra_regs
         )
 
-    def _decompose_zero_control(
+    def decompose_zero_control(
         self,
         selection: Sequence[cirq.Qid],
         ancilla: Sequence[cirq.Qid],
@@ -171,8 +190,10 @@ class UnaryIterationGate(GateWithRegisters):
         ancilla = self.ancilla_registers.merge_qubits(**qubit_regs)
         extra_regs = {k: v for k, v in qubit_regs.items() if k in self.extra_registers}
 
-        if len(control) == 0:
-            yield from self._decompose_zero_control(selection, ancilla, target, **extra_regs)
+        if len(selection) == 0:
+            yield from self.decompose_zero_selection(**qubit_regs)
+        elif len(control) == 0:
+            yield from self.decompose_zero_control(selection, ancilla, target, **extra_regs)
         elif len(control) == 1:
             yield from self.decompose_single_control(
                 control[0], selection, ancilla, target, **extra_regs


### PR DESCRIPTION
`UnaryIterationGate` currently fails with an assertion if `len(selection)` register is 0. This PR adds support for delegating the decomposition logic to subclasses by overriding a new method `decompose_zero_selection`. 

This is useful in cases like `QROM` if you want to load a single data element (i.e. sequence of length 1). This would be further used in a follow-up PR that implements `QROAM` which is a hybrid qrom implementation using `QROM` and `SwapWithZeroGate`. 