### PR TITLE
Fix multiple bugs in T-complexity protocol

### DIFF
--- a/cirq_qubitization/t_complexity_protocol.py
+++ b/cirq_qubitization/t_complexity_protocol.py
@@ -3,11 +3,10 @@ from dataclasses import dataclass
 from typing_extensions import Protocol
 
 import cirq
-from cirq.protocols import SupportsDecompose
 from cirq.protocols.decompose_protocol import _try_decompose_into_operations_and_qubits
-from cirq import flatten_op_tree
 
-_T_GATESET = cirq.Gateset(cirq.T, cirq.T ** -1, unroll_circuit_op=False)
+_T_GATESET = cirq.Gateset(cirq.T, cirq.T**-1, unroll_circuit_op=False)
+
 
 @dataclass(frozen=True)
 class TComplexity:
@@ -17,12 +16,8 @@ class TComplexity:
 
     def __add__(self, other: 'TComplexity') -> 'TComplexity':
         return TComplexity(
-                self.t + other.t,
-                self.clifford + other.clifford,
-                self.rotations + other.rotations)
-
-    def __eq__(self, other: 'TComplexity') -> bool:
-        return self.t == other.t and self.rotations == other.rotations
+            self.t + other.t, self.clifford + other.clifford, self.rotations + other.rotations
+        )
 
 
 class SupportsTComplexity(Protocol):
@@ -41,11 +36,16 @@ def _has_t_complexity(stc: Any) -> Optional[TComplexity]:
     """Returns TComplexity of stc by calling its _t_complexity_ if it exists."""
     estimator = getattr(stc, '_t_complexity_', None)
     if estimator is not None:
-        return estimator()        
+        result = estimator()
+        return None if result is NotImplemented else result
     return None
 
-def _is_cliffort_or_t(stc: Any) -> Optional[TComplexity]:
-    """Attempts to infer the type of an operation as one of clifford, T or Rotation."""
+
+def _is_clifford_or_t(stc: Any) -> Optional[TComplexity]:
+    """Attempts to infer the type of a gate/operation as one of clifford, T or Rotation."""
+    if not isinstance(stc, (cirq.Gate, cirq.Operation)):
+        return None
+
     if isinstance(stc, cirq.ClassicallyControlledOperation):
         stc = stc.without_classical_controls()
 
@@ -53,35 +53,35 @@ def _is_cliffort_or_t(stc: Any) -> Optional[TComplexity]:
         # Clifford operation.
         return TComplexity(clifford=1)
 
-    if isinstance(stc, (cirq.Gate, cirq.Operation)):
-        # Gateset in operator assumes operand is a Gate or Operation
-        if stc in _T_GATESET:
-            return TComplexity(t=1) # T gate
+    if stc in _T_GATESET:
+        # T-gate.
+        return TComplexity(t=1)  # T gate
 
-        if cirq.num_qubits(stc) == 1 and cirq.has_unitary(stc):
-            # Rotation Operation
-            return TComplexity(rotations=1)
+    if cirq.num_qubits(stc) == 1 and cirq.has_unitary(stc):
+        # Single qubit rotation operation.
+        return TComplexity(rotations=1)
     return None
+
 
 def _is_iterable(it: Any) -> Optional[TComplexity]:
-    if isinstance(it, Iterable):
-        t = TComplexity()
-        for v in it:
-            r = t_complexity(v)
-            if r is None:
-                return None
-            t = t + r
-        return t
-    return None
+    if not isinstance(it, Iterable):
+        return None
+    t = TComplexity()
+    for v in it:
+        r = t_complexity(v)
+        if r is None:
+            return None
+        t = t + r
+    return t
 
 
 def _has_decomposition(stc: Any) -> Optional[TComplexity]:
     # Decompose the object and recursively compute the complexity.
-    t = TComplexity()
     decomposition, _, _ = _try_decompose_into_operations_and_qubits(stc)
     if decomposition is None:
         return None
     return _is_iterable(decomposition)
