### PR TITLE
Better return type annotations

### DIFF
--- a/cirq_qubitization/gate_with_registers.py
+++ b/cirq_qubitization/gate_with_registers.py
@@ -95,7 +95,7 @@ class Registers:
             ret += qubits
         return ret
 
-    def get_named_qubits(self) -> Dict[str, Sequence[cirq.Qid]]:
+    def get_named_qubits(self) -> Dict[str, List[cirq.Qid]]:
         def qubits_for_reg(name: str, bitsize: int):
             return (
                 [cirq.NamedQubit(f"{name}")]

--- a/cirq_qubitization/testing.py
+++ b/cirq_qubitization/testing.py
@@ -30,7 +30,7 @@ class GateHelper:
         return self.gate.registers
 
     @cached_property
-    def quregs(self) -> Dict[str, Sequence[cirq.Qid]]:
+    def quregs(self) -> Dict[str, List[cirq.Qid]]:
         """A dictionary of named qubits appropriate for the registers for the gate."""
         return self.r.get_named_qubits()
 


### PR DESCRIPTION
Simple stuff, but it's better to be specific in what you return (and general in what you accept)