### PR TITLE
Render bloqs to musical-score visual layout

### DIFF
--- a/cirq_qubitization/quantum_graph/musical_score.html
+++ b/cirq_qubitization/quantum_graph/musical_score.html
@@ -1,0 +1,42 @@
+<!-- Simple HTML file that shows how to invoke d3.js based musical score drawing.
+
+    1. Set `xDomain` and `yDomain` global variables manually
+    2. Load `musical_score.js` in a script tag
+    3. Call the function `make_from_data(fn)` where fn is the json data dumped
+       from the Python library.
+
+Important note: `make_from_data` will fail (due to CORS policy) if this file
+is opened from disk. You must run a simple web server -- either via the built-in
+pycharm helper, or with
+
+    >>> cd [this directory]
+    >>> python -m http.server
+
+and navigating to http://localhost:8000/musical_score.html
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>musical score</title>
+</head>
+<style>
+    div#content{margin: 10px;}
+
+</style>
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<body>
+<div id="content">
+
+</div>
+<script>
+    let xDomain = [-2, 5];
+    let yDomain = [0, 7];
+</script>
+<script src="musical_score.js"></script>
+<script>
+    make_from_data("musical_score_example.json");
+</script>
+</body>
+</html>

--- a/cirq_qubitization/quantum_graph/musical_score.ipynb
+++ b/cirq_qubitization/quantum_graph/musical_score.ipynb
@@ -1,0 +1,129 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5fa41bdb",
+   "metadata": {},
+   "source": [
+    "# Musical Score\n",
+    "\n",
+    "The internal representation of a `CompositeBloq` is a directed acyclic graph. Here, we lay out that graph on a \"musical score\", which avoids the problems of edges crossing over each other and is more familiar to quantum computing practitioners.\n",
+    "\n",
+    "A musical score is one where time proceeds from left to right and each horizontal line\n",
+    "represents a qubit or register of qubits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b1e3b16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98aac04d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cirq_qubitization.bloq_algos.and_bloq import MultiAnd\n",
+    "from cirq_qubitization.quantum_graph.bloq import Bloq\n",
+    "from cirq_qubitization.quantum_graph.composite_bloq import CompositeBloq, CompositeBloqBuilder\n",
+    "from cirq_qubitization.quantum_graph.fancy_registers import FancyRegisters, FancyRegister\n",
+    "from cirq_qubitization.jupyter_tools import show_bloq"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "664d4689",
+   "metadata": {},
+   "source": [
+    "### Graph\n",
+    "\n",
+    "Below is a graphviz-rendered view of a 4-bit and's decomposition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d642c664",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cb = MultiAnd((1,1,1, 1)).decompose_bloq()\n",
+    "show_bloq(cb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5c0f814",
+   "metadata": {},
+   "source": [
+    "## Matplotlib musical score\n",
+    "\n",
+    "First, we call a function to assign each soquet to a position on the musical score; then we provide it to `draw_musical_score` which will use matplotlib to draw the symbols and lines according to the positions in `soq_assign`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcbbcc9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cirq_qubitization.quantum_graph.musical_score import get_musical_score_data, draw_musical_score\n",
+    "msd = get_musical_score_data(cb)\n",
+    "fig, ax = draw_musical_score(msd)\n",
+    "fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b76e47bd",
+   "metadata": {},
+   "source": [
+    "## Javascript musical score\n",
+    "\n",
+    "We can dump the salient visualization information to JSON so it can be loaded from javascript and displayed using the d3-based drawing utilities in `musical_score.js`. See `musical_score.html` where we load in this information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38271e89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cirq_qubitization.quantum_graph.musical_score import dump_musical_score\n",
+    "\n",
+    "dump_musical_score(msd, name='musical_score_example')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cirq_qubitization/quantum_graph/musical_score.js
+++ b/cirq_qubitization/quantum_graph/musical_score.js
@@ -1,0 +1,268 @@
+const r = 3;
+const xType = d3.scaleLinear; // type of x-scale
+const yType = d3.scaleLinear; // type of y-scale
+const marginTop = 20; // top margin, in pixels
+const marginRight = 30; // right margin, in pixels
+const marginBottom = 30; // bottom margin, in pixels
+const marginLeft = 40; // left margin, in pixels
+const inset = r * 2; // inset the default range, in pixels
+const insetTop = inset; // inset the default y-range
+const insetRight = inset; // inset the default x-range
+const insetBottom = inset; // inset the default y-range
+const insetLeft = inset; // inset the default x-range
+
+const halfHeight = 14;
+const halfWidth = 22;
+
+const n_x = xDomain[1] - xDomain[0];
+const n_y = yDomain[1] - yDomain[0];
+const width = n_x * (halfWidth * 2.5) + marginLeft + marginRight + insetLeft + insetRight;
+const height = n_y * (3 * halfHeight) + marginBottom + insetBottom + marginTop + insetTop;
+const xRange = [marginLeft + insetLeft, width - marginRight - insetRight];
+const yRange = [height - marginBottom - insetBottom, marginTop + insetTop];
+
+// Construct scales and axes.
+const xScale = xType(xDomain, xRange);
+const yScale = yType([yDomain[1], yDomain[0]], yRange);
+const xAxis = d3.axisBottom(xScale).ticks(width / 80);
+const yAxis = d3.axisLeft(yScale).ticks(height / 50);
+
+
+function makeCanvas(sel) {
+  const svg = sel.append("svg")
+    .attr("width", width)
+    .attr("height", height)
+    .attr("viewBox", [0, 0, width, height])
+    .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
+
+  svg.append("g")
+    .attr("transform", `translate(0,${height - marginBottom})`)
+    .call(xAxis)
+    .call(g => g.select(".domain").remove())
+
+  svg.append("g")
+    .attr("transform", `translate(${marginLeft},0)`)
+    .call(yAxis)
+    .call(g => g.select(".domain").remove())
+
+  const datag = svg.append("g")
+    .attr("id", "datag");
+
+  return [svg, datag];
+}
+
+const [canvas, DATA_G] = makeCanvas(d3.select("#content"));
+
+function drawVlines(vlines, tt) {
+  DATA_G.selectAll('line.v')
+    .data(vlines, d => d.x)
+    .join(
+      enter => enter.append("line")
+        .attr("class", "v")
+        .attr("stroke", "black")
+        .attr('x1', d => xScale(d.x))
+        .attr('x2', d => xScale(d.x))
+        .attr('y1', d => yScale(d.bottom_y))
+        .attr('y2', d => yScale(d.bottom_y))
+        .call(enter => enter.transition(tt)
+          .attr('y2', d => yScale(d.top_y))
+        )
+        .lower(),
+      update => update
+        .call(update => update.transition(tt)
+          .attr('x1', d => xScale(d.x))
+          .attr('x2', d => xScale(d.x))
+          .attr('y1', d => yScale(d.bottom_y))
+          .attr('y2', d => yScale(d.top_y))
+        )
+        .lower(),
+      exit => exit
+        .call(exit => exit.transition(tt)
+          .attr('y2', d => yScale(d.bottom_y))
+          .remove()
+        ),
+    );
+
+}
+
+function drawHlines(hlines, tt) {
+  DATA_G.selectAll('line.h')
+    .data(hlines, d => [d.y, d.seq_x_start])
+    .join(
+      enter => enter.append("line")
+        .attr("class", "h")
+        .attr("stroke", "lightblue")
+        .attr('x1', d => xScale(d.seq_x_start))
+        .attr('x2', d => xScale(d.seq_x_start))
+        .attr('y1', d => yScale(d.y))
+        .attr('y2', d => yScale(d.y))
+        .call(enter => enter.transition(tt)
+          .attr('x2', d => xScale(d.seq_x_end))
+        )
+        .lower(),
+      update => update
+        .call(update => update.transition(tt)
+          .attr('x1', d => xScale(d.seq_x_start))
+          .attr('x2', d => xScale(d.seq_x_end))
+          .attr('y1', d => yScale(d.y))
+          .attr('y2', d => yScale(d.y))
+        )
+        .lower(),
+      exit => exit
+        .call(exit => exit.transition(tt)
+          .attr('x2', d => xScale(d.seq_x_start))
+          .remove()
+        ),
+    );
+}
+
+function drawCircles(data, x, y, tt) {
+  DATA_G.selectAll("circle.circle")
+    .data(data.filter(d => d.symb_cls === "Circle"), d => d.ident)
+    .join(
+      enter => enter.append("circle")
+        .attr("class", "circle")
+        .attr("stroke", "black")
+        .attr("r", 5)
+        .attr("fill", d => d.symb_attributes.filled ? "black" : "white")
+        .attr("cx", d => xScale(x(d)))
+        .attr("cy", 0)
+        .attr("opacity", 0)
+        .call(enter => enter.transition(tt)
+          .attr("cy", d => yScale(y(d)))
+          .attr("opacity", 1.0)
+        ),
+      update => update
+        .attr("fill", d => d.symb_attributes.filled ? "black" : "white")
+        .call(enter => enter.transition(tt)
+          .attr("cy", d => yScale(y(d)))
+          .attr("cx", d => xScale(x(d)))
+          .attr("opacity", 1.0)
+        ),
+      exit => exit.transition(tt)
+        .attr("cy", 0)
+        .attr("opacity", 0)
+        .remove()
+    );
+}
+
+function drawModPlus(data, x, y, tt) {
+  DATA_G.selectAll("g.modplus")
+    .data(data.filter(d => d.symb_cls == "ModPlus"), d => d.ident)
+    .join(
+      enter => enter.append("g")
+        .attr("class", "modplus")
+        .attr("stroke", "black")
+        .attr("transform", (d, i) => `translate(${xScale(x(d))}, ${yScale(yDomain[1])})`)
+        .attr("opacity", 0.)
+        .call(g => g.append("path")
+          .attr("d", "M 0 -7 l 0 14 M -7 0 l 14 0")
+        )
+        .call(g => g.append("circle")
+          .attr("fill", "none")
+          .attr("r", 7)
+        )
+        .call(g => g.transition(tt)
+          .attr("transform", (d, i) => `translate(${xScale(x(d))}, ${yScale(y(d))})`)
+          .attr("opacity", 1.)
+        ),
+      update => update.transition(tt)
+        .attr("transform", (d, i) => `translate(${xScale(x(d))}, ${yScale(y(d))})`)
+        .attr("opacity", 1.),
+      exit => exit.transition(tt)
+        .attr("transform", (d, i) => `translate(${xScale(x(d))}, ${yScale(yDomain[1])})`)
+        .attr("opacity", 0.)
+        .remove()
+    );
+}
+
+function drawAnyTextBox(data, x, y, tt, clsname, drawbox) {
+  DATA_G.selectAll(`g.${clsname}`)
+    .data(data.filter(d => d.symb_cls === clsname), d => d.ident)
+    .join(
+      enter => enter
+        .append("g")
+        .attr("class", clsname)
+        .attr("transform", (d, i) => `translate(${xScale(x(d))}, ${yScale(y(d))})`)
+        .on("click", (e, d) => console.log(e, d))
+        .attr("opacity", 0.)
+        .call(r => r.transition(tt)
+          .attr("opacity", 1.)
+        )
+        .call(drawbox)
+        .call(enter => enter.append("text")
+          .attr("text-anchor", "middle")
+          .attr("dominant-baseline", "middle")
+          .text(d => d.symb_attributes.text)
+        ),
+      update => update
+        .call(update => update
+          .select("text")
+          .text(d => d.symb_attributes.text)
+        )
+        .call(update => update.transition(tt)
+          .attr("transform", (d, i) => `translate(${xScale(x(d))}, ${yScale(y(d))})`)
+          .attr("opacity", 1.)
+        ),
+      exit => exit.transition(tt)
+        .attr("opacity", 0.0)
+        .remove()
+    )
+}
+
+function drawTextBox(data, x, y, tt) {
+  drawAnyTextBox(data, x, y, tt, "TextBox",
+    enter => enter.append("rect")
+      .attr("fill", "white").attr("stroke", "black")
+      .attr("width", 2 * halfWidth).attr("height", 2 * halfHeight)
+      .attr("y", -halfHeight).attr("x", -halfWidth)
+  )
+}
+
+function drawRarrowTextBox(data, x, y, tt) {
+  drawAnyTextBox(data, x, y, tt, "RarrowTextBox",
+    g => g.append("polygon")
+      .attr("fill", "white").attr("stroke", "black")
+      .attr("points", `-${halfWidth},-${halfHeight} 15,-${halfHeight} ${halfWidth},0 15,${halfHeight} -${halfWidth},${halfHeight}`)
+      .attr("y", -halfHeight)
+      .attr("x", -halfWidth)
+  )
+}
+
+function drawLarrowTextBox(data, x, y, tt) {
+  drawAnyTextBox(data, x, y, tt, "LarrowTextBox",
+    g => g.append("polygon")
+      .attr("fill", "white").attr("stroke", "black")
+      .attr("points", `-${halfWidth},0 -15,-${halfHeight} ${halfWidth},-${halfHeight} ${halfWidth},${halfHeight} -15,${halfHeight}`)
+      .attr("y", -halfHeight)
+      .attr("x", -halfWidth)
+  )
+}
+
+function drawText(data, x, y, tt) {
+  drawAnyTextBox(data, x, y, tt, "Text", g => g)
+}
+
+function musicalScore(data, vlines, hlines, { x, y }) {
+  const tt = DATA_G.transition().duration(750);
+  drawVlines(vlines, tt);
+  drawHlines(hlines, tt)
+  drawCircles(data, x, y, tt);
+  drawModPlus(data, x, y, tt);
+  drawTextBox(data, x, y, tt);
+  drawLarrowTextBox(data, x, y, tt);
+  drawRarrowTextBox(data, x, y, tt);
+  drawText(data, x, y, tt);
+}
+
+function showError(message, details) {
+  d3.select("#content").append("h3").attr("style", "color:red").text(message)
+  d3.select("#content").append("p").text(details)
+}
+
+function make_from_data(fn) {
+  d3.json(fn)
+    .then(data => musicalScore(data.soqs, data.vlines, data.hlines, { x: (d) => d.seq_x, y: (d) => d.y }))
+    .catch(error => showError(`Error loading '${fn}': ${error}`, "Make sure the file exists and make sure you're serving this page from `python -m http.server` instead of from a file"))
+}
+

--- a/cirq_qubitization/quantum_graph/musical_score.py
+++ b/cirq_qubitization/quantum_graph/musical_score.py
@@ -1,0 +1,612 @@
+"""Tools for laying out composite bloq graphs onto a "musical score".
+
+A musical score is one where time proceeds from left to right and each horizontal line
+represents a qubit or register of qubits.
+"""
+import abc
+import heapq
+import json
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
+
+import attrs
+import networkx as nx
+import numpy as np
+from attrs import frozen, mutable
+from matplotlib import pyplot as plt
+from numpy.typing import NDArray
+
+from cirq_qubitization.quantum_graph.composite_bloq import _binst_to_cxns, CompositeBloq
+from cirq_qubitization.quantum_graph.fancy_registers import FancyRegister, FancyRegisters, Side
+from cirq_qubitization.quantum_graph.quantum_graph import (
+    BloqInstance,
+    Connection,
+    DanglingT,
+    LeftDangle,
+    RightDangle,
+    Soquet,
+)
+from cirq_qubitization.quantum_graph.util_bloqs import Join, Split
+
+
+@frozen
+class RegPosition:
+    """Coordinates for a register when visualizing on a musical score.
+
+    Throughout, we consider two different "x" (i.e. time) coordinates: a sequential one
+    where each bloq is in its own column and a topological one where bloqs that are
+    topologically independent can share a time slice.
+
+    Args:
+        y: The y (vertical) position as an integer.
+        seq_x: The x (horizontal) position where each bloq is enumerated in sequence.
+        topo_gen: The index of the topological generation to which the bloq belongs.
+    """
+
+    y: int
+    seq_x: int
+    topo_gen: int
+
+    def json_dict(self):
+        return attrs.asdict(self)
+
+
+@frozen(order=True)
+class HLine:
+    """Dataclass representing a horizontal line segment at a given vertical position `x`.
+
+    It runs from (sequential) x positions `seq_x_start` to `seq_x_end`, inclusive. If `seq_x_end`
+    is `None`, that indicates we've started a line (by allocating a new qubit perhaps) but
+    we don't know where it ends yet.
+    """
+
+    y: int
+    seq_x_start: int
+    seq_x_end: Optional[int] = None
+
+    def json_dict(self):
+        return attrs.asdict(self)
+
+
+class LineManager:
+    """Methods to manage allocation and de-allocation of lines representing a register of qubits."""
+
+    def __init__(self, max_n_lines: int = 100):
+        self.available = list(range(max_n_lines))
+        heapq.heapify(self.available)
+        self.hlines: Set[HLine] = set()
+
+    def new_y(self, binst: BloqInstance, reg: FancyRegister, idx=None):
+        """Allocate a new y position (i.e. a new qubit or register)."""
+        return heapq.heappop(self.available)
+
+    def new(
+        self, binst: BloqInstance, reg: FancyRegister, seq_x: int, topo_gen: int
+    ) -> Union[RegPosition, NDArray[RegPosition]]:
+        """Allocate a position or positions for `reg`.
+
+        `binst` and `reg` can optionally modify the allocation strategy.
+        `seq_x` and `topo_gen` are passed through.
+        """
+        if not reg.wireshape:
+            y = self.new_y(binst, reg)
+            self.hlines.add(HLine(y=y, seq_x_start=seq_x))
+            return RegPosition(y=y, seq_x=seq_x, topo_gen=topo_gen)
+
+        arg = np.zeros(reg.wireshape, dtype=object)
+        for idx in reg.wire_idxs():
+            y = self.new_y(binst, reg, idx)
+            self.hlines.add(HLine(y=y, seq_x_start=seq_x))
+            arg[idx] = RegPosition(y=y, seq_x=seq_x, topo_gen=topo_gen)
+        return arg
+
+    def finish_hline(self, y: int, seq_x_end: int):
+        """Update `self.hlines` once we know where an HLine ends."""
+        (partial_h_line,) = (h for h in self.hlines if h.y == y and h.seq_x_end is None)
+        self.hlines.remove(partial_h_line)
+        self.hlines.add(attrs.evolve(partial_h_line, seq_x_end=seq_x_end))
+
+    def free(
+        self, binst: BloqInstance, reg: FancyRegister, arr: Union[RegPosition, NDArray[RegPosition]]
+    ):
+        """De-allocate a position or positions for `reg`.
+
+        This will free the position for future allocation. This will find the in-progress
+        HLine associate with `reg` and update it to indicate the end point.
+        """
+        if not reg.wireshape:
+            qline = arr
+            assert isinstance(qline, RegPosition), qline
+            heapq.heappush(self.available, qline.y)
+            self.finish_hline(qline.y, seq_x_end=qline.seq_x)
+            return
+
+        for qline in arr.reshape(-1):
+            heapq.heappush(self.available, qline.y)
+            self.finish_hline(qline.y, seq_x_end=qline.seq_x)
+
+
+def _get_in_vals(
+    binst: BloqInstance, reg: FancyRegister, soq_assign: Dict[Soquet, RegPosition]
+) -> Union[RegPosition, NDArray[RegPosition]]:
+    """Pluck out the correct values from `soq_assign` for `reg` on `binst`."""
+    if not reg.wireshape:
+        return soq_assign[Soquet(binst, reg)]
+
+    arg = np.empty(reg.wireshape, dtype=object)
+    for idx in reg.wire_idxs():
+        soq = Soquet(binst, reg, idx=idx)
+        arg[idx] = soq_assign[soq]
+
+    return arg
+
+
+def _update_assign_from_vals(
+    regs: Iterable[FancyRegister],
+    binst: BloqInstance,
+    vals: Dict[str, RegPosition],
+    soq_assign: Dict[Soquet, RegPosition],
+    seq_x: int,
+    topo_gen: int,
+    manager: LineManager,
+):
+    """Update `soq_assign` using `vals`.
+
+    If a given register is not in the `vals` dictionary, we will allocate a new position for it.
+    This helper function does some shape-compatibility checking.
+    """
+    for reg in regs:
+        try:
+            arr = vals[reg.name]
+        except KeyError:
+            arr = manager.new(binst=binst, reg=reg, seq_x=seq_x, topo_gen=topo_gen)
+
+        if reg.wireshape:
+            arr = np.asarray(arr)
+            if arr.shape != reg.wireshape:
+                raise ValueError(
+                    f"Incorrect shape {arr.shape} received for {binst}.{reg.name}. "
+                    f"Want {reg.wireshape}."
+                )
+
+            for idx in reg.wire_idxs():
+                soq = Soquet(binst, reg, idx=idx)
+                soq_assign[soq] = attrs.evolve(arr[idx], seq_x=seq_x, topo_gen=topo_gen)
+        else:
+            soq = Soquet(binst, reg)
+            soq_assign[soq] = attrs.evolve(arr, seq_x=seq_x, topo_gen=topo_gen)
+
+
+def _binst_assign_line(
+    binst: BloqInstance,
+    pred_cxns: Iterable[Connection],
+    soq_assign: Dict[Soquet, RegPosition],
+    seq_x: int,
+    topo_gen: int,
+    manager: LineManager,
+):
+    """Assign positions for a binst.
+
+    Args:
+        binst: The bloq instance whose bloq we will call `on_classical_vals`.
+        pred_cxns: Predecessor connections for the bloq instance.
+        soq_assign: Current assignment of soquets to classical values.
+        seq_x: The sequential x index of the binst.
+        topo_gen: The topological generation of the binst.
+        manager: The LineManager.
+    """
+
+    # Track inter-Bloq name changes
+    for cxn in pred_cxns:
+        soq_assign[cxn.right] = attrs.evolve(soq_assign[cxn.left], seq_x=seq_x, topo_gen=topo_gen)
+
+    def _in_vals(reg: FancyRegister):
+        # close over binst and `soq_assign`
+        return _get_in_vals(binst, reg, soq_assign=soq_assign)
+
+    bloq = binst.bloq
+    in_vals = {reg.name: _in_vals(reg) for reg in bloq.registers.lefts()}
+    partial_out_vals = {
+        reg.name: in_vals[reg.name] for reg in bloq.registers if reg.side is Side.THRU
+    }
+
+    # The following will use `partial_out_vals` to re-use existing THRU lines; otherwise
+    # the following will allocate new lines.
+    _update_assign_from_vals(
+        bloq.registers.rights(),
+        binst,
+        partial_out_vals,
+        soq_assign,
+        seq_x=seq_x,
+        topo_gen=topo_gen,
+        manager=manager,
+    )
+
+    # Free any purely-left registers.
+    for reg in bloq.registers:
+        if reg.side is Side.LEFT:
+            manager.free(binst, reg, in_vals[reg.name])
+
+
+def _cbloq_musical_score(
+    registers: FancyRegisters, binst_graph: nx.DiGraph, manager: LineManager = None
+) -> Tuple[Dict[str, RegPosition], Dict[Soquet, RegPosition], LineManager]:
+    """Assign musical score positions through a composite bloq's contents.
+
+    Args:
+        registers: The cbloq's registers.
+        binst_graph: The cbloq's binst graph.
+
+    Returns:
+        final_vals: A mapping from register name to output positions
+        soq_assign: An assignment from each soquet to its position
+        manager: The line manager (now containing filled in `hlines` attribute.
+    """
+    if manager is None:
+        manager = LineManager()
+
+    # Keep track of each soquet's position. Initialize by implicitly allocating new positions.
+    # We introduce the convention that `LeftDangle`s are a seq_x=-1 and topo_gen=0
+    soq_assign: Dict[Soquet, RegPosition] = {}
+    topo_gen = 0
+    _update_assign_from_vals(
+        registers.lefts(), LeftDangle, {}, soq_assign, seq_x=-1, topo_gen=topo_gen, manager=manager
+    )
+
+    # Bloq-by-bloq application
+    seq_x = 0
+    for topo_gen, binsts in enumerate(nx.topological_generations(binst_graph)):
+        for binst in binsts:
+            if isinstance(binst, DanglingT):
+                continue
+            pred_cxns, succ_cxns = _binst_to_cxns(binst, binst_graph=binst_graph)
+            _binst_assign_line(
+                binst, pred_cxns, soq_assign, seq_x=seq_x, topo_gen=topo_gen, manager=manager
+            )
+            seq_x += 1
+
+    # Track bloq-to-dangle name changes
+    if len(list(registers.rights())) > 0:
+        final_preds, _ = _binst_to_cxns(RightDangle, binst_graph=binst_graph)
+        for cxn in final_preds:
+            soq_assign[cxn.right] = attrs.evolve(
+                soq_assign[cxn.left], seq_x=seq_x, topo_gen=topo_gen
+            )
+
+    # Formulate output with expected API
+    def _f_vals(reg: FancyRegister):
+        return _get_in_vals(RightDangle, reg, soq_assign)
+
+    final_vals = {reg.name: _f_vals(reg) for reg in registers.rights()}
+    for reg in registers.rights():
+        manager.free(RightDangle, reg, final_vals[reg.name])
+    return final_vals, soq_assign, manager
+
+
+@frozen
+class Symb(metaclass=abc.ABCMeta):
+    """Base class for a symbol.
+
+    A symbol is a particular visual representation of a bloq's register.
+    """
+
+    def draw(self, ax, x, y):
+        """Draw this symbol using matplotlib."""
+
+    def json_dict(self):
+        return {'symb_cls': self.__class__.__name__, 'symb_attributes': attrs.asdict(self)}
+
+
+@frozen
+class TextBox(Symb):
+    text: str
+
+    def draw(self, ax, x, y):
+        ax.text(
+            x,
+            -y,
+            self.text,
+            transform=ax.transData,
+            fontsize=10,
+            ha='center',
+            va='center',
+            bbox={'boxstyle': 'round', 'fc': 'white'},
+        )
+
+
+@frozen
+class Text(Symb):
+    text: str
+
+    def draw(self, ax, x, y):
+        ax.text(
+            x,
+            -y,
+            self.text,
+            transform=ax.transData,
+            fontsize=10,
+            ha='center',
+            va='center',
+            bbox={'lw': 0, 'fc': 'white'},
+        )
+
+
+@frozen
+class RarrowTextBox(Symb):
+    text: str
+
+    def draw(self, ax, x, y):
+        ax.text(
+            x,
+            -y,
+            self.text,
+            transform=ax.transData,
+            fontsize=10,
+            ha='center',
+            va='center',
+            bbox={'boxstyle': 'rarrow', 'fc': 'white'},
+        )
+
+
+@frozen
+class LarrowTextBox(Symb):
+    text: str
+
+    def draw(self, ax, x, y):
+        ax.text(
+            x,
+            -y,
+            self.text,
+            transform=ax.transData,
+            fontsize=10,
+            ha='center',
+            va='center',
+            bbox={'boxstyle': 'larrow', 'fc': 'white'},
+        )
+
+
+@frozen
+class Circle(Symb):
+    filled: bool = True
+
+    def draw(self, ax, x, y):
+        fc = 'k' if self.filled else 'w'
+        c = plt.Circle((x, -y), radius=0.1, fc=fc, ec='k')
+        ax.add_patch(c)
+
+
+@frozen
+class ModPlus(Symb):
+    def draw(self, ax, x, y):
+        ax.text(
+            x,
+            -y,
+            "⊕",
+            transform=ax.transData,
+            fontsize=20,
+            ha='center',
+            va='center',
+            bbox={'fc': 'none', 'lw': 0},
+        )
+
+
+def _soq_to_symb(soq: Soquet) -> Symb:
+    """Return a visual pleasing symbol for the given soquet.
+
+    We start with special cases for known Bloqs and finish with the defaults.
+    """
+    from cirq_qubitization.bloq_algos.and_bloq import And
+    from cirq_qubitization.bloq_algos.basic_gates import CNOT
+    from cirq_qubitization.quantum_graph.meta_bloq import ControlledBloq
+
+    # Use text (with no box) for dangling register identifiers.
+    if isinstance(soq.binst, DanglingT):
+        return Text(soq.pretty())
+
+    # Use circles for control registers. They are filled based on control values.
+    if isinstance(soq.binst.bloq, And) and soq.reg.name == 'ctrl':
+        (c_idx,) = soq.idx
+        filled = bool(soq.binst.bloq.cv1 if c_idx == 0 else soq.binst.bloq.cv2)
+        return Circle(filled)
+
+    # Circles and modplus for CNOT.
+    if isinstance(soq.binst.bloq, CNOT):
+        if soq.reg.name == 'ctrl':
+            return Circle()
+        elif soq.reg.name == 'target':
+            return ModPlus()
+        else:
+            raise AssertionError()
+
+    if isinstance(soq.binst.bloq, (ControlledBloq)) and soq.reg.name == 'ctrl':
+        return Circle()
+
+    text = soq.pretty()
+    if isinstance(soq.binst.bloq, ControlledBloq):
+        bloq = soq.binst.bloq.subbloq
+    else:
+        bloq = soq.binst.bloq
+
+    if isinstance(bloq, (Split, Join)) and soq.reg.wireshape:
+        text = f'[{", ".join(str(i) for i in soq.idx)}]'
+    if isinstance(bloq, And) and soq.reg.name == 'target':
+        text = '∧'
+
+    # Defaults: Text boxes that are pointy depending on their side.
+    if soq.reg.side is Side.THRU:
+        return TextBox(text)
+    elif soq.reg.side is Side.LEFT:
+        return RarrowTextBox(text)
+    elif soq.reg.side is Side.RIGHT:
+        return LarrowTextBox(text)
+
+
+@mutable
+class SoqData:
+    """Data needed to draw a soquet.
+
+    The symbol `symb` and position `RegPosition`. This also includes a string
+    `ident` which can be used as a d3.js "key" to associate objects when transitioning
+    between two musical scores.
+    """
+
+    symb: Symb
+    rpos: RegPosition
+    ident: str
+
+    def json_dict(self):
+        d = self.symb.json_dict()
+        d |= self.rpos.json_dict()
+        d['ident'] = self.ident
+        return d
+
+
+@frozen
+class VLine:
+    """Data for drawing vertical lines."""
+
+    x: int
+    top_y: int
+    bottom_y: int
+
+    def json_dict(self):
+        return attrs.asdict(self)
+
+
+@mutable
+class MusicalScoreData:
+    """All the data required to draw a musical score.
+
+    This can be passed to `draw_musical_score` which will use matplotlib
+    to draw the entities or dumped to json with `dump_musical_score` and then
+    loaded by the d3.js visualization code.
+    """
+
+    max_x: int
+    max_y: int
+    soqs: List[SoqData]
+    hlines: List[HLine]
+    vlines: List[VLine]
+
+    def json_dict(self):
+        return attrs.asdict(self, recurse=False)
+
+
+def _make_ident(binst: BloqInstance, me: Soquet):
+    """Make a unique string identifier key for a soquet."""
+    soqi = f'{me.reg.name},{me.reg.side},{me.idx}'
+    if isinstance(binst, DanglingT):
+        sidestr = 'l' if binst is LeftDangle else 'r'
+        return f'dang,{me.reg.name},{sidestr},{me.idx}'
+
+    return f'{binst.i},{soqi}'
+
+
+def get_musical_score_data(
+    cb: CompositeBloq, manager: Optional[LineManager] = None
+) -> MusicalScoreData:
+    """Get the musical score data for a composite bloq.
+
+    This will first walk through the compute graph to assign each soquet
+    to a register position. Then we iterate again to finalize drawing-relevant
+    properties like symbols and the various horizontal and vertical lines.
+    """
+    _, soq_assign, manager = _cbloq_musical_score(
+        cb.registers, binst_graph=cb._binst_graph, manager=manager
+    )
+    msd = MusicalScoreData(
+        max_x=max(v.seq_x for v in soq_assign.values()),
+        max_y=max(v.y for v in soq_assign.values()),
+        soqs=[],
+        vlines=[],
+        hlines=sorted(manager.hlines),
+    )
+
+    for hline in manager.hlines:
+        if hline.seq_x_end is None:
+            raise ValueError(f"A horizontal line has no end: {hline}")
+
+    for binst in nx.topological_sort(cb._binst_graph):
+        preds, succs = _binst_to_cxns(binst, binst_graph=cb._binst_graph)
+
+        # Keep track of the extent of our vlines
+        binst_top_y = 0
+        binst_bot_y = msd.max_y
+        binst_x = None
+
+        for pred in preds:
+            me = pred.right
+            symb = _soq_to_symb(me)
+            rpos = soq_assign[me]
+            ident = _make_ident(binst, me)
+
+            msd.soqs.append(SoqData(symb=symb, rpos=rpos, ident=ident))
+
+            if rpos.y < binst_bot_y:
+                binst_bot_y = rpos.y
+            if rpos.y > binst_top_y:
+                binst_top_y = rpos.y
+
+            if binst_x is not None:
+                assert binst_x == rpos.seq_x
+            else:
+                binst_x = rpos.seq_x
+
+        for succ in succs:
+            me = succ.left
+            symb = _soq_to_symb(me)
+            rpos = soq_assign[me]
+
+            if me.reg.side is Side.THRU and binst is not LeftDangle:
+                # Already drew is as part of the preds
+                continue
+
+            ident = _make_ident(binst, me)
+            msd.soqs.append(SoqData(symb=symb, rpos=rpos, ident=ident))
+
+            if rpos.y < binst_bot_y:
+                binst_bot_y = rpos.y
+            if rpos.y > binst_top_y:
+                binst_top_y = rpos.y
+
+            if binst_x is not None:
+                assert binst_x == rpos.seq_x
+            else:
+                binst_x = rpos.seq_x
+
+        if not isinstance(binst, DanglingT):
+            msd.vlines.append(VLine(x=binst_x, top_y=binst_top_y, bottom_y=binst_bot_y))
+
+    return msd
+
+
+def draw_musical_score(msd: MusicalScoreData):
+    fig, ax = plt.subplots(figsize=(max(7.0, 0.2 + 0.4 * msd.max_x), 5))
+
+    for hline in msd.hlines:
+        ax.hlines(-hline.y, hline.seq_x_start, hline.seq_x_end, color='k', zorder=-1)
+
+    for vline in msd.vlines:
+        ax.vlines(vline.x, -vline.top_y, -vline.bottom_y, color='k', zorder=-1)
+
+    for soq in msd.soqs:
+        symb = soq.symb
+        symb.draw(ax, soq.rpos.seq_x, soq.rpos.y)
+
+    ax.set_xlim((-2, msd.max_x + 1))
+    ax.set_ylim((-msd.max_y - 1, 0))
+    ax.axis('equal')
+    fig.tight_layout()
+    return fig, ax
+
+
+class MusicalScoreEncoder(json.JSONEncoder):
+    def default(self, o: Any) -> Any:
+        if isinstance(o, (SoqData, HLine, VLine, MusicalScoreData, Symb, RegPosition)):
+            return o.json_dict()
+
+        return super().default(o)
+
+
+def dump_musical_score(msd: MusicalScoreData, name: str):
+    with open(f'{name}.json', 'w') as f:
+        json.dump(msd, f, indent=2, cls=MusicalScoreEncoder)

--- a/cirq_qubitization/quantum_graph/musical_score_example.json
+++ b/cirq_qubitization/quantum_graph/musical_score_example.json
@@ -1,0 +1,260 @@
+{
+  "max_x": 3,
+  "max_y": 6,
+  "soqs": [
+    {
+      "symb_cls": "Text",
+      "symb_attributes": {
+        "text": "ctrl[0]"
+      },
+      "y": 0,
+      "seq_x": -1,
+      "topo_gen": 0,
+      "ident": "dang,ctrl,l,(0,)"
+    },
+    {
+      "symb_cls": "Text",
+      "symb_attributes": {
+        "text": "ctrl[1]"
+      },
+      "y": 1,
+      "seq_x": -1,
+      "topo_gen": 0,
+      "ident": "dang,ctrl,l,(1,)"
+    },
+    {
+      "symb_cls": "Text",
+      "symb_attributes": {
+        "text": "ctrl[2]"
+      },
+      "y": 2,
+      "seq_x": -1,
+      "topo_gen": 0,
+      "ident": "dang,ctrl,l,(2,)"
+    },
+    {
+      "symb_cls": "Text",
+      "symb_attributes": {
+        "text": "ctrl[3]"
+      },
+      "y": 3,
+      "seq_x": -1,
+      "topo_gen": 0,
+      "ident": "dang,ctrl,l,(3,)"
+    },
+    {
+      "symb_cls": "Circle",
+      "symb_attributes": {
+        "filled": true
+      },
+      "y": 0,
+      "seq_x": 0,
+      "topo_gen": 1,
+      "ident": "0,ctrl,Side.THRU,(0,)"
+    },
+    {
+      "symb_cls": "Circle",
+      "symb_attributes": {
+        "filled": true
+      },
+      "y": 1,
+      "seq_x": 0,
+      "topo_gen": 1,
+      "ident": "0,ctrl,Side.THRU,(1,)"
+    },
+    {
+      "symb_cls": "LarrowTextBox",
+      "symb_attributes": {
+        "text": "\u2227"
+      },
+      "y": 4,
+      "seq_x": 0,
+      "topo_gen": 1,
+      "ident": "0,target,Side.RIGHT,()"
+    },
+    {
+      "symb_cls": "Circle",
+      "symb_attributes": {
+        "filled": true
+      },
+      "y": 4,
+      "seq_x": 1,
+      "topo_gen": 2,
+      "ident": "1,ctrl,Side.THRU,(0,)"
+    },
+    {
+      "symb_cls": "Circle",
+      "symb_attributes": {
+        "filled": true
+      },
+      "y": 2,
+      "seq_x": 1,
+      "topo_gen": 2,
+      "ident": "1,ctrl,Side.THRU,(1,)"
+    },
+    {
+      "symb_cls": "LarrowTextBox",
+      "symb_attributes": {
+        "text": "\u2227"
+      },
+      "y": 5,
+      "seq_x": 1,
+      "topo_gen": 2,
+      "ident": "1,target,Side.RIGHT,()"
+    },
+    {
+      "symb_cls": "Circle",
+      "symb_attributes": {
+        "filled": true
+      },
+      "y": 5,
+      "seq_x": 2,
+      "topo_gen": 3,
+      "ident": "2,ctrl,Side.THRU,(0,)"
+    },
+    {
+      "symb_cls": "Circle",
+      "symb_attributes": {
+        "filled": true
+      },
+      "y": 3,
+      "seq_x": 2,
+      "topo_gen": 3,
+      "ident": "2,ctrl,Side.THRU,(1,)"
+    },
+    {
+      "symb_cls": "LarrowTextBox",
+      "symb_attributes": {
+        "text": "\u2227"
+      },
+      "y": 6,
+      "seq_x": 2,
+      "topo_gen": 3,
+      "ident": "2,target,Side.RIGHT,()"
+    },
+    {
+      "symb_cls": "Text",
+      "symb_attributes": {
+        "text": "ctrl[0]"
+      },
+      "y": 0,
+      "seq_x": 3,
+      "topo_gen": 4,
+      "ident": "dang,ctrl,r,(0,)"
+    },
+    {
+      "symb_cls": "Text",
+      "symb_attributes": {
+        "text": "ctrl[1]"
+      },
+      "y": 1,
+      "seq_x": 3,
+      "topo_gen": 4,
+      "ident": "dang,ctrl,r,(1,)"
+    },
+    {
+      "symb_cls": "Text",
+      "symb_attributes": {
+        "text": "ctrl[2]"
+      },
+      "y": 2,
+      "seq_x": 3,
+      "topo_gen": 4,
+      "ident": "dang,ctrl,r,(2,)"
+    },
+    {
+      "symb_cls": "Text",
+      "symb_attributes": {
+        "text": "junk[0]"
+      },
+      "y": 4,
+      "seq_x": 3,
+      "topo_gen": 4,
+      "ident": "dang,junk,r,(0,)"
+    },
+    {
+      "symb_cls": "Text",
+      "symb_attributes": {
+        "text": "ctrl[3]"
+      },
+      "y": 3,
+      "seq_x": 3,
+      "topo_gen": 4,
+      "ident": "dang,ctrl,r,(3,)"
+    },
+    {
+      "symb_cls": "Text",
+      "symb_attributes": {
+        "text": "junk[1]"
+      },
+      "y": 5,
+      "seq_x": 3,
+      "topo_gen": 4,
+      "ident": "dang,junk,r,(1,)"
+    },
+    {
+      "symb_cls": "Text",
+      "symb_attributes": {
+        "text": "target"
+      },
+      "y": 6,
+      "seq_x": 3,
+      "topo_gen": 4,
+      "ident": "dang,target,r,()"
+    }
+  ],
+  "hlines": [
+    {
+      "y": 0,
+      "seq_x_start": -1,
+      "seq_x_end": 3
+    },
+    {
+      "y": 1,
+      "seq_x_start": -1,
+      "seq_x_end": 3
+    },
+    {
+      "y": 2,
+      "seq_x_start": -1,
+      "seq_x_end": 3
+    },
+    {
+      "y": 3,
+      "seq_x_start": -1,
+      "seq_x_end": 3
+    },
+    {
+      "y": 4,
+      "seq_x_start": 0,
+      "seq_x_end": 3
+    },
+    {
+      "y": 5,
+      "seq_x_start": 1,
+      "seq_x_end": 3
+    },
+    {
+      "y": 6,
+      "seq_x_start": 2,
+      "seq_x_end": 3
+    }
+  ],
+  "vlines": [
+    {
+      "x": 0,
+      "top_y": 4,
+      "bottom_y": 0
+    },
+    {
+      "x": 1,
+      "top_y": 5,
+      "bottom_y": 2
+    },
+    {
+      "x": 2,
+      "top_y": 6,
+      "bottom_y": 3
+    }
+  ]
+}

--- a/cirq_qubitization/quantum_graph/musical_score_test.py
+++ b/cirq_qubitization/quantum_graph/musical_score_test.py
@@ -1,0 +1,5 @@
+from cirq_qubitization.jupyter_tools import execute_notebook
+
+
+def test_notebook():
+    execute_notebook('musical_score')


### PR DESCRIPTION
This is a rough-but-functional proof of concept for visualizing composite bloqs as a "musical score". The general flow is

 1. turn composite bloq into a data structure that generically describes a musical-score layout for the compute graph
 2. use a drawing function that consumes that data. Either: pass directly to a matplotlib-based drawer or dump to json which can be loaded by the d3.js-based drawer

Part (1) is split into two parts: first we walk the compute graph using very similar code to the other protocols (quimb, classical sim, cirq conversion) to assign positions on the score. Then we go through again to make sure all the relevant drawing data is organized into a convenient format for the drawer backeneds to consume.

This PR hacks in a soquet-to-symbol function to special case certain bloqs to make the diagrams look pretty (and to facilitate testing the different symbol types). This should probably move to be a method on the different bloqs when things stabilize.

I've included a notebook that draws a multi-and decomposition and dumps the associated json data (which is also commited for convenience). You can load it up with the skeleton html file also provided.

----


This functionality is another "zero to one" transition where it's hard to write exhaustive tests and good design without examples and it's hard to write good examples without being able to visualize them. I also don't want to devote too much time to making pretty javascript when this is a good project for a generic SWE with limited QC knowledge. So I suggest merging for now and tracking cleanup/follow-on work 