### PR TITLE
Bloq counts

### DIFF
--- a/cirq_qubitization/bloq_algos/and_bloq.ipynb
+++ b/cirq_qubitization/bloq_algos/and_bloq.ipynb
@@ -66,6 +66,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "310e538e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cirq_qubitization.quantum_graph.bloq_counts import get_bloq_counts_graph, GraphvizCounts, SympySymbolAllocator\n",
+    "import attrs\n",
+    "\n",
+    "graph, sigma = get_bloq_counts_graph(bloq)\n",
+    "GraphvizCounts(graph).get_svg()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9f0b6b69",
    "metadata": {},
@@ -149,6 +163,20 @@
    "source": [
     "bloq = MultiAnd(cvs=(1, 1, 1, 1))\n",
     "show_bloq(bloq.decompose_bloq())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a61eb113",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cirq_qubitization.quantum_graph.bloq_counts import get_bloq_counts_graph, GraphvizCounts, SympySymbolAllocator\n",
+    "import attrs\n",
+    "\n",
+    "graph, sigma = get_bloq_counts_graph(bloq)\n",
+    "GraphvizCounts(graph).get_svg()"
    ]
   },
   {

--- a/cirq_qubitization/bloq_algos/and_bloq.py
+++ b/cirq_qubitization/bloq_algos/and_bloq.py
@@ -1,16 +1,20 @@
 import itertools
 from functools import cached_property
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import quimb.tensor as qtn
+import sympy
 from attrs import field, frozen
 from numpy.typing import NDArray
 
+from cirq_qubitization.bloq_algos.basic_gates.t_gate import TGate
 from cirq_qubitization.quantum_graph.bloq import Bloq
+from cirq_qubitization.quantum_graph.bloq_counts import big_O, SympySymbolAllocator
 from cirq_qubitization.quantum_graph.composite_bloq import CompositeBloq, SoquetT
 from cirq_qubitization.quantum_graph.fancy_registers import FancyRegister, FancyRegisters, Side
 from cirq_qubitization.quantum_graph.quantum_graph import Soquet
+from cirq_qubitization.quantum_graph.util_bloqs import ArbitraryClifford
 
 
 @frozen
@@ -44,6 +48,16 @@ class And(Bloq):
                 FancyRegister('target', 1, side=Side.RIGHT if not self.adjoint else Side.LEFT),
             ]
         )
+
+    def bloq_counts(self, ssa: 'SympySymbolAllocator') -> List[Tuple[int, Bloq]]:
+        if isinstance(self.cv1, sympy.Expr) or isinstance(self.cv2, sympy.Expr):
+            pre_post_cliffords = big_O(1)
+        else:
+            pre_post_cliffords = 2 - self.cv1 - self.cv2
+        if self.adjoint:
+            return [(4 + 2 * pre_post_cliffords, ArbitraryClifford(n=2))]
+
+        return [(9 + 2 * pre_post_cliffords, ArbitraryClifford(n=2)), (4, TGate())]
 
     def pretty_name(self) -> str:
         dag = '†' if self.adjoint else ''

