### PR TITLE
Bump cirq version for arithmetic #6313 and #6312.

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -1,5 +1,5 @@
-cirq-core==1.3.0.dev20230928195458
-cirq-ft==1.3.0.dev20230928195458
+cirq-core==1.3.0.dev20231010175755
+cirq-ft==1.3.0.dev20231010175755
 
 # drawing
 pydot

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -52,11 +52,11 @@ cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.0
     # via requests
-cirq-core==1.3.0.dev20230928195458
+cirq-core==1.3.0.dev20231010175755
     # via
     #   -r deps/runtime.txt
     #   cirq-ft
-cirq-ft==1.3.0.dev20230928195458
+cirq-ft==1.3.0.dev20231010175755
     # via -r deps/runtime.txt
 click==8.1.7
     # via
@@ -165,11 +165,11 @@ jsonschema-specifications==2023.7.1
     # via jsonschema
 jupyter-cache==0.6.1
     # via myst-nb
-jupyter-client==8.3.1
+jupyter-client==8.4.0
     # via
     #   ipykernel
     #   nbclient
-jupyter-core==5.3.2
+jupyter-core==5.4.0
     # via
     #   ipykernel
     #   jupyter-client
@@ -388,7 +388,7 @@ rfc3986==2.0.0
     # via twine
 rich==13.6.0
     # via twine
-rpds-py==0.10.4
+rpds-py==0.10.6
     # via
     #   jsonschema
     #   referencing

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -66,12 +66,12 @@ charset-normalizer==3.3.0
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.3.0.dev20230928195458
+cirq-core==1.3.0.dev20231010175755
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-ft
-cirq-ft==1.3.0.dev20230928195458
+cirq-ft==1.3.0.dev20231010175755
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -189,12 +189,12 @@ jupyter-cache==0.6.1
     # via
     #   -c envs/dev.env.txt
     #   myst-nb
-jupyter-client==8.3.1
+jupyter-client==8.4.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   nbclient
-jupyter-core==5.3.2
+jupyter-core==5.4.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -421,7 +421,7 @@ requests==2.31.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-rpds-py==0.10.4
+rpds-py==0.10.6
     # via
     #   -c envs/dev.env.txt
     #   jsonschema

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -43,12 +43,12 @@ cachetools==5.3.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-ft
-cirq-core==1.3.0.dev20230928195458
+cirq-core==1.3.0.dev20231010175755
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-ft
-cirq-ft==1.3.0.dev20230928195458
+cirq-ft==1.3.0.dev20231010175755
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -133,11 +133,11 @@ jsonschema-specifications==2023.7.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-client==8.3.1
+jupyter-client==8.4.0
     # via
     #   -c envs/dev.env.txt
     #   nbclient
-jupyter-core==5.3.2
+jupyter-core==5.4.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
@@ -314,7 +314,7 @@ referencing==0.30.2
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==0.10.4
+rpds-py==0.10.6
     # via
     #   -c envs/dev.env.txt
     #   jsonschema

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -39,12 +39,12 @@ cachetools==5.3.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-ft
-cirq-core==1.3.0.dev20230928195458
+cirq-core==1.3.0.dev20231010175755
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-ft
-cirq-ft==1.3.0.dev20230928195458
+cirq-ft==1.3.0.dev20231010175755
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -125,11 +125,11 @@ jsonschema-specifications==2023.7.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-client==8.3.1
+jupyter-client==8.4.0
     # via
     #   -c envs/dev.env.txt
     #   nbclient
-jupyter-core==5.3.2
+jupyter-core==5.4.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
@@ -310,7 +310,7 @@ referencing==0.30.2
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==0.10.4
+rpds-py==0.10.6
     # via
     #   -c envs/dev.env.txt
     #   jsonschema

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -35,12 +35,12 @@ cachetools==5.3.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-ft
-cirq-core==1.3.0.dev20230928195458
+cirq-core==1.3.0.dev20231010175755
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-ft
-cirq-ft==1.3.0.dev20230928195458
+cirq-ft==1.3.0.dev20231010175755
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -136,12 +136,12 @@ jsonschema-specifications==2023.7.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-client==8.3.1
+jupyter-client==8.4.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   nbclient
-jupyter-core==5.3.2
+jupyter-core==5.4.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -344,7 +344,7 @@ referencing==0.30.2
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==0.10.4
+rpds-py==0.10.6
     # via
     #   -c envs/dev.env.txt
     #   jsonschema

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -35,12 +35,12 @@ cachetools==5.3.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-ft
-cirq-core==1.3.0.dev20230928195458
+cirq-core==1.3.0.dev20231010175755
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-ft
-cirq-ft==1.3.0.dev20230928195458
+cirq-ft==1.3.0.dev20231010175755
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -113,11 +113,11 @@ jsonschema-specifications==2023.7.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-client==8.3.1
+jupyter-client==8.4.0
     # via
     #   -c envs/dev.env.txt
     #   nbclient
-jupyter-core==5.3.2
+jupyter-core==5.4.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
@@ -285,7 +285,7 @@ referencing==0.30.2
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==0.10.4
+rpds-py==0.10.6
     # via
     #   -c envs/dev.env.txt
     #   jsonschema


### PR DESCRIPTION
#389 and #388 lead to quantumlib/cirq#6313 and quantumlib/cirq#6312. I need to bump the cirq version to incorporate these fixes to unblock #350.