### PR TITLE
Prettier binst string

### DIFF
--- a/cirq_qubitization/quantum_graph/composite_bloq_test.py
+++ b/cirq_qubitization/quantum_graph/composite_bloq_test.py
@@ -84,15 +84,15 @@ def test_composite_bloq():
     assert (
         cbloq.debug_text()
         == """\
-BloqInstance(bloq=TestBloq(), i=1)
+TestBloq()<1>
   LeftDangle.q1 -> control
   LeftDangle.q2 -> target
-  control -> BloqInstance(bloq=TestBloq(), i=2).target
-  target -> BloqInstance(bloq=TestBloq(), i=2).control
+  control -> TestBloq()<2>.target
+  target -> TestBloq()<2>.control
 --------------------
-BloqInstance(bloq=TestBloq(), i=2)
-  BloqInstance(bloq=TestBloq(), i=1).control -> target
-  BloqInstance(bloq=TestBloq(), i=1).target -> control
+TestBloq()<2>
+  TestBloq()<1>.control -> target
+  TestBloq()<1>.target -> control
   control -> RightDangle.q1
   target -> RightDangle.q2"""
     )

--- a/cirq_qubitization/quantum_graph/quantum_graph.py
+++ b/cirq_qubitization/quantum_graph/quantum_graph.py
@@ -19,6 +19,9 @@ class BloqInstance:
     bloq: Bloq
     i: int
 
+    def __str__(self):
+        return f'{self.bloq}<{self.i}>'
+
 
 class DanglingT:
     """The type of the singleton objects `LeftDangle` and `RightDangle`.

--- a/cirq_qubitization/quantum_graph/quantum_graph_test.py
+++ b/cirq_qubitization/quantum_graph/quantum_graph_test.py
@@ -57,3 +57,10 @@ def test_soquet_idxed():
 
     with pytest.raises(ValueError, match=r'Bad index.*'):
         _ = Soquet(binst, reg, idx=(5,))
+
+
+def test_bloq_instance():
+    binst_a = BloqInstance(TestBloq(), i=1)
+    binst_b = BloqInstance(TestBloq(), i=1)
+    assert binst_a == binst_b
+    assert str(binst_a) == 'TestBloq()<1>'


### PR DESCRIPTION
Override `__str__` to give a shorter (but still unambiguous) representation of a `BloqInstance`. This is used by `CompositeBloq.debug_text()` and results in an (IMO) more readable text-dump of the graph.