### PR TITLE
Update cirq version and use newly added capabilities to Cirq simulators supporting ancilla allocations

### DIFF
--- a/cirq_qubitization/cirq_algos/prepare_uniform_superposition_test.py
+++ b/cirq_qubitization/cirq_algos/prepare_uniform_superposition_test.py
@@ -13,9 +13,8 @@ def test_prepare_uniform_superposition(n, num_controls):
     control, target = (all_qubits[:num_controls], all_qubits[num_controls:])
     turn_on_controls = [cirq.X(c) for c in control]
     prepare_uniform_op = gate.on(*control, *target)
-    circuit = cirq.Circuit(turn_on_controls, cirq.decompose_once(prepare_uniform_op))
-    qubit_order = cirq.QubitOrder.explicit(all_qubits, fallback=cirq.QubitOrder.DEFAULT)
-    result = cirq.Simulator(dtype=np.complex128).simulate(circuit, qubit_order=qubit_order)
+    circuit = cirq.Circuit(turn_on_controls, prepare_uniform_op)
+    result = cirq.Simulator(dtype=np.complex128).simulate(circuit, qubit_order=all_qubits)
     final_target_state = cirq.sub_state_vector(
         result.final_state_vector,
         keep_indices=list(range(num_controls, num_controls + len(target))),

--- a/cirq_qubitization/cirq_algos/unary_iteration_test.py
+++ b/cirq_qubitization/cirq_algos/unary_iteration_test.py
@@ -52,17 +52,17 @@ def test_unary_iteration(selection_bitsize, target_bitsize, control_bitsize):
     for n in range(target_bitsize):
 
         # Initial qubit values
-        qubit_vals = {q: 0 for q in g.all_qubits}
+        qubit_vals = {q: 0 for q in g.operation.qubits}
         # All controls 'on' to activate circuit
         qubit_vals |= {c: 1 for c in g.quregs['control']}
         # Set selection according to `n`
         qubit_vals |= zip(g.quregs['selection'], iter_bits(n, selection_bitsize))
 
-        initial_state = [qubit_vals[x] for x in g.all_qubits]
+        initial_state = [qubit_vals[x] for x in g.operation.qubits]
         qubit_vals[g.quregs['target'][-(n + 1)]] = 1
-        final_state = [qubit_vals[x] for x in g.all_qubits]
+        final_state = [qubit_vals[x] for x in g.operation.qubits]
         cq_testing.assert_circuit_inp_out_cirqsim(
-            g.decomposed_circuit, g.all_qubits, initial_state, final_state
+            g.circuit, g.operation.qubits, initial_state, final_state
         )
 
 
@@ -112,19 +112,19 @@ def test_multi_dimensional_unary_iteration(target_shape: Tuple[int, int, int]):
     max_i, max_j, max_k = target_shape
     i_len, j_len, k_len = tuple(reg.bitsize for reg in gate.selection_registers)
     for i, j, k in itertools.product(range(max_i), range(max_j), range(max_k)):
-        qubit_vals = {x: 0 for x in g.all_qubits}
+        qubit_vals = {x: 0 for x in g.operation.qubits}
         # Initialize selection bits appropriately:
         qubit_vals.update(zip(g.quregs['i'], iter_bits(i, i_len)))
         qubit_vals.update(zip(g.quregs['j'], iter_bits(j, j_len)))
         qubit_vals.update(zip(g.quregs['k'], iter_bits(k, k_len)))
         # Construct initial state
-        initial_state = [qubit_vals[x] for x in g.all_qubits]
+        initial_state = [qubit_vals[x] for x in g.operation.qubits]
         # Build correct statevector with selection_integer bit flipped in the target register:
         for reg_name, idx in zip(['t1', 't2', 't3'], [i, j, k]):
             qubit_vals[g.quregs[reg_name][idx]] = 1
-        final_state = [qubit_vals[x] for x in g.all_qubits]
+        final_state = [qubit_vals[x] for x in g.operation.qubits]
         cq_testing.assert_circuit_inp_out_cirqsim(
-            g.decomposed_circuit, g.all_qubits, initial_state, final_state
+            g.circuit, g.operation.qubits, initial_state, final_state
         )
 
 

--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -3,8 +3,8 @@ pyscf
 openfermion
 # cirq-google as pinned to make sure pip-compile picks up the correct cirq-google version
 # due to a transitive dependency via fqe and openfermion. cirq-google is not a "real" requirement.
-cirq-google==1.2.0.dev20230606042656
-cirq-core==1.2.0.dev20230606042656
+cirq-google==1.2.0.dev20230607180358
+cirq-core==1.2.0.dev20230607180358
 sphinx
 pydot
 

--- a/dev_tools/requirements/dev.env.txt
+++ b/dev_tools/requirements/dev.env.txt
@@ -55,13 +55,13 @@ cffi==1.15.1
     # via argon2-cffi-bindings
 charset-normalizer==3.1.0
     # via requests
-cirq-core==1.2.0.dev20230606042656
+cirq-core==1.2.0.dev20230607180358
     # via
     #   -r deps/runtime.txt
     #   cirq-google
     #   fqe
     #   openfermion
-cirq-google==1.2.0.dev20230606042656
+cirq-google==1.2.0.dev20230607180358
     # via
     #   -r deps/runtime.txt
     #   fqe

--- a/dev_tools/requirements/format.env.txt
+++ b/dev_tools/requirements/format.env.txt
@@ -49,13 +49,13 @@ cffi==1.15.1
     # via argon2-cffi-bindings
 charset-normalizer==3.1.0
     # via requests
-cirq-core==1.2.0.dev20230606042656
+cirq-core==1.2.0.dev20230607180358
     # via
     #   -r deps/runtime.txt
     #   cirq-google
     #   fqe
     #   openfermion
-cirq-google==1.2.0.dev20230606042656
+cirq-google==1.2.0.dev20230607180358
     # via
     #   -r deps/runtime.txt
     #   fqe

--- a/dev_tools/requirements/pylint.env.txt
+++ b/dev_tools/requirements/pylint.env.txt
@@ -47,13 +47,13 @@ cffi==1.15.1
     # via argon2-cffi-bindings
 charset-normalizer==3.1.0
     # via requests
-cirq-core==1.2.0.dev20230606042656
+cirq-core==1.2.0.dev20230607180358
     # via
     #   -r deps/runtime.txt
     #   cirq-google
     #   fqe
     #   openfermion
-cirq-google==1.2.0.dev20230606042656
+cirq-google==1.2.0.dev20230607180358
     # via
     #   -r deps/runtime.txt
     #   fqe

--- a/dev_tools/requirements/pytest.env.txt
+++ b/dev_tools/requirements/pytest.env.txt
@@ -45,13 +45,13 @@ cffi==1.15.1
     # via argon2-cffi-bindings
 charset-normalizer==3.1.0
     # via requests
-cirq-core==1.2.0.dev20230606042656
+cirq-core==1.2.0.dev20230607180358
     # via
     #   -r deps/runtime.txt
     #   cirq-google
     #   fqe
     #   openfermion
-cirq-google==1.2.0.dev20230606042656
+cirq-google==1.2.0.dev20230607180358
     # via
     #   -r deps/runtime.txt
     #   fqe


### PR DESCRIPTION
Cirq simulators now support ancilla allocations (see updates on https://github.com/quantumlib/Cirq/issues/6081) and this PR updates the Cirq version and updates a few tests to demonstrate that our tests pass as expected without having to explicitly decompose circuits to the point where no further ancillas are allocated as part of decompose.


However, I've updated only two tests as a proof of concept for now. The blocker is that Simulators right now don't support custom qubit allocation strategies (like the greedy strategy with maximum reuse) and thus ends up allocating a lot more qubits than we'd like (especially for unary iteration, where an aggressive reuse is possible and required)  and thus are too slow. 

I'll update rest of the tests once the simulators performance is improved.  cc @NoureldinYosri 