### PR TITLE
Fix numerical instability issue in and_gate.ipynb

### DIFF
--- a/cirq_qubitization/cirq_algos/and_gate.ipynb
+++ b/cirq_qubitization/cirq_algos/and_gate.ipynb
@@ -107,9 +107,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "print(result.final_state_vector)\n",
     "inds, = np.where(abs(result.final_state_vector) > 1e-8)\n",
-    "print(inds)\n",
     "assert len(inds) == 1\n",
     "ind, = inds\n",
     "f'{ind:3b}'"


### PR DESCRIPTION
`pytest cirq_qubitization/cirq_algos/and_gate_test.py::test_notebook ` is currently failing for me due to a numerical instability issue where `np.where(result.final_state_vector)` returns 2 indices even though one of them is ~1e-18 because of exact comparison. 

