### PR TITLE
Generalize `MultiControlNot`gate to `MultiControlPauli`

### DIFF
--- a/cirq_qubitization/__init__.py
+++ b/cirq_qubitization/__init__.py
@@ -5,7 +5,7 @@ from cirq_qubitization.cirq_algos import (
     ContiguousRegisterGate,
     LessThanEqualGate,
     LessThanGate,
-    MultiControlNOT,
+    MultiControlPauli,
     MultiTargetCNOT,
     MultiTargetCSwap,
     MultiTargetCSwapApprox,

--- a/cirq_qubitization/cirq_algos/__init__.py
+++ b/cirq_qubitization/cirq_algos/__init__.py
@@ -5,8 +5,8 @@ from cirq_qubitization.cirq_algos.arithmetic_gates import (
     LessThanEqualGate,
     LessThanGate,
 )
-from cirq_qubitization.cirq_algos.multi_control_multi_target_cnot import (
-    MultiControlNOT,
+from cirq_qubitization.cirq_algos.multi_control_multi_target_pauli import (
+    MultiControlPauli,
     MultiTargetCNOT,
 )
 from cirq_qubitization.cirq_algos.prepare_uniform_superposition import PrepareUniformSuperposition

--- a/cirq_qubitization/cirq_algos/multi_control_multi_target_pauli.py
+++ b/cirq_qubitization/cirq_algos/multi_control_multi_target_pauli.py
@@ -40,10 +40,10 @@ class MultiTargetCNOT(GateWithRegisters):
         return cirq.CircuitDiagramInfo(wire_symbols=["@"] + ["X"] * self._num_targets)
 
 
-class MultiControlNOT(GateWithRegisters):
-    """Implements multi-control, single-target C^{n}NOT gate.
+class MultiControlPauli(GateWithRegisters):
+    """Implements multi-control, single-target C^{n}P gate.
 
-    Implements $C^{n}NOT = (1 - |1^{n}><1^{n}|) I + |1^{n}><1^{n}| X^{n}$ using $n-2$
+    Implements $C^{n}P = (1 - |1^{n}><1^{n}|) I + |1^{n}><1^{n}| P^{n}$ using $n-2$
     dirty ancillas and 4n - 8 TOFFOLI gates. See Appendix B.1 of https://arxiv.org/abs/1812.00954 for
     reference.
 
@@ -54,8 +54,9 @@ class MultiControlNOT(GateWithRegisters):
         (https://algassert.com/circuits/2015/06/05/Constructing-Large-Controlled-Nots.html)
     """
 
-    def __init__(self, num_controls: int):
+    def __init__(self, num_controls: int, *, target_gate: cirq.Pauli = cirq.X):
         self._num_controls = num_controls
+        self._target_gate = target_gate
 
     @cached_property
     def registers(self) -> Registers:
@@ -63,18 +64,22 @@ class MultiControlNOT(GateWithRegisters):
 
     def decompose_from_registers(self, controls: Sequence[cirq.Qid], target: Sequence[cirq.Qid]):
         if len(controls) == 2:
-            return cirq.CCNOT(*controls, *target)
+            return self._target_gate(*target).controlled_by(*controls)
         anc = qubit_manager.qborrow(len(controls) - 2)
         ops = [cirq.CCNOT(anc[-i], controls[-i], anc[-i + 1]) for i in range(2, len(anc) + 1)]
         inverted_v_ladder = ops + [cirq.CCNOT(*controls[:2], anc[0])] + ops[::-1]
 
-        yield cirq.CCNOT(anc[-1], controls[-1], *target)
+        yield self._target_gate(*target).controlled_by(anc[-1], controls[-1])
         yield inverted_v_ladder
-        yield cirq.CCNOT(anc[-1], controls[-1], *target)
+        yield self._target_gate(*target).controlled_by(anc[-1], controls[-1])
         yield inverted_v_ladder
 
     def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
-        return cirq.CircuitDiagramInfo(wire_symbols=["@"] * self._num_controls + ["X"])
+        return cirq.CircuitDiagramInfo(
+            wire_symbols=["@"] * self._num_controls + [str(self._target_gate)]
+        )
 
     def _t_complexity_(self) -> TComplexity:
-        return (4 * self._num_controls - 8) * t_complexity(cirq.CCNOT)
+        toffoli_complexity = t_complexity(cirq.CCNOT)
+        controlled_pauli_complexity = t_complexity(self._target_gate.controlled(2))
+        return (4 * self._num_controls - 10) * toffoli_complexity + 2 * controlled_pauli_complexity

--- a/cirq_qubitization/cirq_algos/multi_control_multi_target_pauli_test.py
+++ b/cirq_qubitization/cirq_algos/multi_control_multi_target_pauli_test.py
@@ -19,8 +19,9 @@ def test_multi_target_cnot(num_targets):
     assert len(optimal_circuit) == 2 * np.ceil(np.log2(num_targets)) + 1
 
 
-def test_multi_controlled_not_diagram():
-    gate = cirq_qubitization.MultiControlNOT(5)
+@pytest.mark.parametrize('pauli, c', [(cirq.Z, '@'), (cirq.X, 'X'), (cirq.Y, 'Y')])
+def test_multi_controlled_not_diagram(pauli, c):
+    gate = cirq_qubitization.MultiControlPauli(5, target_gate=pauli)
     with cirq_infra.memory_management_context():
         g = cq_testing.GateHelper(gate)
         circuit = cirq.Circuit(cirq.decompose_once(g.operation))
@@ -32,7 +33,7 @@ def test_multi_controlled_not_diagram():
     )
     cirq.testing.assert_has_diagram(
         circuit,
-        '''
+        f'''
 controls0: ───────────────@───────────────────────@───────────
                           │                       │
 controls1: ───────────────@───────────────────────@───────────
@@ -49,13 +50,14 @@ _b2: ─────────@───X────────────�
               │                       │
 controls4: ───@───────────────────────@───────────────────────
               │                       │
-target: ──────X───────────────────────X───────────────────────
+target: ──────{c}───────────────────────{c}───────────────────────
 ''',
         qubit_order=qubit_order,
     )
 
 
 @pytest.mark.parametrize("num_controls", [*range(7, 17)])
-def test_t_complexity(num_controls: int):
-    gate = cirq_qubitization.MultiControlNOT(num_controls)
+@pytest.mark.parametrize("pauli", [cirq.X, cirq.Y, cirq.Z])
+def test_t_complexity(num_controls: int, pauli: cirq.Pauli):
+    gate = cirq_qubitization.MultiControlPauli(num_controls, target_gate=pauli)
     cq_testing.assert_decompose_is_consistent_with_t_complexity(gate)

--- a/cirq_qubitization/cirq_algos/swap_network.py
+++ b/cirq_qubitization/cirq_algos/swap_network.py
@@ -3,7 +3,7 @@ from typing import Any, Sequence
 
 import cirq
 
-from cirq_qubitization.cirq_algos import multi_control_multi_target_cnot
+from cirq_qubitization.cirq_algos import multi_control_multi_target_pauli
 from cirq_qubitization.cirq_infra.gate_with_registers import GateWithRegisters, Registers
 from cirq_qubitization.t_complexity_protocol import TComplexity
 
@@ -95,7 +95,7 @@ class MultiTargetCSwapApprox(MultiTargetCSwap):
         g_on_y = [list(g(q)) for q in target_y]  # Uses len(target_y) T-gates
 
         yield [cnot_y_to_x, g_inv_on_y, cnot_x_to_y, g_inv_on_y]
-        yield multi_control_multi_target_cnot.MultiTargetCNOT(len(target_y)).on(control, *target_y)
+        yield multi_control_multi_target_pauli.MultiTargetCNOT(len(target_y)).on(control, *target_y)
         yield [g_on_y, cnot_x_to_y, g_on_y, cnot_y_to_x]
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:


### PR DESCRIPTION
Having a `MultiControlPauli` is specifically useful for implementing the `Reflection` operation by applying a multi controlled phase gate (i.e. `MultiControlPauli(num_controls, target_gate=cirq.Z)`)

