### PR TITLE
Local imports for BloqBuilder convenience methods

### DIFF
--- a/cirq_qubitization/quantum_graph/composite_bloq.py
+++ b/cirq_qubitization/quantum_graph/composite_bloq.py
@@ -17,7 +17,6 @@ from cirq_qubitization.quantum_graph.quantum_graph import (
     RightDangle,
     Soquet,
 )
-from cirq_qubitization.quantum_graph.util_bloqs import Allocate, Free, Join, Split
 
 SoquetT = Union[Soquet, NDArray[Soquet]]
 
@@ -460,10 +459,14 @@ class CompositeBloqBuilder:
         return CompositeBloq(cxns=self._cxns, registers=self._parent_regs)
 
     def allocate(self, n: int = 1) -> Soquet:
+        from cirq_qubitization.quantum_graph.util_bloqs import Allocate
+
         (out_soq,) = self.add(Allocate(n=n))
         return out_soq
 
     def free(self, soq: Soquet) -> None:
+        from cirq_qubitization.quantum_graph.util_bloqs import Free
+
         if not isinstance(soq, Soquet):
             raise ValueError("`free` expects a single Soquet to free.")
 
@@ -471,6 +474,8 @@ class CompositeBloqBuilder:
 
     def split(self, soq: Soquet) -> SoquetT:
         """Add a Split bloq to split up a register."""
+        from cirq_qubitization.quantum_graph.util_bloqs import Split
+
         if not isinstance(soq, Soquet):
             raise ValueError("`split` expects a single Soquet to split.")
 
@@ -478,6 +483,8 @@ class CompositeBloqBuilder:
         return out_soqs
 
     def join(self, soqs: NDArray[Soquet]) -> Soquet:
+        from cirq_qubitization.quantum_graph.util_bloqs import Join
+
         try:
             (n,) = soqs.shape
         except AttributeError:


### PR DESCRIPTION
This is in anticipation of a high chance of circular imports. We want util_bloqs to be able to import stuff from composite_bloq.py to have access to the full suite of building stuff. 