### PR TITLE
Fix mypy typing issues for Cirq-FT launch

### DIFF
--- a/cirq_qubitization/cirq_algos/apply_gate_to_lth_target.py
+++ b/cirq_qubitization/cirq_algos/apply_gate_to_lth_target.py
@@ -29,12 +29,12 @@ class ApplyGateToLthQubit(UnaryIterationGate):
         control_regs: Control registers for constructing a controlled version of the gate.
     """
     selection_regs: SelectionRegisters
-    nth_gate: Callable[[int, ...], cirq.Gate]
+    nth_gate: Callable[..., cirq.Gate]
     control_regs: Registers = Registers.build(control=1)
 
     @classmethod
     def make_on(
-        cls, *, nth_gate: Callable[[int, ...], cirq.Gate], **quregs: Sequence[cirq.Qid]
+        cls, *, nth_gate: Callable[..., cirq.Gate], **quregs: Sequence[cirq.Qid]
     ) -> cirq.Operation:
         """Helper constructor to automatically deduce bitsize attributes."""
         return cls(
@@ -62,7 +62,7 @@ class ApplyGateToLthQubit(UnaryIterationGate):
             wire_symbols += [str(self.nth_gate(*it))]
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
-    def nth_operation(
+    def nth_operation(  # type: ignore[override]
         self,
         context: cirq.DecompositionContext,
         control: cirq.Qid,

--- a/cirq_qubitization/cirq_algos/arithmetic_gates.py
+++ b/cirq_qubitization/cirq_algos/arithmetic_gates.py
@@ -1,7 +1,7 @@
 from typing import Iterable, Optional, Sequence, Tuple, Union
 
+import attr
 import cirq
-from attrs import field, frozen
 
 from cirq_qubitization import bit_tools, t_complexity_protocol
 from cirq_qubitization.cirq_algos.and_gate import And
@@ -18,10 +18,11 @@ class LessThanGate(cirq.ArithmeticGate):
     def registers(self) -> Sequence[Union[int, Sequence[int]]]:
         return self._input_register, self._val, self._target_register
 
-    def with_registers(self, *new_registers: Union[int, Sequence[int]]) -> "LessThanGate":
-        return LessThanGate(new_registers[0], new_registers[1])
+    def with_registers(self, *new_registers) -> "LessThanGate":
+        return LessThanGate(*new_registers)
 
-    def apply(self, input_val, max_val, target_register_val) -> Union[int, Iterable[int]]:
+    def apply(self, *register_vals: int) -> Union[int, Iterable[int]]:
+        input_val, max_val, target_register_val = register_vals
         return input_val, max_val, target_register_val ^ (input_val < max_val)
 
     def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
@@ -113,7 +114,11 @@ class LessThanGate(cirq.ArithmeticGate):
         )
 
 
-@frozen
+def _to_tuple(x: Sequence[int]) -> Tuple[int, ...]:
+    return tuple(x)
+
+
+@attr.frozen(auto_attribs=True)
 class AddMod(cirq.ArithmeticGate):
     """Applies U_{M}_{add}|x> = |(x + add) % M> if x < M else |x>.
 
