### PR TITLE
Cache CI dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,9 @@ jobs:
           cache: "pip"
           cache-dependency-path: "dev_tools/requirements/format.env.txt"
       - name: Install dependencies
-        run: pip install -r dev_tools/requirements/format.env.txt
+        run: |
+          pip install wheel
+          pip install -r dev_tools/requirements/format.env.txt
       - run: check/format-incremental
 
   pylint:


### PR DESCRIPTION
https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages

Could probably speed things up.