### PR TITLE
Fix flaky failure in ref-factoring.ipynb

### DIFF
--- a/qualtran/bloq_algos/factoring/ref-factoring.ipynb
+++ b/qualtran/bloq_algos/factoring/ref-factoring.ipynb
@@ -133,7 +133,7 @@
    "outputs": [],
    "source": [
     "# We can quickly count up the number of T-gates required to factor a number\n",
-    "ModExp.make_for_shor(17*19).t_complexity()"
+    "ModExp.make_for_shor(17*19, g=8).t_complexity()"
    ]
   },
   {
@@ -157,7 +157,7 @@
     "g, N = sympy.symbols('g N')\n",
     "bloq = ModExp.make_for_shor(big_n=N, g=g)\n",
     "for reg in bloq.registers:\n",
-    "    display(reg.name, reg.bitsize)\n"
+    "    display(reg.name, reg.bitsize)"
    ]
   },
   {


### PR DESCRIPTION
If you use `make_for_shor` it will chose a random
base for the exponent. Sometimes this isn't invertible under the modulus with such small numbers causing this to fail. Putting in a specific base `g` removes the random failures.

Flaky was introduced in #291 