@@ -130,9 +135,9 @@ class AddMod(cirq.ArithmeticGate):
     """
 
     bitsize: int
-    mod: int = field()
+    mod: int = attr.field()
     add_val: int = 1
-    cv: Tuple[int, ...] = field(converter=tuple, default=())
+    cv: Tuple[int, ...] = attr.field(converter=_to_tuple, default=())
 
     @mod.validator
     def _validate_mod(self, attribute, value):
@@ -184,12 +189,11 @@ class LessThanEqualGate(cirq.ArithmeticGate):
     def registers(self) -> Sequence[Union[int, Sequence[int]]]:
         return (self._first_input_register, self._second_input_register, self._target_register)
 
-    def with_registers(self, *new_registers: Union[int, Sequence[int]]) -> "LessThanEqualGate":
-        return LessThanEqualGate(new_registers[0], new_registers[1])
+    def with_registers(self, *new_registers) -> "LessThanEqualGate":
+        return LessThanEqualGate(*new_registers)
 
-    def apply(
-        self, first_input_val, second_input_val, target_register_val
-    ) -> Union[int, int, Iterable[int]]:
+    def apply(self, *register_vals: int) -> Union[int, int, Iterable[int]]:
+        first_input_val, second_input_val, target_register_val = register_vals
         return (
             first_input_val,
             second_input_val,
@@ -252,10 +256,11 @@ class ContiguousRegisterGate(cirq.ArithmeticGate):
     def registers(self) -> Sequence[Union[int, Sequence[int]]]:
         return (self._p_register, self._q_register, self._target_register)
 
-    def with_registers(self, *new_registers: Union[int, Sequence[int]]) -> 'ContiguousRegisterGate':
+    def with_registers(self, *new_registers) -> 'ContiguousRegisterGate':
         return ContiguousRegisterGate(len(new_registers[0]), len(new_registers[-1]))
 
-    def apply(self, p: int, q: int, target: int) -> Union[int, Iterable[int]]:
+    def apply(self, *register_vals: int) -> Union[int, Iterable[int]]:
+        p, q, target = register_vals
         return p, q, target ^ ((p * (p - 1)) // 2 + q)
 
     def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
@@ -291,10 +296,11 @@ class AdditionGate(cirq.ArithmeticGate):
     def registers(self) -> Sequence[Union[int, Sequence[int]]]:
         return (self._input_register, self._output_register)
 
-    def with_registers(self, *new_registers: Union[int, Sequence[int]]) -> 'AdditionGate':
+    def with_registers(self, *new_registers) -> 'AdditionGate':
         return AdditionGate(len(new_registers[0]))
 
-    def apply(self, p: int, q: int) -> Union[int, Iterable[int]]:
+    def apply(self, *register_values: int) -> Union[int, Iterable[int]]:
+        p, q = register_values
         return p, p + q
 
     def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:

--- a/cirq_qubitization/cirq_algos/multi_control_multi_target_pauli.py
+++ b/cirq_qubitization/cirq_algos/multi_control_multi_target_pauli.py
@@ -27,25 +27,27 @@ class MultiTargetCNOT(GateWithRegisters):
         return Registers.build(control=1, targets=self._num_targets)
 
     def decompose_from_registers(
-        self,
-        context: cirq.DecompositionContext,
-        control: Sequence[cirq.Qid],
-        targets: Sequence[cirq.Qid],
+        self, *, context: cirq.DecompositionContext, **quregs: Sequence[cirq.Qid]
     ):
+        control, targets = quregs['control'], quregs['targets']
+
         def cnots_for_depth_i(i: int, q: Sequence[cirq.Qid]) -> cirq.OP_TREE:
             for c, t in zip(q[: 2**i], q[2**i : min(len(q), 2 ** (i + 1))]):
                 yield cirq.CNOT(c, t)
 
-        (control,) = control
         depth = len(targets).bit_length()
         for i in range(depth):
             yield cirq.Moment(cnots_for_depth_i(depth - i - 1, targets))
-        yield cirq.CNOT(control, targets[0])
+        yield cirq.CNOT(*control, targets[0])
         for i in range(depth):
             yield cirq.Moment(cnots_for_depth_i(i, targets))
 
     def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
         return cirq.CircuitDiagramInfo(wire_symbols=["@"] + ["X"] * self._num_targets)
+
+
+def _to_tuple(x: Sequence[int]) -> Tuple[int, ...]:
+    return tuple(x)
 
 
 @frozen
@@ -67,7 +69,7 @@ class MultiControlPauli(GateWithRegisters):
         CLEAN_ANCILLA = 1
         DIRTY_ANCILLA = 2
 
-    cvs: Tuple[int, ...] = field(converter=tuple)
+    cvs: Tuple[int, ...] = field(converter=_to_tuple)
     target_gate: cirq.Pauli = cirq.X
     mode: DecomposeMode = DecomposeMode.CLEAN_ANCILLA
 
@@ -80,7 +82,7 @@ class MultiControlPauli(GateWithRegisters):
         context: cirq.DecompositionContext,
         controls: Sequence[cirq.Qid],
         target: Sequence[cirq.Qid],
-    ):
+    ) -> cirq.ops.op_tree.OpTree:
         pre_post_x = [cirq.X(controls[i]) for i, b in enumerate(self.cvs) if not b]
         if len(controls) == 2:
             return [pre_post_x, self.target_gate(*target).controlled_by(*controls), pre_post_x]
@@ -101,7 +103,7 @@ class MultiControlPauli(GateWithRegisters):
         context: cirq.DecompositionContext,
         controls: Sequence[cirq.Qid],
         target: Sequence[cirq.Qid],
-    ):
+    ) -> cirq.ops.op_tree.OpTree:
         qm = context.qubit_manager
         and_ancilla, and_target = qm.qalloc(len(self.cvs) - 2), qm.qalloc(1)
         yield and_gate.And(self.cvs).on_registers(
@@ -113,11 +115,14 @@ class MultiControlPauli(GateWithRegisters):
         )
         qm.qfree(and_ancilla + and_target)
 
-    def decompose_from_registers(self, **kwargs):
+    def decompose_from_registers(
+        self, *, context: cirq.DecompositionContext, **quregs: Sequence['cirq.Qid']
+    ) -> cirq.OP_TREE:
+        controls, target = quregs['controls'], quregs['target']
         if self.mode == self.DecomposeMode.CLEAN_ANCILLA:
-            yield from self._decompose_clean(**kwargs)
+            yield from self._decompose_clean(context=context, controls=controls, target=target)
         elif self.mode == self.DecomposeMode.DIRTY_ANCILLA:
-            yield from self._decompose_dirty(**kwargs)
+            yield from self._decompose_dirty(context=context, controls=controls, target=target)
         else:
             raise ValueError(f"Unsupported mode: {self.mode}")
 

--- a/cirq_qubitization/cirq_algos/prepare_uniform_superposition.py
+++ b/cirq_qubitization/cirq_algos/prepare_uniform_superposition.py
@@ -49,11 +49,9 @@ class PrepareUniformSuperposition(cirq_infra.GateWithRegisters):
         return cirq.CircuitDiagramInfo(wire_symbols=control_symbols + target_symbols)
 
     def decompose_from_registers(
-        self,
-        context: cirq.DecompositionContext,
-        controls: Sequence[cirq.Qid],
-        target: Sequence[cirq.Qid],
+        self, *, context: cirq.DecompositionContext, **quregs: Sequence[cirq.Qid]
     ) -> cirq.OP_TREE:
+        controls, target = quregs['controls'], quregs['target']
         # Find K and L as per https://arxiv.org/abs/1805.03662 Fig 12.
         n, k = self.n, 0
         while n > 1 and n % 2 == 0:

--- a/cirq_qubitization/cirq_algos/programmable_rotation_gate_array.py
+++ b/cirq_qubitization/cirq_algos/programmable_rotation_gate_array.py
@@ -118,13 +118,12 @@ class ProgrammableRotationGateArrayBase(GateWithRegisters):
         )
 
     def decompose_from_registers(
-        self,
-        context: cirq.DecompositionContext,
-        selection: Sequence[cirq.Qid],
-        kappa_load_target: Sequence[cirq.Qid],
-        rotations_target: Sequence[cirq.Qid],
-        **interleaved_unitary_target: Sequence[cirq.Qid],
+        self, *, context: cirq.DecompositionContext, **quregs: Sequence[cirq.Qid]
     ) -> cirq.OP_TREE:
+        selection, kappa_load_target = quregs.pop('selection'), quregs.pop('kappa_load_target')
+        rotations_target = quregs.pop('rotations_target')
+        interleaved_unitary_target = quregs
+
         # 1. Find a convenient way to process batches of size kappa.
         num_bits = sum(max(thetas).bit_length() for thetas in self.angles)
         iteration_length = self.selection_registers[0].iteration_length

--- a/cirq_qubitization/cirq_algos/qubitization_walk_operator.py
+++ b/cirq_qubitization/cirq_algos/qubitization_walk_operator.py
@@ -89,20 +89,26 @@ class QubitizationWalkOperator(cirq_infra.GateWithRegisters):
 
     def controlled(
         self,
-        num_controls: int = None,
-        control_values: Sequence[Union[int, Collection[int]]] = None,
+        num_controls: Optional[int] = None,
+        control_values: Optional[
+            Union[cirq.ops.AbstractControlValues, Sequence[Union[int, Collection[int]]]]
+        ] = None,
         control_qid_shape: Optional[Tuple[int, ...]] = None,
     ) -> 'QubitizationWalkOperator':
         if num_controls is None:
             num_controls = 1
         if control_values is None:
             control_values = [1] * num_controls
-        if len(control_values) == 1 and self.control_val is None:
+        if (
+            isinstance(control_values, Sequence)
+            and isinstance(control_values[0], int)
+            and len(control_values) == 1
+            and self.control_val is None
+        ):
+            c_select = self.select.controlled(control_values=control_values)
+            assert isinstance(c_select, select_and_prepare.SelectOracle)
             return QubitizationWalkOperator(
-                self.select.controlled(control_values=control_values),
-                self.prepare,
-                control_val=control_values[-1],
-                power=self.power,
+                c_select, self.prepare, control_val=control_values[0], power=self.power
             )
         raise NotImplementedError(f'Cannot create a controlled version of {self}')
 

--- a/cirq_qubitization/cirq_algos/reflection_using_prepare.py
+++ b/cirq_qubitization/cirq_algos/reflection_using_prepare.py
@@ -68,7 +68,7 @@ class ReflectionUsingPrepare(cirq_infra.GateWithRegisters):
             **state_prep_selection_regs, **state_prep_ancilla
         )
         # 1. PREPARE†
-        yield prepare_op**-1
+        yield cirq.inverse(prepare_op)
         # 2. MultiControlled Z, controlled on |000..00> state.
         phase_control = self.selection_registers.merge_qubits(**state_prep_selection_regs)
         yield cirq.X(phase_target) if not self.control_val else []
@@ -91,14 +91,23 @@ class ReflectionUsingPrepare(cirq_infra.GateWithRegisters):
 
     def controlled(
         self,
-        num_controls: int = None,
-        control_values: Sequence[Union[int, Collection[int]]] = None,
+        num_controls: Optional[int] = None,
+        control_values: Optional[
+            Union[cirq.ops.AbstractControlValues, Sequence[Union[int, Collection[int]]]]
+        ] = None,
         control_qid_shape: Optional[Tuple[int, ...]] = None,
     ) -> 'ReflectionUsingPrepare':
         if num_controls is None:
             num_controls = 1
         if control_values is None:
             control_values = [1] * num_controls
-        if len(control_values) == 1 and self.control_val is None:
-            return ReflectionUsingPrepare(self.prepare_gate, control_val=control_values[-1])
-        raise NotImplementedError(f'Cannot create a controlled version of {self}')
+        if (
+            isinstance(control_values, Sequence)
+            and isinstance(control_values[0], int)
+            and len(control_values) == 1
+            and self.control_val is None
+        ):
+            return ReflectionUsingPrepare(self.prepare_gate, control_val=control_values[0])
+        raise NotImplementedError(
+            f'Cannot create a controlled version of {self} with {control_values=}.'
+        )

--- a/cirq_qubitization/cirq_algos/selected_majorana_fermion.py
+++ b/cirq_qubitization/cirq_algos/selected_majorana_fermion.py
@@ -70,7 +70,7 @@ class SelectedMajoranaFermionGate(unary_iteration.UnaryIterationGate):
         wire_symbols += [f"Z{self.target_gate}"] * self.target_registers.bitsize
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
-    def nth_operation(
+    def nth_operation(  # type: ignore[override]
         self,
         context: cirq.DecompositionContext,
         control: cirq.Qid,

--- a/cirq_qubitization/cirq_algos/state_preparation.py
+++ b/cirq_qubitization/cirq_algos/state_preparation.py
@@ -128,14 +128,10 @@ class StatePreparationAliasSampling(PrepareOracle):
         )
 
     def decompose_from_registers(
-        self,
-        context: cirq.DecompositionContext,
-        selection: Sequence[cirq.Qid],
-        sigma_mu: Sequence[cirq.Qid],
-        alt: Sequence[cirq.Qid],
-        keep: Sequence[cirq.Qid],
-        less_than_equal: Sequence[cirq.Qid],
+        self, *, context: cirq.DecompositionContext, **quregs: Sequence[cirq.Qid]
     ) -> cirq.OP_TREE:
+        selection, less_than_equal = quregs['selection'], quregs['less_than_equal']
+        sigma_mu, alt, keep = quregs['sigma_mu'], quregs['alt'], quregs['keep']
         N = self.selection_registers[0].iteration_length
         yield PrepareUniformSuperposition(N).on(*selection)
         yield cirq.H.on_each(*sigma_mu)

--- a/cirq_qubitization/cirq_infra/decompose_protocol.py
+++ b/cirq_qubitization/cirq_infra/decompose_protocol.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence
+from typing import Any, FrozenSet, Sequence
 
 import cirq
 from cirq.protocols.decompose_protocol import DecomposeResult
@@ -40,7 +40,7 @@ def _try_decompose_from_known_decompositions(
     qubits = cirq.LineQid.for_gate(val) if isinstance(val, cirq.Gate) else val.qubits
     known_decompositions = [(_FREDKIN_GATESET, _fredkin)]
 
-    classical_controls = ()
+    classical_controls: FrozenSet[cirq.Condition] = frozenset()
     if isinstance(val, cirq.ClassicallyControlledOperation):
         classical_controls = val.classical_controls
         val = val.without_classical_controls()

--- a/cirq_qubitization/cirq_infra/qubit_management_transformers.py
+++ b/cirq_qubitization/cirq_infra/qubit_management_transformers.py
@@ -74,7 +74,6 @@ def map_clean_and_borrowable_qubits(
     """
     if qm is None:
         qm = qubit_manager.GreedyQubitManager(prefix="ancilla")