+
 
 def t_complexity(stc: Any, fail_quietly: bool = False) -> Optional[TComplexity]:
     """Returns the TComplexity.
@@ -89,26 +89,18 @@ def t_complexity(stc: Any, fail_quietly: bool = False) -> Optional[TComplexity]:
     Args:
         stc: an object to compute its TComplexity.
         fail_quietly: bool whether to return None on failure or raise an error.
-    
+
     Returns:
         The TComplexity of the given object or None on failure (and fail_quietly=True).
-    
+
     Raises:
-        TypeError if fail_quietly=False and the methods fails to compute TComplexity. 
+        TypeError if fail_quietly=False and the methods fails to compute TComplexity.
     """
-    strategies = [
-        _has_t_complexity,
-        _has_decomposition,
-        _is_cliffort_or_t,
-        _is_iterable,
-    ]
+    strategies = [_has_t_complexity, _is_clifford_or_t, _has_decomposition, _is_iterable]
     for strategy in strategies:
         ret = strategy(stc)
         if ret is not None:
             return ret
     if fail_quietly:
         return None
-    raise TypeError("couldn't compute TComplexity of:\n"
-                    f"type: {type(stc)}\n"
-                     f"value: {stc}")
-
+    raise TypeError("couldn't compute TComplexity of:\n" f"type: {type(stc)}\n" f"value: {stc}")

--- a/cirq_qubitization/t_complexity_protocol_test.py
+++ b/cirq_qubitization/t_complexity_protocol_test.py
@@ -7,22 +7,23 @@ from cirq_qubitization.and_gate import And
 
 
 class SupportTComplexity(cirq.Operation):
-    
     def qubits(self):
         return []
-    
+
     def with_qubits(self, _):
         pass
 
     def _t_complexity_(self) -> TComplexity:
-        return TComplexity(t=1)        
+        return TComplexity(t=1)
+
 
 class DoesNotSupportTComplexity(cirq.Gate):
     def _num_qubits_(self):
         return 1
+
     def _qid_shape_(self):
         return (1,)
-    
+
     def num_qubits(self):
         return self._num_qubits_()
 
@@ -39,21 +40,21 @@ def test_t_complexity():
     q = cirq.NamedQubit('q')
     assert t_complexity([cirq.T(q), cirq.X(q)]) == TComplexity(t=1, clifford=1)
 
+
 def test_gates():
     # T gate and its adjoint
     assert t_complexity(cirq.T) == TComplexity(t=1)
-    assert t_complexity(cirq.T ** -1) == TComplexity(t=1)
+    assert t_complexity(cirq.T**-1) == TComplexity(t=1)
 
-    assert t_complexity(cirq.H) == TComplexity(clifford=1) # Hadamard
-    assert t_complexity(cirq.CNOT) == TComplexity(clifford=1) # CNOT
-    assert t_complexity(cirq.S) == TComplexity(clifford=1) # S
-    assert t_complexity(cirq.S ** -1) == TComplexity(clifford=1) # S†
+    assert t_complexity(cirq.H) == TComplexity(clifford=1)  # Hadamard
+    assert t_complexity(cirq.CNOT) == TComplexity(clifford=1)  # CNOT
+    assert t_complexity(cirq.S) == TComplexity(clifford=1)  # S
+    assert t_complexity(cirq.S**-1) == TComplexity(clifford=1)  # S†
 
     # Pauli operators are clifford
     assert t_complexity(cirq.X) == TComplexity(clifford=1)
     assert t_complexity(cirq.Y) == TComplexity(clifford=1)
     assert t_complexity(cirq.Z) == TComplexity(clifford=1)
-    
 
     # Rotation about X, Y, and Z axes
     assert t_complexity(cirq.Rx(rads=2)) == TComplexity(rotations=1)
@@ -83,45 +84,40 @@ def test_circuits():
     circuit = cirq.Circuit(
         cirq.Rz(rads=0.6)(q),
         cirq.T(q),
-        cirq.X(q)**0.5,
+        cirq.X(q) ** 0.5,
         cirq.Rx(rads=0.1)(q),
         cirq.Ry(rads=0.6)(q),
-        cirq.measure(q, key='m')
+        cirq.measure(q, key='m'),
     )
     assert t_complexity(circuit) == TComplexity(clifford=2, rotations=3, t=1)
 
