### PR TITLE
Add `ContiguousRegisterGate`

### DIFF
--- a/cirq_qubitization/__init__.py
+++ b/cirq_qubitization/__init__.py
@@ -1,7 +1,11 @@
 from cirq_qubitization.alt_keep_qrom import construct_alt_keep_qrom
 from cirq_qubitization.cirq_algos.and_gate import And
 from cirq_qubitization.cirq_algos.apply_gate_to_lth_target import ApplyGateToLthQubit
-from cirq_qubitization.cirq_algos.arithmetic_gates import LessThanEqualGate, LessThanGate
+from cirq_qubitization.cirq_algos.arithmetic_gates import (
+    ContiguousRegisterGate,
+    LessThanEqualGate,
+    LessThanGate,
+)
 from cirq_qubitization.cirq_algos.multi_control_multi_target_cnot import (
     MultiControlNOT,
     MultiTargetCNOT,

--- a/cirq_qubitization/cirq_algos/__init__.py
+++ b/cirq_qubitization/cirq_algos/__init__.py
@@ -1,6 +1,10 @@
 from cirq_qubitization.cirq_algos.and_gate import And
 from cirq_qubitization.cirq_algos.apply_gate_to_lth_target import ApplyGateToLthQubit
-from cirq_qubitization.cirq_algos.arithmetic_gates import LessThanEqualGate, LessThanGate
+from cirq_qubitization.cirq_algos.arithmetic_gates import (
+    ContiguousRegisterGate,
+    LessThanEqualGate,
+    LessThanGate,
+)
 from cirq_qubitization.cirq_algos.multi_control_multi_target_cnot import (
     MultiControlNOT,
     MultiTargetCNOT,

--- a/cirq_qubitization/cirq_algos/arithmetic_gates.py
+++ b/cirq_qubitization/cirq_algos/arithmetic_gates.py
@@ -2,6 +2,8 @@ from typing import Iterable, Sequence, Union
 
 import cirq
 
+from cirq_qubitization import t_complexity_protocol
+
 
 class LessThanGate(cirq.ArithmeticGate):
     """Applies U_a|x>|z> = |x> |z ^ (x < a)>"""
@@ -56,3 +58,62 @@ class LessThanEqualGate(cirq.ArithmeticGate):
         wire_symbols += ["In(y)"] * len(self._second_input_register)
         wire_symbols += ['+(x <= y)']
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
+
+
+class ContiguousRegisterGate(cirq.ArithmeticGate):
+    """Applies U|p>|q>|0> -> |p>|q>|p * (p - 1) / 2 + q>
+
+    This is useful in the case when $|p>$ and $|q>$ represent two selection registers such that
+     $q < p$. For example, imagine a classical for-loop over two variables $p$ and $q$:
+
+     >>> for p in range(N);
+     >>>     for q in range(p):
+     >>>         yield data[p][q] # Iterates over a total of (N * (N - 1)) / 2 elements.
+
+     We can rewrite the above using a single for-loop that uses a "contiguous" variable `i` s.t.
+
+     >>> for i in range((N * (N - 1)) / 2):
+     >>>    p = np.floor((1 + np.sqrt(1 + 8 * i)) / 2)
+     >>>    q = i - (p * (p - 1)) / 2
+     >>>    yield data[p][q]
+
+     Note that both the for-loops iterate over the same ranges and in the same order. The only
+     difference is that the second loop is a "flattened" version of the first one.
+
+     Such a flattening of selection registers is useful when we want to load multi dimensional
+     data to a target register which is indexed on selection registers $p$ and $q$ such that
+     $0<= q <= p < N$ and we want to use a `SelectSwapQROM` to laod this data; which gives a
+     sqrt-speedup over a traditional QROM at the cost of using more memory and loading chunks
+     of size `sqrt(N)` in a single iteration. See the reference for more details.
+
+     References:
+         [Even More Efficient Quantum Computations of Chemistry Through Tensor Hypercontraction]
+         (https://arxiv.org/abs/2011.03494)
+            Lee et. al. (2020). Appendix F, Page 67.
+    """
+
+    def __init__(self, selection_bitsize: int, target_bitsize: int):
+        self._p_register = [2] * selection_bitsize
+        self._q_register = [2] * selection_bitsize
+        self._target_register = [2] * target_bitsize
+
+    def registers(self) -> Sequence[Union[int, Sequence[int]]]:
+        return (self._p_register, self._q_register, self._target_register)
+
+    def with_registers(self, *new_registers: Union[int, Sequence[int]]) -> 'ContiguousRegisterGate':
+        return ContiguousRegisterGate(len(new_registers[0]), len(new_registers[-1]))
+
+    def apply(self, p: int, q: int, target: int) -> Union[int, Iterable[int]]:
+        return p, q, target ^ ((p * (p - 1)) // 2 + q)
+
+    def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
+        wire_symbols = ["In(x)"] * len(self._p_register)
+        wire_symbols += ["In(y)"] * len(self._q_register)
+        wire_symbols += ['+[x(x-1)/2 + y]']
+        return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
+
+    def _t_complexity_(self) -> 't_complexity_protocol.TComplexity':
+        # See the linked reference for explanation of the Toffoli complexity.
+        toffoli_complexity = t_complexity_protocol.t_complexity(cirq.CCNOT)
+        n = len(self._p_register)
+        return (n**2 + n - 1) * toffoli_complexity

--- a/cirq_qubitization/cirq_algos/arithmetic_gates_test.py
+++ b/cirq_qubitization/cirq_algos/arithmetic_gates_test.py
@@ -1,6 +1,7 @@
 import itertools
 
 import cirq
+import pytest
 
 import cirq_qubitization
 
@@ -47,3 +48,24 @@ def test_multi_in_less_equal_than_gate():
             assert true_out_int == int(out_bin, 2)
             maps[input_int] = output_int
     cirq.testing.assert_equivalent_computational_basis_map(maps, circuit)
+
+
+def test_contiguous_register_gate():
+    circuit = cirq.Circuit(
+        cirq_qubitization.ContiguousRegisterGate(3, 6).on(*cirq.LineQubit.range(12))
+    )
+    maps = {}
+    for p in range(2**3):
+        for q in range(p):
+            inp = f'0b_{p:03b}_{q:03b}_{0:06b}'
+            out = f'0b_{p:03b}_{q:03b}_{(p * (p - 1))//2 + q:06b}'
+            maps[int(inp, 2)] = int(out, 2)
+
+    cirq.testing.assert_equivalent_computational_basis_map(maps, circuit)
+
+
+@pytest.mark.parametrize('n', [*range(1, 10)])
+def test_contiguous_register_gate_t_complexity(n):
+    gate = cirq_qubitization.ContiguousRegisterGate(n, 2 * n)
+    toffoli_complexity = cirq_qubitization.t_complexity(cirq.CCNOT)
+    assert cirq_qubitization.t_complexity(gate) == (n**2 + n - 1) * toffoli_complexity


### PR DESCRIPTION
This PR adds a gate to compute contiguous registers from two selection registers `|p>|q>` s.t. 1 <= q <= p < N. This is used every time we want to use a `SelectSwapQROM` to load symmetrical multi-dimensional data where the input registers iterate only on the `N * (N - 1) // 2` unique values.

See https://arxiv.org/abs/2011.03494 for more details on the costings. 

This is currently implemented as an `ArithmeticGate` but at some point it'd be nice to implement the algorithm described in the paper described above to verify the optimal implementation. However, I don't think it's urgent or blocking. 