### PR TITLE
Fix a bug in SelectedMajoranaFermionGate

### DIFF
--- a/cirq_qubitization/cirq_algos/selected_majorana_fermion.py
+++ b/cirq_qubitization/cirq_algos/selected_majorana_fermion.py
@@ -59,17 +59,9 @@ class SelectedMajoranaFermionGate(unary_iteration.UnaryIterationGate):
     def extra_registers(self) -> Registers:
         return Registers.build(accumulator=1)
 
-    def _decompose_single_control(
-        self,
-        control: cirq.Qid,
-        selection: Sequence[cirq.Qid],
-        target: Sequence[cirq.Qid],
-        accumulator: Sequence[cirq.Qid],
-    ) -> cirq.OP_TREE:
-        yield cirq.CNOT(control, accumulator[0])
-        yield from super()._decompose_single_control(
-            control, selection, target, accumulator=accumulator
-        )
+    def decompose_from_registers(self, **qubit_regs: Sequence[cirq.Qid]) -> cirq.OP_TREE:
+        yield cirq.CNOT(*qubit_regs['control'], *qubit_regs['accumulator'])
+        yield super().decompose_from_registers(**qubit_regs)
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
         wire_symbols = ["@"] * self.control_registers.bitsize


### PR DESCRIPTION
Fixes https://github.com/quantumlib/cirq-qubitization/issues/170


https://github.com/quantumlib/cirq-qubitization/pull/19 renamed `_decompose_single_control` in `UnaryIterationGate` to `decompose_single_control` but the renamed was not done in the derived class `SelectMajoranaFermionGate`. This introduced a bug where the initial `CNOT(control, accumulator)` in `SelectMajoranaFermionGate` was not yielded. 

Follow up PRs further refactored the unary iteration gate but this bug in the derived class `SelectMajoranaFermionGate` persisted. This PR fixes the bug and as a result the aforementioned issue. 