### PR TITLE
Wrap SelectSwapQROM as a bloq.

### DIFF
--- a/qualtran/bloqs/qrom.py
+++ b/qualtran/bloqs/qrom.py
@@ -12,11 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Dict, Sequence, Tuple
+from typing import Dict, Optional, Sequence, Tuple
 
 import cirq
+import numpy as np
 from attrs import frozen
 from cirq_ft import QROM as CirqQROM
+from cirq_ft import SelectSwapQROM as CirqSelectSwapQROM
+from cirq_ft.algos.select_swap_qrom import find_optimal_log_block_size
 from numpy.typing import NDArray
 
 from qualtran import Bloq, CompositeBloq, Register, Signature
@@ -85,3 +88,107 @@ class QROM(Bloq):
 
     def __ne__(self, other) -> bool:
         return self.signature != other.signature
+
+
+@frozen
+class SelectSwapQROM(Bloq):
+    """Gate to load data[l] in the target register when the selection stores an index l.
+
+    In contrast to the QROM bloq, SelectSwapQROM only accepts one-dimensional
+    data. See cirq_ft.select_swap_qrom for futher implmentation details.
+
+    The final T-complexity of `SelectSwapQROM` is `O(B * b + N / B)`
+    T-gates; where `B` is the block-size with an optimal value of `O(sqrt(N /
+    b))`.
+
+    This improvement in T-complexity is achieved at the cost of using an additional `O(B * b)`
+    ancilla qubits, with a nice property that these additional ancillas can be `dirty`; i.e.
+    they don't need to start in the |0> state and thus can be borrowed from other parts of the
+    algorithm. The state of these dirty ancillas would be unaffected after the operation has
+    finished.
+
+    For more details, see the reference below:
+
+    References:
+        [Trading T-gates for dirty qubits in state preparation and unitary synthesis]
+        (https://arxiv.org/abs/1812.00954).  Low, Kliuchnikov, Schaeffer. 2018.
+    """
+
+    data: Tuple[Tuple[int, ...], ...]
+    target_bitsizes: Sequence[int]
+    selection_bitsize: int
+    block_size: int
+    num_blocks: int
+    num_sequences: int
+
+    @classmethod
+    def build(
+        cls,
+        *data: Sequence[int],
+        target_bitsizes: Optional[Sequence[int]] = None,
+        block_size: Optional[int] = None,
+    ) -> 'SelectSwapQROM':
+        """Factory method to build SelectSwapQROM instance.
+
+        For a single data sequence of length `N`, maximum target bitsize `b` and block size `B`;
+        SelectSwapQROM requires:
+            - Selection register & ancilla of size `logN` for QROM data load.
+            - 1 clean target register of size `b`.
+            - `B` dirty target registers, each of size `b`.
+
+        Similarly, to load `M` such data sequences, `SelectSwapQROM` requires:
+            - Selection register & ancilla of size `logN` for QROM data load.
+            - 1 clean target register of size `sum(target_bitsizes)`.
+            - `B` dirty target registers, each of size `sum(target_bitsizes)`.
+
+        Args:
+            data: Sequence of integers to load in the target register. If more than one sequence
+                is provided, each sequence must be of the same length.
+            target_bitsizes: Sequence of integers describing the size of target register for each
+                data sequence to load. Defaults to `max(data[i]).bit_length()` for each i.
+            block_size(B): Load batches of `B` data elements in each iteration of traditional QROM
+                (N/B iterations required). Complexity of SelectSwap QROAM scales as
+                `O(B * b + N / B)`, where `B` is the block_size. Defaults to optimal value of
+                 `O(sqrt(N / b))`.
+
+        Raises:
+            ValueError: If all target data sequences to load do not have the same length.
+        """
+        # Validate input.
+        if len(set(len(d) for d in data)) != 1:
+            raise ValueError("All data sequences to load must be of equal length.")
+        if target_bitsizes is None:
+            target_bitsizes = [max(d).bit_length() for d in data]
+        assert len(target_bitsizes) == len(data)
+        assert all(t >= max(d).bit_length() for t, d in zip(target_bitsizes, data))
+        num_sequences = len(data)
+        target_bitsizes = target_bitsizes
+        iteration_length = len(data[0])
+        if block_size is None:
+            # Figure out optimal value of block_size
+            block_size = 2 ** find_optimal_log_block_size(iteration_length, sum(target_bitsizes))
+        assert 0 < block_size <= iteration_length
+        block_size = block_size
+        num_blocks = int(np.ceil(iteration_length / block_size))
+        selection_q, selection_r = tuple((L - 1).bit_length() for L in [num_blocks, block_size])
+        data = tuple(tuple(d) for d in data)
+        return SelectSwapQROM(
+            data, target_bitsizes, selection_q + selection_r, block_size, num_blocks, num_sequences
+        )
+
+    @cached_property
+    def signature(self) -> Signature:
+        regs = [Register("selection", bitsize=self.selection_bitsize)]
+        regs += [Register(f"target{i}", bitsize=bs) for i, bs in enumerate(self.target_bitsizes)]
+        return Signature(regs)
+
+    def decompose_bloq(self) -> 'CompositeBloq':
+        return decompose_from_cirq_op(self)
+
+    def as_cirq_op(
+        self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
+        qrom = CirqSelectSwapQROM(
+            *self.data, target_bitsizes=tuple(self.target_bitsizes), block_size=self.block_size
+        )
+        return (qrom.on_registers(**cirq_quregs), cirq_quregs)

--- a/qualtran/bloqs/qrom_test.py
+++ b/qualtran/bloqs/qrom_test.py
@@ -15,10 +15,11 @@
 
 import numpy as np
 from cirq_ft import QROM as CirqQROM
+from cirq_ft import SelectSwapQROM as CirqSelectSwapQROM
 from cirq_ft.infra import t_complexity
 
 import qualtran.testing as qlt_testing
-from qualtran.bloqs.qrom import QROM
+from qualtran.bloqs.qrom import QROM, SelectSwapQROM
 
 
 def test_qrom_decomp():
@@ -52,3 +53,15 @@ def test_hashing():
     qrom_2 = QROM([data], selection_bitsizes=sel_bitsizes, data_bitsizes=(5,))
     assert qrom == qrom
     assert qrom_2 != qrom
+
+
+def test_select_swap_qrom_decomp():
+    qrom = SelectSwapQROM.build(*[[0, 1, 2, 3, 4]])
+    qlt_testing.assert_valid_bloq_decomposition(qrom)
+
+
+def test_select_swap_qrom_tcomplexity():
+    qrom = SelectSwapQROM.build([0, 1], [2, 3])
+    cbloq = qrom.decompose_bloq()
+    cqrom = CirqSelectSwapQROM([0, 1], [2, 3], target_bitsizes=(1, 2))
+    assert cbloq.t_complexity() == t_complexity(cqrom)


### PR DESCRIPTION
We need the SelectSwapQROM gate as well for chemistry. I just wrapped the cirq_ft gate and stole it's documentation / put the constructor logic in a factory method rather than the __init__