-    assert isinstance(qm, cirq.QubitManager)
 
     allocated_qubits = {q for q in circuit.all_qubits() if _is_temp(q)}
     qubits_lifespan = _get_qubit_mapping_first_and_last_moment(circuit)
@@ -88,6 +87,7 @@ def map_clean_and_borrowable_qubits(
 
     def map_func(op: cirq.Operation, idx: int) -> cirq.OP_TREE:
         nonlocal last_op_idx, to_free
+        assert isinstance(qm, cirq.QubitManager)
 
         for q in sorted(to_free):
             is_managed_qubit = allocated_map[q] not in all_qubits

--- a/cirq_qubitization/generic_select.py
+++ b/cirq_qubitization/generic_select.py
@@ -1,16 +1,17 @@
 """Gates for applying generic selected unitaries."""
 from functools import cached_property
-from typing import Collection, List, Optional, Sequence, Tuple, Union
+from typing import Collection, Optional, Sequence, Tuple, Union
 
 import cirq
 import numpy as np
 
+from cirq_qubitization.cirq_algos.select_and_prepare import SelectOracle
 from cirq_qubitization.cirq_algos.unary_iteration import UnaryIterationGate
 from cirq_qubitization.cirq_infra.gate_with_registers import Register, Registers, SelectionRegisters
 
 
 @cirq.value_equality()
-class GenericSelect(UnaryIterationGate):
+class GenericSelect(SelectOracle, UnaryIterationGate):
     r"""A SELECT gate for selecting and applying operators from an array of `PauliString`s.
 
     $$
@@ -34,7 +35,7 @@ class GenericSelect(UnaryIterationGate):
         self,
         selection_bitsize: int,
         target_bitsize: int,
-        select_unitaries: List[cirq.DensePauliString],
+        select_unitaries: Sequence[cirq.DensePauliString],
         *,
         control_val: Optional[int] = None,
     ):
@@ -56,7 +57,7 @@ class GenericSelect(UnaryIterationGate):
         return Registers(registers)
 
     @cached_property
-    def selection_registers(self) -> Registers:
+    def selection_registers(self) -> SelectionRegisters:
         return SelectionRegisters.build(
             selection=(self._selection_bitsize, len(self.select_unitaries))
         )
@@ -68,11 +69,11 @@ class GenericSelect(UnaryIterationGate):
     def decompose_from_registers(self, context, **qubit_regs: Sequence[cirq.Qid]) -> cirq.OP_TREE:
         if self._control_val == 0:
             yield cirq.X(*qubit_regs['control'])
-        yield from super().decompose_from_registers(context, **qubit_regs)
+        yield super().decompose_from_registers(context=context, **qubit_regs)
         if self._control_val == 0:
             yield cirq.X(*qubit_regs['control'])
 
-    def nth_operation(
+    def nth_operation(  # type: ignore[override]
         self,
         context: cirq.DecompositionContext,
         selection: int,
@@ -91,26 +92,35 @@ class GenericSelect(UnaryIterationGate):
         if selection < 0 or selection >= 2**self._selection_bitsize:
             raise ValueError("n is outside selection length range")
         ps = self.select_unitaries[selection].on(*target)
-        return ps.with_coefficient(np.sign(ps.coefficient.real)).controlled_by(control)
+        return ps.with_coefficient(np.sign(complex(ps.coefficient).real)).controlled_by(control)
 
     def controlled(
         self,
-        num_controls: int = None,
-        control_values: Sequence[Union[int, Collection[int]]] = None,
+        num_controls: Optional[int] = None,
+        control_values: Optional[
+            Union[cirq.ops.AbstractControlValues, Sequence[Union[int, Collection[int]]]]
+        ] = None,
         control_qid_shape: Optional[Tuple[int, ...]] = None,
     ) -> 'GenericSelect':
         if num_controls is None:
             num_controls = 1
         if control_values is None:
             control_values = [1] * num_controls
-        if len(control_values) == 1 and self._control_val is None:
+        if (
+            isinstance(control_values, Sequence)
+            and isinstance(control_values[0], int)
+            and len(control_values) == 1
+            and self._control_val is None
+        ):
             return GenericSelect(
                 self._selection_bitsize,
                 self._target_bitsize,
                 self.select_unitaries,
                 control_val=control_values[0],
             )
-        raise NotImplementedError(f'Cannot create a controlled version of {self}')
+        raise NotImplementedError(
+            f'Cannot create a controlled version of {self} with {control_values=}.'
+        )
 
     def _value_equality_values_(self):
         return (
@@ -119,6 +129,3 @@ class GenericSelect(UnaryIterationGate):
             self._target_bitsize,
             self._control_val,
         )
-
-
-GenericSelect.__hash__ = cirq._compat.cached_method(GenericSelect.__hash__)

--- a/cirq_qubitization/t_complexity_protocol.py
+++ b/cirq_qubitization/t_complexity_protocol.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Literal, Optional, overload
 
 import cirq
 from attrs import frozen
@@ -149,6 +149,16 @@ def _t_complexity(
     if h is not None:
         cache[h] = ret if ret is not None else TComplexity()
     return ret
+
+
+@overload
+def t_complexity(stc: Any, fail_quietly: Literal[False] = False) -> TComplexity:
+    ...
+
+
+@overload
+def t_complexity(stc: Any, fail_quietly: bool) -> Optional[TComplexity]:
+    ...
 
 
 def t_complexity(stc: Any, fail_quietly: bool = False) -> Optional[TComplexity]:


### PR DESCRIPTION
This PR fixes all the mypy typing errors related to `cirq_algo/` and `cirq_infra/`. This unblocks the Cirq-FT launch and we are not ready to move things over to the Cirq land! 
