### PR TITLE
Swap network gates to bloqs

### DIFF
--- a/cirq_qubitization/bloq_algos/basic_gates/__init__.py
+++ b/cirq_qubitization/bloq_algos/basic_gates/__init__.py
@@ -1,3 +1,4 @@
 from .cnot import CNOT
+from .swap import CSwap, TwoBitCSwap, TwoBitSwap
 from .x_basis import MinusEffect, MinusState, PlusEffect, PlusState, XGate
-from .z_basis import OneEffect, OneState, ZeroEffect, ZeroState, ZGate
+from .z_basis import IntEffect, IntState, OneEffect, OneState, ZeroEffect, ZeroState, ZGate

--- a/cirq_qubitization/bloq_algos/basic_gates/swap.py
+++ b/cirq_qubitization/bloq_algos/basic_gates/swap.py
@@ -1,0 +1,176 @@
+from functools import cached_property
+from typing import Any, Dict, Tuple, TYPE_CHECKING
+
+import cirq
+import numpy as np
+import quimb.tensor as qtn
+from attrs import frozen
+from numpy.typing import NDArray
+
+from cirq_qubitization.quantum_graph.bloq import Bloq
+from cirq_qubitization.quantum_graph.composite_bloq import SoquetT
+from cirq_qubitization.quantum_graph.fancy_registers import FancyRegister, FancyRegisters
+from cirq_qubitization.t_complexity_protocol import TComplexity
+
+if TYPE_CHECKING:
+
+    from cirq_qubitization.quantum_graph.cirq_conversion import CirqQuregT
+    from cirq_qubitization.quantum_graph.classical_sim import ClassicalValT
+
+
+def _swap_matrix() -> NDArray[np.complex128]:
+    x = np.eye(2**2, dtype=np.complex128).reshape((2,) * 2 * 2)
+    return x.transpose([0, 3, 1, 2])
+
+
+def _controlled_swap_matrix():
+    x = np.eye(2**3, dtype=np.complex128).reshape((2,) * 3 * 2)
+    x[1, :, :, 1, ::] = _swap_matrix()
+    return x
+
+
+@frozen
+class TwoBitSwap(Bloq):
+    """Swap two bits.
+
+    Registers:
+        x: the first bit
+        y: the second bit
+    """
+
+    def short_name(self) -> str:
+        return 'swap'
+
+    @cached_property
+    def registers(self) -> FancyRegisters:
+        return FancyRegisters.build(x=1, y=1)
+
+    def as_cirq_op(
+        self, x: 'CirqQuregT', y: 'CirqQuregT'
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
+        (x,) = x
+        (y,) = y
+        return cirq.SWAP.on(x, y)
+
+    def add_my_tensors(
+        self,
+        tn: 'qtn.TensorNetwork',
+        tag: Any,
+        *,
+        incoming: Dict[str, 'SoquetT'],
+        outgoing: Dict[str, 'SoquetT'],
+    ):
+        matrix = _swap_matrix()
+        out_inds = [outgoing['x'], outgoing['y']]
+        in_inds = [incoming['x'], incoming['y']]
+        tn.add(qtn.Tensor(data=matrix, inds=out_inds + in_inds, tags=[self.short_name(), tag]))
+
+    def on_classical_vals(
+        self, x: 'ClassicalValT', y: 'ClassicalValT'
+    ) -> Dict[str, 'ClassicalValT']:
+        return {'x': y, 'y': x}
+
+
+@frozen
+class TwoBitCSwap(Bloq):
+    """Swap two bits controlled on a control bit.
+
+    This is sometimes known as the [Fredkin Gate](https://en.wikipedia.org/wiki/Fredkin_gate).
+
+    Registers:
+        ctrl: the control bit
+        x: the first bit
+        y: the second bit
+    """
+
+    def short_name(self) -> str:
+        return 'swap'
+
+    @cached_property
+    def registers(self) -> FancyRegisters:
+        return FancyRegisters.build(ctrl=1, x=1, y=1)
+
+    def as_cirq_op(
+        self, ctrl: 'CirqQuregT', x: 'CirqQuregT', y: 'CirqQuregT'
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
+        (ctrl,) = ctrl
+        (x,) = x
+        (y,) = y
+        return cirq.CSWAP.on(ctrl, x, y), {'ctrl': [ctrl], 'x': [x], 'y': [y]}
+
+    def add_my_tensors(
+        self,
+        tn: 'qtn.TensorNetwork',
+        tag: Any,
+        *,
+        incoming: Dict[str, 'SoquetT'],
+        outgoing: Dict[str, 'SoquetT'],
+    ):
+        matrix = _controlled_swap_matrix()
+        out_inds = [outgoing['ctrl'], outgoing['x'], outgoing['y']]
+        in_inds = [incoming['ctrl'], incoming['x'], incoming['y']]
+        tn.add(qtn.Tensor(data=matrix, inds=out_inds + in_inds, tags=[self.short_name(), tag]))
+
+    def on_classical_vals(
+        self, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'
+    ) -> Dict[str, 'ClassicalValT']:
+        if ctrl == 0:
+            return {'ctrl': 0, 'x': x, 'y': y}
+        if ctrl == 1:
+            return {'ctrl': 1, 'x': y, 'y': x}
+        raise ValueError("Bad control value for TwoBitCSwap classical simulation.")
+
+    def t_complexity(self) -> 'TComplexity':
+        """The t complexity.
+
+        References:
+            [An algorithm for the T-count](https://arxiv.org/abs/1308.4134). Gosset et. al. 2013.
+            Figure 5.2.
+        """
+        # https://arxiv.org/abs/1308.4134
+        return TComplexity(t=7, clifford=10)
+
+
+@frozen
+class CSwap(Bloq):
+    """Swap two registers controlled on a control bit.
+
+    This decomposes into a qubitwise SWAP on the two target registers, and takes 14*n T-gates.
+
+    Args:
+        bitsize: The bitsize of each of the two registers being swapped.
+
+    Registers:
+        ctrl: the control bit
+        x: the first register
+        y: the second register
+    """
+
+    bitsize: int
+
+    @cached_property
+    def registers(self) -> FancyRegisters:
+        return FancyRegisters.build(ctrl=1, x=self.bitsize, y=self.bitsize)
+
+    def build_composite_bloq(
+        self, bb: 'CompositeBloqBuilder', ctrl: 'SoquetT', x: 'SoquetT', y: 'SoquetT'
+    ) -> Dict[str, 'SoquetT']:
+        xs = bb.split(x)
+        ys = bb.split(y)
+
+        for i in range(self.bitsize):
+            ctrl, xs[i], ys[i] = bb.add(TwoBitCSwap(), ctrl=ctrl, x=xs[i], y=ys[i])
+
+        return {'ctrl': ctrl, 'x': bb.join(xs), 'y': bb.join(ys)}
+
+    def on_classical_vals(
+        self, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'
+    ) -> Dict[str, 'ClassicalValT']:
+        if ctrl == 0:
+            return {'ctrl': 0, 'x': x, 'y': y}
+        if ctrl == 1:
+            return {'ctrl': 1, 'x': y, 'y': x}
+        raise ValueError("Bad control value for CSwap classical simulation.")
+
+    def short_name(self) -> str:
+        return 'swap'

--- a/cirq_qubitization/bloq_algos/basic_gates/swap_test.py
+++ b/cirq_qubitization/bloq_algos/basic_gates/swap_test.py
@@ -1,0 +1,121 @@
+import cirq
+import numpy as np
+
+from cirq_qubitization.bloq_algos.basic_gates import (
+    OneEffect,
+    OneState,
+    TwoBitCSwap,
+    TwoBitSwap,
+    ZeroEffect,
+    ZeroState,
+)
+from cirq_qubitization.bloq_algos.basic_gates.swap import (
+    _controlled_swap_matrix,
+    _swap_matrix,
+    CSwap,
+)
+from cirq_qubitization.quantum_graph.composite_bloq import CompositeBloqBuilder
+
+
+def _make_CSwap():
+    from cirq_qubitization.bloq_algos.basic_gates import CSwap
+
+    return CSwap(bitsize=64)
+
+
+def test_swap_matrix():
+    m = _swap_matrix().reshape(4, 4)
+    np.testing.assert_array_equal(m, cirq.unitary(cirq.SWAP))
+
+
+def test_cswap_matrix():
+    m = _controlled_swap_matrix().reshape(8, 8)
+    np.testing.assert_array_equal(m, cirq.unitary(cirq.CSWAP))
+
+
+def test_two_bit_swap():
+    swap = TwoBitSwap()
+    np.testing.assert_array_equal(swap.tensor_contract(), cirq.unitary(cirq.SWAP))
+
+    x, y = swap.call_classically(x=0, y=1)
+    assert x == 1
+    assert y == 0
+
+
+def _set_ctrl_two_bit_swap(ctrl_bit):
+    states = [ZeroState(), OneState()]
+    effs = [ZeroEffect(), OneEffect()]
+
+    bb = CompositeBloqBuilder()
+    (q0,) = bb.add(states[ctrl_bit])
+    q1 = bb.add_register('q1', 1)
+    q2 = bb.add_register('q2', 1)
+    q0, q1, q2 = bb.add(TwoBitCSwap(), ctrl=q0, x=q1, y=q2)
+    bb.add(effs[ctrl_bit], q=q0)
+    return bb.finalize(q1=q1, q2=q2)
+
+
+def test_two_bit_cswap():
+    cswap = TwoBitCSwap()
+    np.testing.assert_array_equal(cswap.tensor_contract(), cirq.unitary(cirq.CSWAP))
+
+    # Zero ctrl -- it's identity
+    np.testing.assert_array_equal(np.eye(4), _set_ctrl_two_bit_swap(0).tensor_contract())
+    # One ctrl -- it's swap
+    np.testing.assert_array_equal(
+        _swap_matrix().reshape(4, 4), _set_ctrl_two_bit_swap(1).tensor_contract()
+    )
+
+    # classical logic
+    ctrl, x, y = cswap.call_classically(ctrl=0, x=1, y=0)
+    assert (ctrl, x, y) == (0, 1, 0)
+    ctrl, x, y = cswap.call_classically(ctrl=1, x=1, y=0)
+    assert (ctrl, x, y) == (1, 0, 1)
+
+    # cirq
+    c1 = cirq.Circuit([cirq.CSWAP(*cirq.LineQubit.range(3))]).freeze()
+    c2, _ = cswap.as_composite_bloq().to_cirq_circuit(
+        ctrl=[cirq.LineQubit(0)], x=[cirq.LineQubit(1)], y=[cirq.LineQubit(2)]
+    )
+    assert c1 == c2
+
+
+def _set_ctrl_swap(ctrl_bit, bloq: CSwap):
+    states = [ZeroState(), OneState()]
+    effs = [ZeroEffect(), OneEffect()]
+
+    bb = CompositeBloqBuilder()
+    (q0,) = bb.add(states[ctrl_bit])
+    q1 = bb.add_register('q1', bloq.bitsize)
+    q2 = bb.add_register('q2', bloq.bitsize)
+    q0, q1, q2 = bb.add(bloq, ctrl=q0, x=q1, y=q2)
+    bb.add(effs[ctrl_bit], q=q0)
+    return bb.finalize(q1=q1, q2=q2)
+
+
+def test_cswap_unitary():
+    cswap = CSwap(bitsize=4)
+
+    # Zero ctrl -- it's identity
+    np.testing.assert_array_equal(np.eye(2 ** (4 * 2)), _set_ctrl_swap(0, cswap).tensor_contract())
+
+    # One ctrl -- it's multi-swap
+    qubits = cirq.LineQubit.range(8)
+    q_x, q_y = qubits[:4], qubits[4:]
+    unitary = cirq.unitary(cirq.Circuit(cirq.SWAP(x, y) for x, y in zip(q_x, q_y)))
+    np.testing.assert_array_equal(unitary, _set_ctrl_swap(1, cswap).tensor_contract())
+
+
+def test_cswap_classical():
+    cswap = CSwap(bitsize=8)
+    cswap_d = cswap.decompose_bloq()
+
+    ctrl, x, y = cswap.call_classically(ctrl=0, x=255, y=128)
+    assert (ctrl, x, y) == (0, 255, 128)
+    ctrl, x, y = cswap_d.call_classically(ctrl=0, x=255, y=128)
+    assert (ctrl, x, y) == (0, 255, 128)
+
+    ctrl, x, y = cswap.call_classically(ctrl=1, x=255, y=128)
+    assert (ctrl, x, y) == (1, 128, 255)
+    ctrl, x, y = cswap_d.call_classically(ctrl=1, x=255, y=128)
+    assert (ctrl, x, y) == (1, 128, 255)

--- a/cirq_qubitization/bloq_algos/basic_gates/z_basis.py
+++ b/cirq_qubitization/bloq_algos/basic_gates/z_basis.py
@@ -1,11 +1,13 @@
 from functools import cached_property
-from typing import Dict, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Tuple, TYPE_CHECKING
 
+import attrs
 import numpy as np
 import quimb.tensor as qtn
 from attrs import frozen
 
 from cirq_qubitization.quantum_graph.bloq import Bloq
+from cirq_qubitization.quantum_graph.classical_sim import ints_to_bits
 from cirq_qubitization.quantum_graph.composite_bloq import SoquetT
 from cirq_qubitization.quantum_graph.fancy_registers import FancyRegister, FancyRegisters, Side
 
@@ -13,6 +15,7 @@ if TYPE_CHECKING:
     import cirq
 
     from cirq_qubitization.quantum_graph.cirq_conversion import CirqQuregT
+    from cirq_qubitization.quantum_graph.classical_sim import ClassicalValT
 
 _ZERO = np.array([1, 0], dtype=np.complex128)
 _ONE = np.array([0, 1], dtype=np.complex128)
@@ -155,3 +158,110 @@ class ZGate(Bloq):
 
         (q,) = q
         return cirq.Z(q), {'q': [q]}
+
+
+@frozen
+class _IntVector(Bloq):
+    """Represent a classical non-negative integer vector (state or effect).
+
+    Args:
+        val: the classical value
+        bitsize: The bitsize of the register
+        state: True if this is a state; an effect otherwise.
+
+    Registers:
+        val: The register of size `bitsize` which initializes the value `val`.
+    """
+
+    val: int = attrs.field()
+    bitsize: int
+    state: bool
+
+    @val.validator
+    def check(self, attribute, val):
+        if val < 0:
+            raise ValueError("`val` must be positive")
+
+        if val >= 2**self.bitsize:
+            raise ValueError(f"`val` is too big for bitsize {self.bitsize}")
+
+    @cached_property
+    def registers(self) -> FancyRegisters:
+        side = Side.RIGHT if self.state else Side.LEFT
+        return FancyRegisters([FancyRegister('val', bitsize=self.bitsize, side=side)])
+
+    def build_composite_bloq(self, bb: 'CompositeBloqBuilder') -> Dict[str, 'SoquetT']:
+        states = [ZeroState(), OneState()]
+        xs = []
+        for bit in ints_to_bits(np.array([self.val]), w=self.bitsize)[0]:
+            (x,) = bb.add(states[bit])
+            xs.append(x)
+        xs = np.array(xs)
+
+        return {'val': bb.join(xs)}
+
+    def add_my_tensors(
+        self,
+        tn: qtn.TensorNetwork,
+        tag: Any,
+        *,
+        incoming: Dict[str, SoquetT],
+        outgoing: Dict[str, SoquetT],
+    ):
+        data = np.zeros(2**self.bitsize).reshape((2,) * self.bitsize)
+        bitstring = ints_to_bits(np.array([self.val]), w=self.bitsize)[0]
+        data[tuple(bitstring)] = 1
+        data = data.reshape(-1)
+
+        if self.state:
+            inds = (outgoing['val'],)
+        else:
+            inds = (incoming['val'],)
+
+        tn.add(qtn.Tensor(data=data, inds=inds, tags=[self.short_name(), tag]))
+
+    def on_classical_vals(self, **vals: 'ClassicalValT') -> Dict[str, int]:
+        if self.state:
+            assert not vals
+            return {'val': self.val}
+
+        assert vals['val'] == self.val, vals['val']
+
+    def short_name(self) -> str:
+        return f'{self.val}'
+
+    def pretty_name(self) -> str:
+        s = self.short_name()
+        return f'|{s}>' if self.state else f'<{s}|'
+
+
+@frozen(init=False, field_transformer=_hide_base_fields)
+class IntState(_IntVector):
+    """The state |val> for non-negative integer val
+
+    Args:
+        val: the classical value
+        bitsize: The bitsize of the register
+
+    Registers:
+        val: The register of size `bitsize` which initializes the value `val`.
+    """
+
+    def __init__(self, val: int, bitsize: int):
+        self.__attrs_init__(val=val, bitsize=bitsize, state=True)
+
+
+@frozen(init=False, field_transformer=_hide_base_fields)
+class IntEffect(_IntVector):
+    """The effect <val| for non-negative integer val
+
+    Args:
+        val: the classical value
+        bitsize: The bitsize of the register
+
+    Registers:
+        val: The register of size `bitsize` which de-allocates the value `val`.
+    """
+
+    def __init__(self, val: int, bitsize: int):
+        self.__attrs_init__(val=val, bitsize=bitsize, state=False)

--- a/cirq_qubitization/bloq_algos/basic_gates/z_basis_test.py
+++ b/cirq_qubitization/bloq_algos/basic_gates/z_basis_test.py
@@ -1,7 +1,14 @@
 import numpy as np
 import pytest
 
-from cirq_qubitization.bloq_algos.basic_gates import OneEffect, OneState, ZeroEffect, ZeroState
+from cirq_qubitization.bloq_algos.basic_gates import (
+    IntEffect,
+    IntState,
+    OneEffect,
+    OneState,
+    ZeroEffect,
+    ZeroState,
+)
 from cirq_qubitization.quantum_graph.composite_bloq import CompositeBloqBuilder
 
 
@@ -92,3 +99,29 @@ def test_zero_state_effect(bit):
 
     res = cbloq.call_classically()
     assert res == ()
+
+
+def test_int_state():
+    k = IntState(255, bitsize=8)
+    assert k.short_name() == '255'
+    assert k.pretty_name() == '|255>'
+    (val,) = k.call_classically()
+    assert val == 255
+
+    with pytest.raises(ValueError):
+        _ = IntState(255, bitsize=7)
+    with pytest.raises(ValueError):
+        _ = IntState(-1, bitsize=8)
+
+    np.testing.assert_allclose(k.tensor_contract(), k.decompose_bloq().tensor_contract())
+
+
+def test_int_effect():
+    k = IntEffect(255, bitsize=8)
+    assert k.short_name() == '255'
+    assert k.pretty_name() == '<255|'
+    ret = k.call_classically(val=255)
+    assert ret == ()
+
+    with pytest.raises(AssertionError):
+        k.call_classically(val=245)

--- a/cirq_qubitization/bloq_algos/swap_network.ipynb
+++ b/cirq_qubitization/bloq_algos/swap_network.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "287eb288",
+   "metadata": {
+    "cq.autogen": "title_cell"
+   },
+   "source": [
+    "# Swap Network"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0aea9bd4",
+   "metadata": {
+    "cq.autogen": "top_imports"
+   },
+   "outputs": [],
+   "source": [
+    "import cirq\n",
+    "import numpy as np\n",
+    "import cirq_qubitization\n",
+    "import cirq_qubitization.cirq_infra.testing as cq_testing\n",
+    "from cirq_qubitization.jupyter_tools import display_gate_and_compilation, show_bloq\n",
+    "from typing import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e668982",
+   "metadata": {
+    "cq.autogen": "_make_CSwap.md"
+   },
+   "source": [
+    "## `CSwap`\n",
+    "Swap two registers controlled on a control bit.\n",
+    "\n",
+    "This decomposes into a qubitwise SWAP on the two target registers, and takes 14*n T-gates.\n",
+    "\n",
+    "#### Parameters\n",
+    " - `bitsize`: The bitsize of each of the two registers being swapped. \n",
+    "\n",
+    "Registers:\n",
+    "    ctrl: the control bit\n",
+    "    x: the first register\n",
+    "    y: the second register"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7486a640",
+   "metadata": {
+    "cq.autogen": "_make_CSwap.py"
+   },
+   "outputs": [],
+   "source": [
+    "from cirq_qubitization.bloq_algos.basic_gates import CSwap\n",
+    "\n",
+    "bloq = CSwap(bitsize=64)\n",
+    "show_bloq(bloq)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "714c89db",
+   "metadata": {
+    "cq.autogen": "_make_CSwapApprox.md"
+   },
+   "source": [
+    "## `CSwapApprox`\n",
+    "Approximately implements a multi-target controlled swap unitary using only 4 * n T-gates.\n",
+    "\n",
+    "Implements $\\mathrm{CSWAP}_n = |0 \\rangle\\langle 0| I + |1 \\rangle\\langle 1| \\mathrm{SWAP}_n$\n",
+    "such that the output state is correct up to a global phase factor of +1 / -1.\n",
+    "\n",
+    "This is useful when the incorrect phase can be absorbed in a garbage state of an algorithm\n",
+    "and thus ignored. See the reference for more details.\n",
+    "\n",
+    "#### Parameters\n",
+    " - `bitsize`: The bitsize of the two registers being swapped. \n",
+    "\n",
+    "Registers:\n",
+    "    ctrl: the control bit\n",
+    "    x: the first register\n",
+    "    y: the second register\n",
+    "\n",
+    "#### References\n",
+    "[Trading T-gates for dirty qubits in state preparation and unitary synthesis](https://arxiv.org/abs/1812.00954). Low et. al. 2018. See Appendix B.2.c.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0818b4b3",
+   "metadata": {
+    "cq.autogen": "_make_CSwapApprox.py"
+   },
+   "outputs": [],
+   "source": [
+    "from cirq_qubitization.bloq_algos.swap_network import CSwapApprox\n",
+    "\n",
+    "bloq = CSwapApprox(bitsize=64)\n",
+    "show_bloq(bloq)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "786a4524",
+   "metadata": {
+    "cq.autogen": "_make_SwapWithZero.md"
+   },
+   "source": [
+    "## `SwapWithZero`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26ca63f7",
+   "metadata": {
+    "cq.autogen": "_make_SwapWithZero.py"
+   },
+   "outputs": [],
+   "source": [
+    "from cirq_qubitization.bloq_algos.swap_network import SwapWithZero\n",
+    "\n",
+    "bloq = SwapWithZero(selection_bitsize=3, target_bitsize=64, n_target_registers=5)\n",
+    "show_bloq(bloq)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cirq_qubitization/bloq_algos/swap_network.py
+++ b/cirq_qubitization/bloq_algos/swap_network.py
@@ -1,0 +1,150 @@
+from functools import cached_property
+from typing import Dict, Sequence, TYPE_CHECKING
+
+import cirq
+import numpy as np
+from attrs import frozen
+from numpy.typing import NDArray
+
+from cirq_qubitization.cirq_algos import multi_control_multi_target_pauli
+from cirq_qubitization.quantum_graph.bloq import Bloq
+from cirq_qubitization.quantum_graph.composite_bloq import CompositeBloqBuilder, SoquetT
+from cirq_qubitization.quantum_graph.fancy_registers import FancyRegister, FancyRegisters
+from cirq_qubitization.quantum_graph.quantum_graph import Soquet
+from cirq_qubitization.t_complexity_protocol import TComplexity
+
+if TYPE_CHECKING:
+    from cirq_qubitization.quantum_graph.classical_sim import ClassicalValT
+
+
+@frozen
+class CSwapApprox(Bloq):
+    r"""Approximately implements a multi-target controlled swap unitary using only 4 * n T-gates.
+
+    Implements $\mathrm{CSWAP}_n = |0 \rangle\langle 0| I + |1 \rangle\langle 1| \mathrm{SWAP}_n$
+    such that the output state is correct up to a global phase factor of +1 / -1.
+
+    This is useful when the incorrect phase can be absorbed in a garbage state of an algorithm
+    and thus ignored. See the reference for more details.
+
+    Args:
+        bitsize: The bitsize of the two registers being swapped.
+
+    Registers:
+        ctrl: the control bit
+        x: the first register
+        y: the second register
+
+    References:
+        [Trading T-gates for dirty qubits in state preparation and unitary synthesis](https://arxiv.org/abs/1812.00954).
+        Low et. al. 2018. See Appendix B.2.c.
+    """
+
+    bitsize: int
+
+    @cached_property
+    def registers(self) -> FancyRegisters:
+        return FancyRegisters.build(ctrl=1, x=self.bitsize, y=self.bitsize)
+
+    def cirq_decomposition(
+        self, ctrl: Sequence[cirq.Qid], x: Sequence[cirq.Qid], y: Sequence[cirq.Qid]
+    ) -> cirq.OP_TREE:
+        """Write the decomposition as a cirq circuit.
+
+        This method is taken from the cirq.GateWithRegisters implementation and is used
+        to partially support `build_composite_bloq` by relying on this cirq implementation.
+        """
+        (ctrl,) = ctrl
+
+        def g(q: cirq.Qid, adjoint=False) -> cirq.OP_TREE:
+            yield [cirq.S(q), cirq.H(q)]
+            yield cirq.T(q) ** (1 - 2 * adjoint)
+            yield [cirq.H(q), cirq.S(q) ** -1]
+
+        cnot_x_to_y = [cirq.CNOT(x, y) for x, y in zip(x, y)]
+        cnot_y_to_x = [cirq.CNOT(y, x) for x, y in zip(x, y)]
+        g_inv_on_y = [list(g(q, True)) for q in y]  # Uses len(target_y) T-gates
+        g_on_y = [list(g(q)) for q in y]  # Uses len(target_y) T-gates
+
+        yield [cnot_y_to_x, g_inv_on_y, cnot_x_to_y, g_inv_on_y]
+        yield multi_control_multi_target_pauli.MultiTargetCNOT(len(y)).on(ctrl, *y)
+        yield [g_on_y, cnot_x_to_y, g_on_y, cnot_y_to_x]
+
+    def build_composite_bloq(
+        self, bb: 'CompositeBloqBuilder', ctrl: 'SoquetT', x: 'SoquetT', y: 'SoquetT'
+    ) -> Dict[str, 'SoquetT']:
+        from cirq_qubitization.quantum_graph.cirq_conversion import cirq_circuit_to_cbloq
+
+        cirq_quregs = self.registers.get_cirq_quregs()
+        cbloq = cirq_circuit_to_cbloq(cirq.Circuit(self.cirq_decomposition(**cirq_quregs)))
+
+        # Split our registers to "flat" api from cirq circuit; add the circuit; join back up.
+        qvars = np.concatenate(([ctrl], bb.split(x), bb.split(y)))
+        (qvars,) = bb.add_from(cbloq, qubits=qvars)
+        return {
+            'ctrl': qvars[0],
+            'x': bb.join(qvars[1 : self.bitsize + 1]),
+            'y': bb.join(qvars[-self.bitsize :]),
+        }
+
+    def on_classical_vals(
+        self, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'
+    ) -> Dict[str, 'ClassicalValT']:
+        if ctrl == 0:
+            return {'ctrl': 0, 'x': x, 'y': y}
+        if ctrl == 1:
+            return {'ctrl': 1, 'x': y, 'y': x}
+        raise ValueError("Bad control value for CSwap classical simulation.")
+
+    def t_complexity(self) -> TComplexity:
+        """T complexity as explained in Appendix B.2.c of https://arxiv.org/abs/1812.00954"""
+        n = self.bitsize
+        # 4 * n: G gates, each wth 1 T and 4 cliffords
+        # 4 * n: CNOTs
+        # 2 * n - 1: CNOTs from 1 MultiTargetCNOT
+        return TComplexity(t=4 * n, clifford=22 * n - 1)
+
+    def short_name(self) -> str:
+        return '~swap'
+
+
+@frozen
+class SwapWithZero(Bloq):
+    selection_bitsize: int
+    target_bitsize: int
+    n_target_registers: int
+
+    @cached_property
+    def registers(self) -> FancyRegisters:
+        return FancyRegisters(
+            [
+                FancyRegister('selection', self.selection_bitsize),
+                FancyRegister('targets', self.target_bitsize, wireshape=(self.n_target_registers,)),
+            ]
+        )
+
+    def build_composite_bloq(
+        self, bb: 'CompositeBloqBuilder', selection: Soquet, targets: NDArray[Soquet]
+    ) -> Dict[str, 'SoquetT']:
+        cswap_n = CSwapApprox(self.target_bitsize)
+        # Imagine a complete binary tree of depth `logN` with `N` leaves, each denoting a target
+        # register. If the selection register stores index `r`, we want to bring the value stored
+        # in leaf indexed `r` to the leaf indexed `0`. At each node of the binary tree, the left
+        # subtree contains node with current bit 0 and right subtree contains nodes with current
+        # bit 1. Thus, leaf indexed `0` is the leftmost node in the tree.
+        # Start iterating from the root of the tree. If the j'th bit is set in the selection
+        # register (i.e. the control would be activated); we know that the value we are searching
+        # for is in the right subtree. In order to (eventually) bring the desired value to node
+        # 0; we swap all values in the right subtree with all values in the left subtree. This
+        # takes (N / (2 ** (j + 1)) swaps at level `j`.
+        # Therefore, in total, we need $\sum_{j=0}^{logN-1} \frac{N}{2 ^ {j + 1}}$ controlled swaps.
+        selection = bb.split(selection)
+        for j in range(self.selection_bitsize):
+            for i in range(0, self.n_target_registers - 2**j, 2 ** (j + 1)):
+                # The inner loop is executed at-most `N - 1` times, where `N:= len(target_regs)`.
+                sel_i = self.selection_bitsize - j - 1
+                selection[sel_i], targets[i], targets[i + 2**j] = bb.add(
+                    cswap_n, ctrl=selection[sel_i], x=targets[i], y=targets[i + 2**j]
+                )
+
+        return {'selection': bb.join(selection), 'targets': targets}

--- a/cirq_qubitization/bloq_algos/swap_network_cirq.py
+++ b/cirq_qubitization/bloq_algos/swap_network_cirq.py
@@ -1,0 +1,97 @@
+"""Gates expected to be found in `cirq_algos.swap_network` that are wrappers around bloqs."""
+
+from typing import Sequence
+
+import cirq
+
+from cirq_qubitization.bloq_algos.basic_gates import CSwap
+from cirq_qubitization.bloq_algos.swap_network import CSwapApprox, SwapWithZero
+from cirq_qubitization.quantum_graph.cirq_conversion import BloqAsCirqGate
+from cirq_qubitization.quantum_graph.fancy_registers import FancyRegister
+
+# for reprs
+_MY_NAMESPACE = 'cirq_qubitization.bloq_algos.swap_network_cirq'
+
+
+class MultiTargetCSwap(BloqAsCirqGate):
+    def __init__(self, target_bitsize: int):
+        super().__init__(bloq=CSwap(bitsize=target_bitsize))
+
+    @classmethod
+    def make_on(cls, **quregs: Sequence[cirq.Qid]) -> cirq.Operation:
+        """Helper constructor to automatically deduce bitsize attributes."""
+        return cls(target_bitsize=len(quregs['x'])).on_registers(**quregs)
+
+    @property
+    def _target_bitsize(self) -> int:
+        return self._bloq.bitsize
+
+    def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
+        if not args.use_unicode_characters:
+            return cirq.CircuitDiagramInfo(
+                ("@",) + ("swap_x",) * self._target_bitsize + ("swap_y",) * self._target_bitsize
+            )
+        return cirq.CircuitDiagramInfo(
+            ("@",) + ("×(x)",) * self._target_bitsize + ("×(y)",) * self._target_bitsize
+        )
+
+    def __repr__(self) -> str:
+        return f"{_MY_NAMESPACE}.MultiTargetCSwap({self._target_bitsize})"
+
+
+MultiTargetCSwap.__doc__ = CSwap.__doc__
+
+
+class MultiTargetCSwapApprox(BloqAsCirqGate):
+    def __init__(self, target_bitsize: int):
+        super().__init__(bloq=CSwapApprox(bitsize=target_bitsize))
+
+    @property
+    def _target_bitsize(self) -> int:
+        return self._bloq.bitsize
+
+    def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
+        if not args.use_unicode_characters:
+            return cirq.CircuitDiagramInfo(
+                ("@(approx)",)
+                + ("swap_x",) * self._target_bitsize
+                + ("swap_y",) * self._target_bitsize
+            )
+        return cirq.CircuitDiagramInfo(
+            ("@(approx)",) + ("×(x)",) * self._target_bitsize + ("×(y)",) * self._target_bitsize
+        )
+
+    def __repr__(self) -> str:
+        return f"{_MY_NAMESPACE}.MultiTargetCSwapApprox({self._target_bitsize})"
+
+
+MultiTargetCSwapApprox.__doc__ = CSwapApprox.__doc__
+
+
+def swz_reg_to_wires(reg: 'FancyRegister'):
+    if reg.name == 'selection':
+        return ["@(r⇋0)"] * reg.bitsize
+
+    if reg.name == 'targets':
+        symbs = []
+        (n_target,) = reg.wireshape
+        for i in range(n_target):
+            symbs += [f"swap_{i}"] * reg.bitsize
+        return symbs
+
+    raise ValueError(f"Unknown register {reg}")
+
+
+class SwapWithZeroGate(BloqAsCirqGate):
+    def __init__(self, selection_bitsize: int, target_bitsize: int, n_target_registers: int):
+        super().__init__(
+            bloq=SwapWithZero(
+                selection_bitsize=selection_bitsize,
+                target_bitsize=target_bitsize,
+                n_target_registers=n_target_registers,
+            ),
+            reg_to_wires=swz_reg_to_wires,
+        )
+
+
+SwapWithZeroGate.__doc__ = SwapWithZero.__doc__

--- a/cirq_qubitization/bloq_algos/swap_network_cirq_test.py
+++ b/cirq_qubitization/bloq_algos/swap_network_cirq_test.py
@@ -1,0 +1,161 @@
+import random
+
+import cirq
+import numpy as np
+import pytest
+
+import cirq_qubitization.cirq_infra.testing as cq_testing
+from cirq_qubitization.bloq_algos.swap_network_cirq import (
+    MultiTargetCSwap,
+    MultiTargetCSwapApprox,
+    SwapWithZeroGate,
+)
+from cirq_qubitization.t_complexity_protocol import t_complexity, TComplexity
+
+random.seed(12345)
+
+
+@pytest.mark.parametrize(
+    "selection_bitsize, target_bitsize, n_target_registers",
+    [[3, 5, 1], [2, 2, 3], [2, 3, 4], [3, 2, 5], [4, 1, 10]],
+)
+def test_swap_with_zero_gate(selection_bitsize, target_bitsize, n_target_registers):
+    # Construct the gate.
+    gate = SwapWithZeroGate(selection_bitsize, target_bitsize, n_target_registers)
+    # Allocate selection and target qubits.
+    all_qubits = cirq.LineQubit.range(cirq.num_qubits(gate))
+    selection = all_qubits[:selection_bitsize]
+    targets = {
+        f'targets_{i}': all_qubits[st : st + target_bitsize]
+        for i, st in enumerate(range(selection_bitsize, len(all_qubits), target_bitsize))
+    }
+    # Create a circuit.
+    circuit = cirq.Circuit(gate.on_registers(selection=selection, **targets))
+
+    # Load data[i] in i'th target register; where each register is of size target_bitsize
+    data = [random.randint(0, 2**target_bitsize - 1) for _ in range(n_target_registers)]
+    target_state = [int(x) for d in data for x in format(d, f"0{target_bitsize}b")]
+
+    sim = cirq.Simulator(dtype=np.complex128)
+    expected_state_vector = np.zeros(2**target_bitsize)
+    # Iterate on every selection integer.
+    for selection_integer in range(len(data)):
+        # Load `selection_integer` in the selection register and construct initial state.
+        selection_state = [int(x) for x in format(selection_integer, f"0{selection_bitsize}b")]
+        initial_state = selection_state + target_state
+        # Simulate the circuit with the initial state.
+        result = sim.simulate(circuit, initial_state=initial_state)
+        # Get the sub_state_vector corresponding to qubit register `target[0]`.
+        result_state_vector = cirq.sub_state_vector(
+            result.final_state_vector,
+            keep_indices=list(range(selection_bitsize, selection_bitsize + target_bitsize)),
+        )
+        # Expected state vector should correspond to data[selection_integer] due to the swap.
+        expected_state_vector[data[selection_integer]] = 1
+        # Assert that result and expected state vectors are equal; reset and continue.
+        assert cirq.equal_up_to_global_phase(result_state_vector, expected_state_vector)
+        expected_state_vector[data[selection_integer]] = 0
+
+
+def test_swap_with_zero_gate_diagram():
+    gate = SwapWithZeroGate(3, 2, 4)
+    q = cirq.LineQubit.range(cirq.num_qubits(gate))
+    circuit = cirq.Circuit(gate.on_registers(**gate.registers.split_qubits(q)))
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+0: ────@(r⇋0)───
+       │
+1: ────@(r⇋0)───
+       │
+2: ────@(r⇋0)───
+       │
+3: ────swap_0───
+       │
+4: ────swap_0───
+       │
+5: ────swap_1───
+       │
+6: ────swap_1───
+       │
+7: ────swap_2───
+       │
+8: ────swap_2───
+       │
+9: ────swap_3───
+       │
+10: ───swap_3───
+""",
+    )
+
+
+def test_multi_target_cswap():
+    qubits = cirq.LineQubit.range(5)
+    c, q_x, q_y = qubits[0], qubits[1:3], qubits[3:]
+    cswap = MultiTargetCSwap(2).on_registers(ctrl=c, x=q_x, y=q_y)
+    cswap_approx = MultiTargetCSwapApprox(2).on_registers(ctrl=c, x=q_x, y=q_y)
+    setup_code = "import cirq\nimport cirq_qubitization"
+    cirq.testing.assert_implements_consistent_protocols(cswap, setup_code=setup_code)
+    cirq.testing.assert_implements_consistent_protocols(cswap_approx, setup_code=setup_code)
+    circuit = cirq.Circuit(cswap, cswap_approx)
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+0: ───@──────@(approx)───
+      │      │
+1: ───×(x)───×(x)────────
+      │      │
+2: ───×(x)───×(x)────────
+      │      │
+3: ───×(y)───×(y)────────
+      │      │
+4: ───×(y)───×(y)────────
+    """,
+    )
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+0: ---@--------@(approx)---
+      |        |
+1: ---swap_x---swap_x------
+      |        |
+2: ---swap_x---swap_x------
+      |        |
+3: ---swap_y---swap_y------
+      |        |
+4: ---swap_y---swap_y------
+    """,
+        use_unicode_characters=False,
+    )
+
+
+def test_multi_target_cswap_make_on():
+    qubits = cirq.LineQubit.range(5)
+    c, q_x, q_y = qubits[0], qubits[1:3], qubits[3:]
+    cswap1 = MultiTargetCSwap(2).on_registers(ctrl=c, x=q_x, y=q_y)
+    cswap2 = MultiTargetCSwap.make_on(ctrl=c, x=q_x, y=q_y)
+    assert cswap1 == cswap2
+
+
+@pytest.mark.parametrize("n", [*range(1, 6)])
+def test_t_complexity(n):
+    g = MultiTargetCSwap(n)
+    cq_testing.assert_decompose_is_consistent_with_t_complexity(g)
+
+    g = MultiTargetCSwapApprox(n)
+    cq_testing.assert_decompose_is_consistent_with_t_complexity(g)
+
+
+@pytest.mark.parametrize(
+    "selection_bitsize, target_bitsize, n_target_registers, want",
+    [
+        [3, 5, 1, TComplexity(t=0, clifford=0)],
+        [2, 2, 3, TComplexity(t=16, clifford=86)],
+        [2, 3, 4, TComplexity(t=36, clifford=195)],
+        [3, 2, 5, TComplexity(t=32, clifford=172)],
+        [4, 1, 10, TComplexity(t=36, clifford=189)],
+    ],
+)
+def test_swap_with_zero_t_complexity(selection_bitsize, target_bitsize, n_target_registers, want):
+    gate = SwapWithZeroGate(selection_bitsize, target_bitsize, n_target_registers)
+    assert want == t_complexity(gate)

--- a/cirq_qubitization/bloq_algos/swap_network_test.py
+++ b/cirq_qubitization/bloq_algos/swap_network_test.py
@@ -1,0 +1,108 @@
+import random
+
+import cirq
+import numpy as np
+import pytest
+
+import cirq_qubitization
+import cirq_qubitization.cirq_infra.testing as cq_testing
+from cirq_qubitization.bloq_algos.basic_gates.z_basis import IntState
+from cirq_qubitization.bloq_algos.swap_network import CSwapApprox, SwapWithZero
+from cirq_qubitization.jupyter_tools import execute_notebook
+from cirq_qubitization.quantum_graph.composite_bloq import CompositeBloqBuilder
+from cirq_qubitization.t_complexity_protocol import t_complexity, TComplexity
+
+random.seed(12345)
+
+
+def _make_CSwapApprox():
+    from cirq_qubitization.bloq_algos.swap_network import CSwapApprox
+
+    return CSwapApprox(bitsize=64)
+
+
+def _make_SwapWithZero():
+    from cirq_qubitization.bloq_algos.swap_network import SwapWithZero
+
+    return SwapWithZero(selection_bitsize=3, target_bitsize=64, n_target_registers=5)
+
+
+@pytest.mark.parametrize('n', [5, 32])
+def test_approx_cswap_t_count(n):
+    cswap = CSwapApprox(bitsize=n)
+    assert cswap.declares_t_complexity()
+    cswap_d = cswap.decompose_bloq()
+
+    assert cswap.t_complexity() == cswap_d.t_complexity()
+
+
+@pytest.mark.parametrize(
+    "selection_bitsize, target_bitsize, n_target_registers",
+    [[3, 5, 1], [2, 2, 3], [2, 3, 4], [3, 2, 5], [4, 1, 10]],
+)
+def test_swap_with_zero_bloq(selection_bitsize, target_bitsize, n_target_registers):
+    swz = SwapWithZero(selection_bitsize, target_bitsize, n_target_registers)
+    data = [random.randint(0, 2**target_bitsize - 1) for _ in range(n_target_registers)]
+
+    expected_state_vector = np.zeros(2**target_bitsize)
+    # Iterate on every selection integer.
+    for selection_integer in range(len(data)):
+
+        bb = CompositeBloqBuilder()
+        (sel,) = bb.add(IntState(val=selection_integer, bitsize=selection_bitsize))
+        trgs = []
+        for i in range(n_target_registers):
+            (trg,) = bb.add(IntState(val=data[i], bitsize=target_bitsize))
+            trgs.append(trg)
+        sel, trgs = bb.add(swz, selection=sel, targets=np.array(trgs))
+        circuit = bb.finalize(sel=sel, trgs=trgs)
+        full_state_vector = circuit.flatten_once(
+            lambda binst: not binst.bloq.declares_my_tensors()
+        ).tensor_contract()
+
+        result_state_vector = cirq.sub_state_vector(
+            full_state_vector,
+            keep_indices=list(range(selection_bitsize, selection_bitsize + target_bitsize)),
+        )
+        # Expected state vector should correspond to data[selection_integer] due to the swap.
+        expected_state_vector[data[selection_integer]] = 1
+        # Assert that result and expected state vectors are equal; reset and continue.
+        assert cirq.equal_up_to_global_phase(result_state_vector, expected_state_vector)
+        expected_state_vector[data[selection_integer]] = 0
+
+
+def test_swap_with_zero_classically():
+    data = np.array([131, 255, 92, 2])
+    swz = SwapWithZero(selection_bitsize=2, target_bitsize=8, n_target_registers=4)
+
+    for sel in range(2**2):
+        sel, out_data = swz.call_classically(selection=sel, targets=data)
+        print(sel, out_data)
+
+
+@pytest.mark.parametrize("n", [*range(1, 6)])
+def test_t_complexity(n):
+    g = cirq_qubitization.MultiTargetCSwap(n)
+    cq_testing.assert_decompose_is_consistent_with_t_complexity(g)
+
+    g = cirq_qubitization.MultiTargetCSwapApprox(n)
+    cq_testing.assert_decompose_is_consistent_with_t_complexity(g)
+
+
+@pytest.mark.parametrize(
+    "selection_bitsize, target_bitsize, n_target_registers, want",
+    [
+        [3, 5, 1, TComplexity(t=0, clifford=0)],
+        [2, 2, 3, TComplexity(t=16, clifford=86)],
+        [2, 3, 4, TComplexity(t=36, clifford=195)],
+        [3, 2, 5, TComplexity(t=32, clifford=172)],
+        [4, 1, 10, TComplexity(t=36, clifford=189)],
+    ],
+)
+def test_swap_with_zero_t_complexity(selection_bitsize, target_bitsize, n_target_registers, want):
+    gate = cirq_qubitization.SwapWithZeroGate(selection_bitsize, target_bitsize, n_target_registers)
+    assert want == t_complexity(gate)
+
+
+def test_notebook():
+    execute_notebook('swap_network')

--- a/cirq_qubitization/cirq_algos/swap_network.ipynb
+++ b/cirq_qubitization/cirq_algos/swap_network.ipynb
@@ -98,6 +98,42 @@
     "\n",
     "display_gate_and_compilation(g)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fae3dd8",
+   "metadata": {
+    "cq.autogen": "_make_SwapWithZeroGate.md"
+   },
+   "source": [
+    "## `SwapWithZeroGate`\n",
+    "Swaps |Psi_0> with |Psi_x> if selection register stores index `x`.\n",
+    "\n",
+    "Implements the unitary U |x> |Psi_0> |Psi_1> ... |Psi_{n-1}> --> |x> |Psi_x> |Rest of Psi>.\n",
+    "Note that the state of `|Rest of Psi>` is allowed to be anything and should not be depended\n",
+    "upon.\n",
+    "\n",
+    "#### References\n",
+    "[Trading T-gates for dirty qubits in state preparation and unitary synthesis] (https://arxiv.org/abs/1812.00954). Low, Kliuchnikov, Schaeffer. 2018.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad3849f0",
+   "metadata": {
+    "cq.autogen": "_make_SwapWithZeroGate.py"
+   },
+   "outputs": [],
+   "source": [
+    "from cirq_qubitization.cirq_algos.swap_network import SwapWithZeroGate\n",
+    "\n",
+    "g = cq_testing.GateHelper(\n",
+    "    SwapWithZeroGate(selection_bitsize=2, target_bitsize=3, n_target_registers=4)\n",
+    ")\n",
+    "\n",
+    "display_gate_and_compilation(g)"
+   ]
   }
  ],
  "metadata": {
@@ -116,7 +152,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/cirq_qubitization/jupyter_autogen.py
+++ b/cirq_qubitization/jupyter_autogen.py
@@ -40,7 +40,10 @@ from sphinx.ext.napoleon import Config, GoogleDocstring
 
 import cirq_qubitization.bloq_algos.and_bloq_test
 import cirq_qubitization.bloq_algos.basic_gates.cnot_test
+import cirq_qubitization.bloq_algos.basic_gates.swap_test
 import cirq_qubitization.bloq_algos.basic_gates.x_basis_test
+import cirq_qubitization.bloq_algos.swap_network
+import cirq_qubitization.bloq_algos.swap_network_test
 import cirq_qubitization.jupyter_autogen_factories as jaf
 import cirq_qubitization.quantum_graph
 from cirq_qubitization.cirq_infra.gate_with_registers import GateWithRegisters
@@ -110,47 +113,62 @@ class NotebookSpec:
     gate_specs: List[Union[GateNbSpec, BloqNbSpec]]
     directory: str = '.'
 
+    @property
+    def basename(self):
+        return self.module.__name__.split('.')[-1]
 
-NOTEBOOK_SPECS: Dict[str, NotebookSpec] = {
-    'apply_gate_to_lth_target': NotebookSpec(
+
+NOTEBOOK_SPECS: List[NotebookSpec] = [
+    NotebookSpec(
         title='Apply to L-th Target',
         module=cirq_qubitization.cirq_algos.apply_gate_to_lth_target,
         directory='./cirq_algos',
         gate_specs=[GateNbSpec(jaf._make_ApplyGateToLthQubit)],
     ),
-    'qrom': NotebookSpec(
+    NotebookSpec(
         title='QROM',
         module=cirq_qubitization.cirq_algos.qrom,
         gate_specs=[GateNbSpec(jaf._make_QROM)],
         directory='./cirq_algos',
     ),
-    'swap_network': NotebookSpec(
+    NotebookSpec(
         title='Swap Network',
         module=cirq_qubitization.cirq_algos.swap_network,
         gate_specs=[
             GateNbSpec(jaf._make_MultiTargetCSwap),
             GateNbSpec(jaf._make_MultiTargetCSwapApprox),
+            GateNbSpec(jaf._make_SwapWithZeroGate),
         ],
         directory='./cirq_algos',
     ),
-    'generic_select': NotebookSpec(
+    NotebookSpec(
+        title='Swap Network',
+        module=cirq_qubitization.bloq_algos.swap_network,
+        gate_specs=[
+            BloqNbSpec(cirq_qubitization.bloq_algos.basic_gates.swap_test._make_CSwap),
+            BloqNbSpec(cirq_qubitization.bloq_algos.swap_network_test._make_CSwapApprox),
+            BloqNbSpec(cirq_qubitization.bloq_algos.swap_network_test._make_SwapWithZero),
+        ],
+        directory='./bloq_algos',
+    ),
+    NotebookSpec(
         title='Generic Select',
         module=cirq_qubitization.generic_select,
         gate_specs=[GateNbSpec(jaf._make_GenericSelect, draw_vertical=True)],
     ),
-    'state_preparation': NotebookSpec(
+    NotebookSpec(
         title='State Preparation using Coherent Alias Sampling',
         module=cirq_qubitization.cirq_algos.state_preparation,
         gate_specs=[GateNbSpec(jaf._make_StatePreparationAliasSampling)],
         directory='./cirq_algos',
     ),
-    'qubitization_walk_operator': NotebookSpec(
+    NotebookSpec(
         title='Szegedy Quantum Walk operator using LCU oracles SELECT and PREPARE',
         module=cirq_qubitization.cirq_algos.qubitization_walk_operator,
         gate_specs=[GateNbSpec(jaf._make_QubitizationWalkOperator)],
         directory='./cirq_algos',
     ),
-    'basic_gates': NotebookSpec(
+    NotebookSpec(
         title='Basic Gates',
         module=cirq_qubitization.bloq_algos.basic_gates,
         gate_specs=[
@@ -159,7 +177,7 @@ NOTEBOOK_SPECS: Dict[str, NotebookSpec] = {
         ],
         directory='./bloq_algos',
     ),
-    'and_bloq': NotebookSpec(
+    NotebookSpec(
         title='And',
         module=cirq_qubitization.bloq_algos.and_bloq,
         gate_specs=[
@@ -168,7 +186,7 @@ NOTEBOOK_SPECS: Dict[str, NotebookSpec] = {
         ],
         directory='./bloq_algos',
     ),
-}
+]
 
 
 class _GoogleDocstringToMarkdown(GoogleDocstring):
@@ -394,18 +412,19 @@ def render_notebook_cells(nbspec: NotebookSpec) -> NbCells:
 
 
 def _init_notebook(
-    modname: str, overwrite=False, directory: str = '.'
+    basename: str, overwrite=False, directory: str = '.'
 ) -> Tuple[nbformat.NotebookNode, Path]:
     """Initialize a jupyter notebook.
 
     If one already exists: load it in. Otherwise, create a new one.
 
     Args:
-        modname: The name used to find the notebook if it exists.
+        basename: The extensionless filename to find the notebook if it exists.
         overwrite: If set, remove any existing notebook and start from scratch.
+        directory: The directory in which we look for the filename.
     """
 
-    nb_path = Path(f'{directory}/{modname}.ipynb')
+    nb_path = Path(f'{directory}/{basename}.ipynb')
 
     if overwrite:
         nb_path.unlink(missing_ok=True)
@@ -425,9 +444,9 @@ def _init_notebook(
 
 
 def render_notebooks():
-    for modname, nbspec in NOTEBOOK_SPECS.items():
+    for nbspec in NOTEBOOK_SPECS:
         # 1. get a notebook (existing or empty)
-        nb, nb_path = _init_notebook(modname=modname, directory=nbspec.directory)
+        nb, nb_path = _init_notebook(basename=nbspec.basename, directory=nbspec.directory)
 
         # 2. Render all the cells we can render
         cells = render_notebook_cells(nbspec)
@@ -439,7 +458,7 @@ def render_notebooks():
             cell = nb.cells[i]
             if _K_CQ_AUTOGEN in cell.metadata:
                 cqid: str = cell.metadata[_K_CQ_AUTOGEN]
-                print(f"[{modname}] Replacing {cqid} cell.")
+                print(f"[{nbspec.basename}] Replacing {cqid} cell.")
                 new_cell = cells.get_cell_from_cqid(cqid)
                 new_cell.id = cell.id  # keep id from existing cell
                 nb.cells[i] = new_cell
@@ -447,7 +466,7 @@ def render_notebooks():
 
         # 4. Any rendered cells that weren't already there, append.
         for cqid in cqids_to_render:
-            print(f"[{modname}] Adding {cqid}")
+            print(f"[{nbspec.basename}] Adding {cqid}")
             new_cell = cells.get_cell_from_cqid(cqid)
             nb.cells.append(new_cell)
 

--- a/cirq_qubitization/jupyter_autogen_factories.py
+++ b/cirq_qubitization/jupyter_autogen_factories.py
@@ -59,6 +59,12 @@ def _make_MultiTargetCSwapApprox():
     return MultiTargetCSwapApprox(2)
 
 
+def _make_SwapWithZeroGate():
+    from cirq_qubitization.cirq_algos.swap_network import SwapWithZeroGate
+
+    return SwapWithZeroGate(selection_bitsize=2, target_bitsize=3, n_target_registers=4)
+
+
 def _make_GenericSelect():
     from cirq_qubitization.generic_select import GenericSelect
 

--- a/cirq_qubitization/quantum_graph/composite_bloq.py
+++ b/cirq_qubitization/quantum_graph/composite_bloq.py
@@ -20,7 +20,6 @@ import networkx as nx
 import numpy as np
 from numpy.typing import NDArray
 
-from cirq_qubitization import TComplexity
 from cirq_qubitization.quantum_graph.bloq import Bloq
 from cirq_qubitization.quantum_graph.fancy_registers import FancyRegister, FancyRegisters, Side
 from cirq_qubitization.quantum_graph.quantum_graph import (
@@ -31,6 +30,7 @@ from cirq_qubitization.quantum_graph.quantum_graph import (
     RightDangle,
     Soquet,
 )
+from cirq_qubitization.t_complexity_protocol import TComplexity
 
 if TYPE_CHECKING:
     import cirq

--- a/cirq_qubitization/quantum_graph/composite_bloq_test.py
+++ b/cirq_qubitization/quantum_graph/composite_bloq_test.py
@@ -143,7 +143,8 @@ def test_map_soqs():
     fsoqs = map_soqs(cbloq.final_soqs(), soq_map)
     for k, val in fsoqs.items():
         assert val.binst.i >= 100
-    return bb.finalize(**fsoqs)
+    cbloq = bb.finalize(**fsoqs)
+    assert isinstance(cbloq, CompositeBloq)
 
 
 def test_bb_composite_bloq():

--- a/cirq_qubitization/quantum_graph/util_bloqs.py
+++ b/cirq_qubitization/quantum_graph/util_bloqs.py
@@ -13,7 +13,6 @@ from cirq_qubitization.quantum_graph.fancy_registers import FancyRegister, Fancy
 from cirq_qubitization.quantum_graph.quantum_graph import BloqInstance
 
 if TYPE_CHECKING:
-    import cirq
     from numpy.typing import NDArray
 
     from cirq_qubitization.quantum_graph.cirq_conversion import CirqQuregT
@@ -46,8 +45,23 @@ class Split(Bloq):
         return TComplexity()
 
     def on_classical_vals(self, split: int) -> Dict[str, 'ClassicalValT']:
-        assert split.bit_length() <= self.n
         return {'split': ints_to_bits(np.array([split]), self.n)[0]}
+
+    def add_my_tensors(
+        self,
+        tn: qtn.TensorNetwork,
+        binst: BloqInstance,
+        *,
+        incoming: Dict[str, 'SoquetT'],
+        outgoing: Dict[str, 'SoquetT'],
+    ):
+        tn.add(
+            qtn.Tensor(
+                data=np.eye(2**self.n, 2**self.n).reshape((2,) * self.n + (2**self.n,)),
+                inds=outgoing['split'].tolist() + [incoming['split']],
+                tags=['Split', binst],
+            )
+        )
 
 
 @frozen

--- a/cirq_qubitization/quantum_graph/util_bloqs_test.py
+++ b/cirq_qubitization/quantum_graph/util_bloqs_test.py
@@ -64,5 +64,25 @@ def test_classical_sim():
     assert ret == {'y': 4}
 
 
+def test_classical_sim_dtypes():
+    s = Split(n=8)
+    (xx,) = s.call_classically(split=255)
+    assert xx.tolist() == [1, 1, 1, 1, 1, 1, 1, 1]
+
+    with pytest.raises(ValueError):
+        _ = s.call_classically(split=256)
+
+    # with numpy types
+    (xx,) = s.call_classically(split=np.uint8(255))
+    assert xx.tolist() == [1, 1, 1, 1, 1, 1, 1, 1]
+
+    # Warning: numpy will wrap too-large values
+    (xx,) = s.call_classically(split=np.uint8(256))
+    assert xx.tolist() == [0, 0, 0, 0, 0, 0, 0, 0]
+
+    with pytest.raises(ValueError):
+        _ = s.call_classically(split=np.uint16(256))
+
+
 def test_notebook():
     execute_notebook('util_bloqs')


### PR DESCRIPTION
 - `SwapWithZero` -> write as a native bloq
 - Add basic swapping utilities
 - `CSwapApprox` -> write a bloq but for decomposition, use the previous cirq decomposition
 - Wrap things back into `BloqAsCirqGate` in place in `cirq_algos` so that everything still works.

We've been talking about moving the cirq algos to cirq which would foil this piecewise movement. @tanujkhattar respond to my comment in the doc! Anyways: I can revert the changes to the cirq part although it's a nice proof-of-concept. 