-    circuit = cirq.FrozenCircuit(
-        cirq.T(q)**-1,
-        cirq.Rx(rads=0.1)(q),
-        cirq.measure(q, key='m')
-    )
+    circuit = cirq.FrozenCircuit(cirq.T(q) ** -1, cirq.Rx(rads=0.1)(q), cirq.measure(q, key='m'))
     assert t_complexity(circuit) == TComplexity(clifford=1, rotations=1, t=1)
 
 
 def test_circuit_operations():
     q = cirq.NamedQubit('q')
     circuit = cirq.FrozenCircuit(
-        cirq.T(q),
-        cirq.X(q)**0.5,
-        cirq.Rx(rads=0.1)(q),
-        cirq.measure(q, key='m')
+        cirq.T(q), cirq.X(q) ** 0.5, cirq.Rx(rads=0.1)(q), cirq.measure(q, key='m')
     )
     assert t_complexity(cirq.CircuitOperation(circuit)) == TComplexity(clifford=2, rotations=1, t=1)
-    assert t_complexity(cirq.CircuitOperation(circuit, repetitions=10)) == TComplexity(clifford=20, rotations=10, t=10)
-
-    circuit = cirq.FrozenCircuit(
-        cirq.T(q)**-1,
-        cirq.Rx(rads=0.1)(q),
-        cirq.measure(q, key='m')
+    assert t_complexity(cirq.CircuitOperation(circuit, repetitions=10)) == TComplexity(
+        clifford=20, rotations=10, t=10
     )
+
+    circuit = cirq.FrozenCircuit(cirq.T(q) ** -1, cirq.Rx(rads=0.1)(q), cirq.measure(q, key='m'))
     assert t_complexity(cirq.CircuitOperation(circuit)) == TComplexity(clifford=1, rotations=1, t=1)
-    assert t_complexity(cirq.CircuitOperation(circuit, repetitions=3)) == TComplexity(clifford=3, rotations=3, t=3)
+    assert t_complexity(cirq.CircuitOperation(circuit, repetitions=3)) == TComplexity(
+        clifford=3, rotations=3, t=3
+    )
 
 
 def test_classically_controlled_operations():
     q = cirq.NamedQubit('q')
     assert t_complexity(cirq.X(q).with_classical_controls('c')) == TComplexity(clifford=1)
-    assert t_complexity(cirq.Rx(rads=0.1)(q).with_classical_controls('c')) == TComplexity(rotations=1)
+    assert t_complexity(cirq.Rx(rads=0.1)(q).with_classical_controls('c')) == TComplexity(
+        rotations=1
+    )
     assert t_complexity(cirq.T(q).with_classical_controls('c')) == TComplexity(t=1)
 
 


### PR DESCRIPTION
This PR makes the following improvements to the T-complexity protocol:
1) Because of the ordering of `strategies`, the `_has_decomposition` strategy had a priority over `_is_clifford_or_t` strategy; because of which `t_complexity(cirq.CNOT)` was `TComplexity(t=0, clifford=3, rotations=0)` instead of `TComplexity(t=0, clifford=1, rotations=0)`. This is now fixed by following a new ordering. 
2) Despite the above bug, `assert t_complexity(cirq.CNOT) == TComplexity(clifford=1)  # CNOT` test in `cirq_qubitization/t_complexity_protocol_test.py` was passing. This is because the custom equality operator in `TComplexity` ignored `clifford` field by default. The PR fixes this behavior to rely on default equality operator instead, which compares all the 3 fields -- which I think should be the default. We should be able to notice if there is a change in clifford count in the T-complexity of an object. 
3) Removes a bunch of dead code and reformats. Usually, before sending out PRs, we should run `./check/format-incremental` and `./check/pylint` to notice and fix these inconsistencies. Eventually, we should add these checks as part of the CI. 
