### PR TITLE
create assert_decompose_is_consistent_with_t_complexity

### DIFF
--- a/cirq_qubitization/testing.py
+++ b/cirq_qubitization/testing.py
@@ -11,6 +11,7 @@ from nbconvert.preprocessors import ExecutePreprocessor
 from cirq_qubitization.gate_with_registers import GateWithRegisters, Registers
 from cirq_qubitization.t_complexity_protocol import t_complexity
 
+
 @dataclass(frozen=True)
 class GateHelper:
     """A collection of related objects derivable from a `GateWithRegisters`.


### PR DESCRIPTION
adding `assert_decompose_is_consistent_with_t_complexity` to check if a class's `_t_complexity_` is consistent with its decomposition