### PR TITLE
Use Cirq-FT's multi-dimensional registers directly in BloqAsCirqGate

### DIFF
--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -907,8 +907,7 @@ class BloqBuilder:
                 unpacking. In this final case, the ordering is according to `bloq.signature`
                 and irrespective of the order of `**in_soqs`.
         """
-        binst = BloqInstance(bloq, i=self._new_binst_i())
-        outs = tuple(soq for _, soq in self._add_binst(binst, in_soqs=in_soqs))
+        outs = self.add_t(bloq, **in_soqs)
         if len(outs) == 0:
             return None
         if len(outs) == 1:

--- a/qualtran/bloqs/swap_network_cirq_test.py
+++ b/qualtran/bloqs/swap_network_cirq_test.py
@@ -39,12 +39,11 @@ def test_swap_with_zero_gate(selection_bitsize, target_bitsize, n_target_registe
     # Allocate selection and target qubits.
     all_qubits = cirq.LineQubit.range(cirq.num_qubits(gate))
     selection = all_qubits[:selection_bitsize]
-    targets = {
-        f'targets_{i}': all_qubits[st : st + target_bitsize]
-        for i, st in enumerate(range(selection_bitsize, len(all_qubits), target_bitsize))
-    }
+    targets = np.asarray(all_qubits[selection_bitsize:]).reshape(
+        (n_target_registers, target_bitsize)
+    )
     # Create a circuit.
-    circuit = cirq.Circuit(gate.on_registers(selection=selection, **targets))
+    circuit = cirq.Circuit(gate.on_registers(selection=selection, targets=targets))
 
     # Load data[i] in i'th target register; where each register is of size target_bitsize
     data = [random.randint(0, 2**target_bitsize - 1) for _ in range(n_target_registers)]

--- a/qualtran/cirq_interop/_cirq_interop.py
+++ b/qualtran/cirq_interop/_cirq_interop.py
@@ -461,7 +461,8 @@ class BloqAsCirqGate(cirq_ft.GateWithRegisters):
             symbs = reg_to_wires(reg)
             assert len(symbs) == reg.total_bits()
             wire_symbols.extend(symbs)
-        wire_symbols[0] = self._bloq.pretty_name()
+        if self._reg_to_wires is None:
+            wire_symbols[0] = self._bloq.pretty_name()
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
     def __eq__(self, other):


### PR DESCRIPTION
This gets rid of the conversion to/from a flat list of API when wrapping a Bloq as a Cirq gate. Part of a larger series of PRs to improve Cirq interop. 



cc @mpharrigan 