--- a/cirq_qubitization/bloq_algos/basic_gates/t_gate.py
+++ b/cirq_qubitization/bloq_algos/basic_gates/t_gate.py
@@ -1,0 +1,31 @@
+from functools import cached_property
+from typing import Dict, Tuple, TYPE_CHECKING
+
+from attrs import frozen
+from cirq_ft import TComplexity
+
+from cirq_qubitization.quantum_graph.bloq import Bloq
+from cirq_qubitization.quantum_graph.fancy_registers import FancyRegisters
+
+if TYPE_CHECKING:
+    import cirq
+
+    from cirq_qubitization.quantum_graph.cirq_conversion import CirqQuregT
+
+
+@frozen
+class TGate(Bloq):
+    @cached_property
+    def registers(self) -> 'FancyRegisters':
+        return FancyRegisters.build(q=1)
+
+    def t_complexity(self) -> 'TComplexity':
+        return TComplexity(t=1)
+
+    def as_cirq_op(
+        self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
+        import cirq
+
+        (q,) = q
+        return cirq.T(q), {'q': [q]}

--- a/cirq_qubitization/bloq_algos/basic_gates/z_basis.py
+++ b/cirq_qubitization/bloq_algos/basic_gates/z_basis.py
@@ -4,12 +4,16 @@ from typing import Any, Dict, Tuple, TYPE_CHECKING
 import attrs
 import numpy as np
 import quimb.tensor as qtn
+import sympy
 from attrs import frozen
+from cirq_ft import TComplexity
 
 from cirq_qubitization.quantum_graph.bloq import Bloq
+from cirq_qubitization.quantum_graph.bloq_counts import big_O
 from cirq_qubitization.quantum_graph.classical_sim import ints_to_bits
 from cirq_qubitization.quantum_graph.composite_bloq import SoquetT
 from cirq_qubitization.quantum_graph.fancy_registers import FancyRegister, FancyRegisters, Side
+from cirq_qubitization.quantum_graph.util_bloqs import ArbitraryClifford
 
 if TYPE_CHECKING:
     import cirq
@@ -181,6 +185,9 @@ class _IntVector(Bloq):
 
     @val.validator
     def check(self, attribute, val):
+        if isinstance(val, sympy.Expr) or isinstance(self.bitsize, sympy.Expr):
+            return
+
         if val < 0:
             raise ValueError("`val` must be positive")
 
@@ -228,6 +235,12 @@ class _IntVector(Bloq):
             return {'val': self.val}
 
         assert vals['val'] == self.val, vals['val']
+
+    def t_complexity(self) -> 'TComplexity':
+        return TComplexity()
+
+    def bloq_counts(self, ss):
+        return [(big_O(1), ArbitraryClifford(self.bitsize))]
 
     def short_name(self) -> str:
         return f'{self.val}'

--- a/cirq_qubitization/quantum_graph/bloq.py
+++ b/cirq_qubitization/quantum_graph/bloq.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, Tuple, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Tuple, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     import cirq
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from cirq_qubitization import TComplexity
+    from cirq_qubitization.quantum_graph.bloq_counts import SympySymbolAllocator
     from cirq_qubitization.quantum_graph.cirq_conversion import CirqQuregT
     from cirq_qubitization.quantum_graph.classical_sim import ClassicalValT
     from cirq_qubitization.quantum_graph.composite_bloq import (
@@ -206,6 +207,26 @@ class Bloq(metaclass=abc.ABCMeta):
         return an accurate value.
         """
         return not self.add_my_tensors.__qualname__.startswith('Bloq.')
+
+    def bloq_counts(self, ssa: 'SympySymbolAllocator') -> List[Tuple[int, 'Bloq']]:
+        """Return a list of `(n, bloq)` tuples where bloq is used `n` times in the decomposition.
+
+        By default, this method will use `self.decompose_bloq()` to count up bloqs.
+        However, you can override this if you don't want to provide a complete decomposition,
+        if you know symbolic expressions for the counts, or if you need to "generalize"
+        the subbloqs by overwriting bloq attributes that do not affect its cost with generic
+        sympy symbols (perhaps with the aid of the provided `SympySymbolAllocator`).
+        """
+        return self.decompose_bloq().bloq_counts(ssa)
+
+    def declares_bloq_counts(self) -> bool:
+        """Whether this bloq declares its bloq counts by overriding `.bloq_counts(...)`.
+
+        By default, we check that the method is overriden. For
+        extraordinary circumstances, you may need to override this method directly to
+        return an accurate value.
+        """
+        return not self.bloq_counts.__qualname__.startswith('Bloq.')
 
     def t_complexity(self) -> 'TComplexity':
         """The `TComplexity` for this bloq.

--- a/cirq_qubitization/quantum_graph/bloq_counts.ipynb
+++ b/cirq_qubitization/quantum_graph/bloq_counts.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1fd2bad2",
+   "metadata": {},
+   "source": [
+    "# The Bloq Counts Protocol\n",
+    "\n",
+    "`Bloq.bloq_counts(ssa)` is a protocol that queries the number of each distinct subbloq in the parent bloq's decomposition. This can be derived from the full decomposition or annotated directly by overriding the `bloq_counts` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef985a45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cirq_qubitization.quantum_graph.bloq_counts import get_bloq_counts_graph, print_counts_graph, \\\n",
+    "    GraphvizCounts, markdown_counts_graph, markdown_counts_sigma, SympySymbolAllocator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44c8cb64",
+   "metadata": {},
+   "source": [
+    "## Basic counts graph of `And`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38e14dac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cirq_qubitization.bloq_algos.and_bloq import MultiAnd, And\n",
+    "\n",
+    "graph, sigma = get_bloq_counts_graph(MultiAnd(cvs=(1,)*6))\n",
+    "print_counts_graph(graph)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68cb3c3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markdown_counts_graph(graph)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62a69633",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "GraphvizCounts(graph).get_svg()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54b71267",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markdown_counts_sigma(sigma)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e4aa56b",
+   "metadata": {},
+   "source": [
+    "## Importance of bloq generalization\n",
+    "\n",
+    "Often, bloqs have attributes that are important for describing their specific action but don't affect the bloq's resource cost. For example, `Rx(0.12)` and `Rx(0.13)` should probably be considered equal when counting the number of operations. Another example is given below where we group all two-bit `And` operations no matter their control values. \n",
+    "\n",
+    "`get_bloq_counts_graph` takes an optional callable that takes specific bloqs to general bloqs. See below for an example of what happens to the `MultiAnd` counts graph without generalization, and how we can use it to replace specific control values with sympy symbols."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c9f2b05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph, sigma = get_bloq_counts_graph(MultiAnd(cvs=(1,0)*3))\n",
+    "GraphvizCounts(graph).get_svg()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5e33995",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import attrs\n",
+    "\n",
+    "ssa = SympySymbolAllocator()\n",
+    "cv1 = ssa.new_symbol('cv1')\n",
+    "cv2 = ssa.new_symbol('cv2')\n",
+    "\n",
+    "\n",
+    "def generalize(bloq):\n",
+    "    if isinstance(bloq, And):\n",
+    "        return attrs.evolve(bloq, cv1=cv1, cv2=cv2)\n",
+    "    \n",
+    "    return bloq\n",
+    "\n",
+    "graph, sigma = get_bloq_counts_graph(MultiAnd(cvs=(1,0)*3), generalize, ssa)\n",
+    "GraphvizCounts(graph).get_svg()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cd3ea34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markdown_counts_sigma(sigma)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cirq_qubitization/quantum_graph/bloq_counts.py
+++ b/cirq_qubitization/quantum_graph/bloq_counts.py
@@ -1,0 +1,242 @@
+from collections import defaultdict
+from typing import Callable, Dict, Optional, Sequence, Tuple, Union
+
+import IPython.display
+import networkx as nx
+import pydot
+import sympy
+
+from cirq_qubitization.quantum_graph.bloq import Bloq
+from cirq_qubitization.quantum_graph.composite_bloq import CompositeBloq
+
+
+def big_O(expr):
+    """Helper to deal with CS-style big-O notation that takes the infinite limit by default."""
+    if isinstance(expr, (int, float)):
+        return sympy.Order(expr)
+    return sympy.Order(expr, *[(var, sympy.oo) for var in expr.free_symbols])
+
+
+class SympySymbolAllocator:
+    """A class that allocates unique sympy symbols for integrating out bloq attributes.
+
+    When counting, we group bloqs that only differ in attributes that do not affect
+    resource costs. In practice, we do this by replacing bloqs with a version where
+    the offending attributes have been set to an arbitrary (but unique) symbol allocated
+    by this class. We refer to this process as "generalizing".
+    """
+
+    def __init__(self):
+        self._idxs: Dict[str, int] = defaultdict(lambda: 0)
+
+    def new_symbol(self, prefix: str) -> sympy.Symbol:
+        """Return a unique symbol beginning with _prefix."""
+        s = sympy.Symbol(f'_{prefix}{self._idxs[prefix]}')
+        self._idxs[prefix] += 1
+        return s
+
+
+def _cbloq_bloq_counts(cbloq: CompositeBloq):
+    """Implementation of `CompositeBloq.bloq_counts`.
+
+    This just counts all the cbloq's subbloqs.
+    """
+    counts: Dict[Bloq, int] = defaultdict(lambda: 0)
+    for binst in cbloq.bloq_instances:
+        counts[binst.bloq] += 1
+
+    return {(n, bloq) for bloq, n in counts.items()}
+
+
+def _descend_counts(
+    parent: Bloq,
+    g: nx.DiGraph,
+    ssa: SympySymbolAllocator,
+    generalizer: Callable[[Bloq], Optional[Bloq]],
+    keep: Sequence[Bloq],
+) -> Dict[Bloq, Union[int, sympy.Expr]]:
+    """Recursive counting function.
+
+    Args:
+        parent: The current, parent bloq.
+        g: The networkx graph to which we will add the parent and its successors. This
+            argument is mutated!
+        ssa: A SympySymbolAllocator to help canonicalize bloqs.
+        generalizer: A function that replaces bloq attributes that do not affect resource costs
+            with sympy placeholders using `ssa`.
+        keep: Use these bloqs as the base case leaf nodes. Otherwise, we stop whenever there's
+            no decomposition, i.e. when `parent.bloq_counts` raises NotImplementedError
+
+    Returns:
+        sigma: A dictionary keyed by bloqs whose value is the running sum.
+    """
+    g.add_node(parent)
+
+    # Base case 1: This node is requested by the user to be a leaf node via the `keep` parameter.
+    if parent in keep:
+        return {parent: 1}
+    try:
+        count_decomp = parent.bloq_counts(ssa)
+    except NotImplementedError:
+        # Base case 2: Decomposition (or `bloq_counts`) is not implemented. This is left as a
+        #              leaf node.
+        return {parent: 1}
+
+    sigma: Dict[Bloq, int] = defaultdict(lambda: 0)
+    for n, child in count_decomp:
+        child = generalizer(child)
+        if child is None:
+            continue
+
+        # Update edge in `g`
+        if (parent, child) in g.edges:
+            g.edges[parent, child]['n'] += n
+        else:
+            g.add_edge(parent, child, n=n)
+
+        # Do the recursive step, which will continue to mutate `g`
+        child_counts = _descend_counts(child, g, ssa, generalizer, keep)
+
+        # Update `sigma` with the recursion results.
+        for k in child_counts.keys():
+            sigma[k] += child_counts[k] * n
+
+    return dict(sigma)
+
+
+def get_bloq_counts_graph(
+    bloq: Bloq,
+    generalizer: Callable[[Bloq], Optional[Bloq]] = None,
+    ssa: Optional[SympySymbolAllocator] = None,
+    keep: Optional[Sequence[Bloq]] = None,
+) -> Tuple[nx.DiGraph, Dict[Bloq, Union[int, sympy.Expr]]]:
+    """Recursively gather bloq counts.
+
+    Args:
+        bloq: The bloq to count sub-bloqs.
+        generalizer: If provided, run this function on each (sub)bloq to replace attributes
+            that do not affect resource estimates with generic sympy symbols. If this function
+            returns `None`, the bloq is ommitted from the counts graph.
+        ssa: a `SympySymbolAllocator` that will be passed to the `Bloq.bloq_counts` methods. If
+            your `generalizer` function closes over a `SympySymbolAllocator`, provide it here as
+            well. Otherwise, we will create a new allocator.
+        keep: Stop recursing and keep these bloqs as leaf nodes in the counts graph. Otherwise,
+            leaf nodes are those without a decomposition.
+
+    Returns:
+        g: A directed graph where nodes are (generalized) bloqs and edge attribute 'n' counts
+            how many of the successor bloqs are used in the decomposition of the predecessor
+            bloq(s).
+        sigma: A mapping from leaf bloqs to their total counts.
+
+    """
+    if ssa is None:
+        ssa = SympySymbolAllocator()
+    if keep is None:
+        keep = []
+    if generalizer is None:
+        generalizer = lambda b: b
+
+    g = nx.DiGraph()
+    bloq = generalizer(bloq)
+    if bloq is None:
+        raise ValueError("You can't generalize away the root bloq.")
+    sigma = _descend_counts(bloq, g, ssa, generalizer, keep)
+    return g, sigma
+
+
+def print_counts_graph(g: nx.DiGraph):
+    """Print the graph returned from `get_bloq_counts_graph`."""
+    for b in nx.topological_sort(g):
+        for succ in g.succ[b]:
+            print(b, '--', g.edges[b, succ]['n'], '->', succ)
+
+
+def markdown_bloq_expr(bloq: Bloq, expr: Union[int, sympy.Expr]):
+    """Return "`bloq`: expr" as markdown."""
+    try:
+        expr = expr._repr_latex_()
+    except AttributeError:
+        expr = f'{expr}'
+
+    return f'`{bloq}`: {expr}'
+
+
+def markdown_counts_graph(graph: nx.DiGraph) -> IPython.display.Markdown:
+    """Render the graph returned from `get_bloq_counts_graph` as markdown."""
+    m = ""
+    for bloq in nx.topological_sort(graph):
+        if not graph.succ[bloq]:
+            continue
+        m += f' - `{bloq}`\n'
+        for succ in graph.succ[bloq]:
+            expr = sympy.sympify(graph.edges[bloq, succ]['n'])
+            m += f'   - {markdown_bloq_expr(bloq, expr)}\n'
+
+    return IPython.display.Markdown(m)
+
+
+def markdown_counts_sigma(sigma: Dict[Bloq, Union[int, sympy.Expr]]) -> IPython.display.Markdown:
+    lines = []
+    for bloq, expr in sigma.items():
+        lines.append(' - ' + markdown_bloq_expr(bloq, expr))
+    return IPython.display.Markdown('\n'.join(lines))
+
+
+class GraphvizCounts:
+    """This class turns a bloqs count graph into Graphviz objects and drawings.
+
+    Args:
+        g: The counts graph.
+    """
+
+    def __init__(self, g: nx.DiGraph):
+        self.g = g
+        self._ids: Dict[Bloq, str] = {}
+        self._i = 0
+
+    def get_id(self, b: Bloq) -> str:
+        if b in self._ids:
+            return self._ids[b]
+        new_id = f'b{self._i}'
+        self._i += 1
+        self._ids[b] = new_id
+        return new_id
+
+    def get_node_properties(self, b: Bloq):
+        """Get graphviz properties for a bloq node representing `b`."""
+        label = [
+            '<',
+            f'{b.pretty_name().replace("<", "&lt;").replace(">", "&gt;")}<br />',
+            f'<font face="monospace" point-size="10">{repr(b)}</font><br/>',
+            '>',
+        ]
+        return {'label': ''.join(label), 'shape': 'rect'}
+
+    def add_nodes(self, graph: pydot.Graph):
+        """Helper function to add nodes to the pydot graph."""
+        b: Bloq
+        for b in nx.topological_sort(self.g):
+            graph.add_node(pydot.Node(self.get_id(b), **self.get_node_properties(b)))
+
+    def add_edges(self, graph: pydot.Graph):
+        """Helper function to add edges to the pydot graph."""
+        for b1, b2 in self.g.edges:
+            n = self.g.edges[b1, b2]['n']
+            label = sympy.printing.pretty(n)
+            graph.add_edge(pydot.Edge(self.get_id(b1), self.get_id(b2), label=label))
+
+    def get_graph(self):
+        """Get the pydot graph."""
+        graph = pydot.Dot('counts', graph_type='digraph', rankdir='TB')
+        self.add_nodes(graph)
+        self.add_edges(graph)
+        return graph
+
+    def get_svg_bytes(self) -> bytes:
+        """Get the SVG code (as bytes) for drawing the graph."""
+        return self.get_graph().create_svg()
+
+    def get_svg(self) -> IPython.display.SVG:
+        """Get an IPython SVG object displaying the graph."""
+        return IPython.display.SVG(self.get_svg_bytes())

--- a/cirq_qubitization/quantum_graph/bloq_counts_test.py
+++ b/cirq_qubitization/quantum_graph/bloq_counts_test.py
@@ -1,0 +1,92 @@
+from functools import cached_property
+from typing import Dict, Optional, Tuple
+
+import attrs
+import networkx as nx
+import sympy
+from attrs import frozen
+
+from cirq_qubitization.bloq_algos.basic_gates.t_gate import TGate
+from cirq_qubitization.quantum_graph.bloq import Bloq
+from cirq_qubitization.quantum_graph.bloq_counts import get_bloq_counts_graph, SympySymbolAllocator
+from cirq_qubitization.quantum_graph.fancy_registers import FancyRegisters
+from cirq_qubitization.quantum_graph.util_bloqs import ArbitraryClifford, Join, Split
+
+
+@frozen
+class BigBloq(Bloq):
+    bitsize: int
+
+    @cached_property
+    def registers(self) -> 'FancyRegisters':
+        return FancyRegisters.build(x=self.bitsize)
+
+    def bloq_counts(self, ssa: SympySymbolAllocator):
+        return [(sympy.log(self.bitsize), SubBloq(unrelated_param=0.5))]
+
+
+@frozen
+class DecompBloq(Bloq):
+    bitsize: int
+
+    @cached_property
+    def registers(self) -> 'FancyRegisters':
+        return FancyRegisters.build(x=self.bitsize)
+
+    def build_composite_bloq(
+        self, bb: 'CompositeBloqBuilder', x: 'SoquetT'
+    ) -> Dict[str, 'SoquetT']:
+        qs = bb.split(x)
+        for i in range(self.bitsize):
+            (qs[i],) = bb.add(SubBloq(unrelated_param=i / 12), q=qs[i])
+
+        return {'x': bb.join(qs)}
+
+
+@frozen
+class SubBloq(Bloq):
+    unrelated_param: float
+
+    @cached_property
+    def registers(self) -> 'FancyRegisters':
+        return FancyRegisters.build(q=1)
+
+    def bloq_counts(self, ssa: SympySymbolAllocator):
+        return [(3, TGate())]
+
+
+def get_big_bloq_counts_graph_1(bloq: Bloq) -> Tuple[nx.DiGraph, Dict[Bloq, int]]:
+    ss = SympySymbolAllocator()
+    n_c = ss.new_symbol('n_c')
+
+    def generalize(bloq: Bloq) -> Optional[Bloq]:
+        if isinstance(bloq, ArbitraryClifford):
+            return attrs.evolve(bloq, n=n_c)
+
+        return bloq
+
+    return get_bloq_counts_graph(bloq, generalize, ss)
+
+
+def test_bloq_counts_method():
+    graph, sigma = get_big_bloq_counts_graph_1(BigBloq(100))
+    assert len(sigma) == 1
+    expr = sigma[TGate()]
+    assert str(expr) == '3*log(100)'
+
+
+def test_bloq_counts_decomp():
+    graph, sigma = get_bloq_counts_graph(DecompBloq(10))
+    assert len(sigma) == 3  # includes split and join
+    expr = sigma[TGate()]
+    assert str(expr) == '30'
+
+    def generalize(bloq):
+        if isinstance(bloq, (Split, Join)):
+            return None
+        return bloq
+
+    graph, sigma = get_bloq_counts_graph(DecompBloq(10), generalize)
+    assert len(sigma) == 1
+    expr = sigma[TGate()]
+    assert str(expr) == '30'

--- a/cirq_qubitization/quantum_graph/composite_bloq.py
+++ b/cirq_qubitization/quantum_graph/composite_bloq.py
@@ -177,6 +177,12 @@ class CompositeBloq(Bloq):
     def decompose_bloq(self) -> 'CompositeBloq':
         raise NotImplementedError("Come back later.")
 
+    def bloq_counts(self, _) -> List[Tuple[int, Bloq]]:
+        """Return the bloq counts by counting up all the subbloqs."""
+        from cirq_qubitization.quantum_graph.bloq_counts import _cbloq_bloq_counts
+
+        return _cbloq_bloq_counts(self)
+
     def iter_bloqnections(
         self,
     ) -> Iterator[Tuple[BloqInstance, List[Connection], List[Connection]]]:

--- a/cirq_qubitization/quantum_graph/util_bloqs.py
+++ b/cirq_qubitization/quantum_graph/util_bloqs.py
@@ -142,3 +142,23 @@ class Free(Bloq):
     @cached_property
     def registers(self) -> FancyRegisters:
         return FancyRegisters([FancyRegister('free', bitsize=self.n, side=Side.LEFT)])
+
+
+@frozen
+class ArbitraryClifford(Bloq):
+    """A bloq representing an arbitrary `n`-qubit clifford operation.
+
+    In the surface code architecture, clifford operations are generally considered
+    cheaper than non-clifford gates. Each clifford also has roughly the same cost independent
+    of what particular operation it is doing.
+
+    You can use this to bloq to represent an arbitrary clifford operation e.g. in bloq_counts
+    resource estimates where the details are unimportant for the resource estimation task
+    at hand.
+    """
+
+    n: int
+
+    @cached_property
+    def registers(self) -> FancyRegisters:
+        return FancyRegisters([FancyRegister('x', bitsize=self.n)])


### PR DESCRIPTION
Rough implementation of #218 

Note that the method name is `Bloq.rough_decompose()` but I will likely change it to `bloq_counts`. You're expected to "canonicalize" your bloqs by substituting in attributes that don't matter for resource counting with sympy symbols. There's a brief demo in the included notebook. 