### PR TITLE
[autotest] Basic structure for automatic testing

### DIFF
--- a/qualtran/__init__.py
+++ b/qualtran/__init__.py
@@ -58,4 +58,6 @@ from ._infra.quantum_graph import (
     Soquet,
 )
 
+from ._infra.bloq_example import BloqExample, bloq_example
+
 # --------------------------------------------------------------------------------------------------

--- a/qualtran/__init__.py
+++ b/qualtran/__init__.py
@@ -27,7 +27,7 @@ isort:skip_file
 
 # Internal imports: none
 # External imports: none
-from ._infra.bloq import Bloq
+from ._infra.bloq import Bloq, DecomposeTypeError, DecomposeNotImplementedError
 
 # External imports:
 #     networkx - create binst graph, topological sorting

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -39,6 +39,14 @@ def _decompose_from_build_composite_bloq(bloq: 'Bloq') -> 'CompositeBloq':
     return bb.finalize(**out_soqs)
 
 
+class DecomposeNotImplementedError(NotImplementedError):
+    pass
+
+
+class DecomposeTypeError(TypeError):
+    pass
+
+
 class Bloq(metaclass=abc.ABCMeta):
     """Bloq is the primary abstract base class for all operations.
 
@@ -99,7 +107,7 @@ class Bloq(metaclass=abc.ABCMeta):
             The soquets corresponding to the outputs of the Bloq (keyed by name) or
             `NotImplemented` if there is no decomposition.
         """
-        raise NotImplementedError(f"{self} does not support decomposition.")
+        raise DecomposeNotImplementedError(f"{self}.")
 
     def decompose_bloq(self) -> 'CompositeBloq':
         """Decompose this Bloq into its constituent parts contained in a CompositeBloq.

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -105,7 +105,7 @@ class Bloq(metaclass=abc.ABCMeta):
     def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
         """Override this method to define a Bloq in terms of its constituent parts.
 
-        Bloq definers should override this method. If you already have an instance of a `Bloq`,
+        Bloq authors should override this method. If you already have an instance of a `Bloq`,
         consider calling `decompose_bloq()` which will set up the correct context for
         calling this function.
 
@@ -117,7 +117,7 @@ class Bloq(metaclass=abc.ABCMeta):
             The soquets corresponding to the outputs of the Bloq (keyed by name) or
             `NotImplemented` if there is no decomposition.
         """
-        raise DecomposeNotImplementedError(f"{self}")
+        raise DecomposeNotImplementedError(f"{self} does not declare a decomposition.")
 
     def decompose_bloq(self) -> 'CompositeBloq':
         """Decompose this Bloq into its constituent parts contained in a CompositeBloq.

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -40,11 +40,21 @@ def _decompose_from_build_composite_bloq(bloq: 'Bloq') -> 'CompositeBloq':
 
 
 class DecomposeNotImplementedError(NotImplementedError):
-    pass
+    """Raised if a decomposition is not yet provided.
+
+    In contrast to `DecomposeTypeError`, a decomposition is theoretically possible; just not
+    implemented yet.
+    """
 
 
 class DecomposeTypeError(TypeError):
-    pass
+    """Raised if a decomposition does not make sense in this context.
+
+    In contrast to `DecomposeNotImplementedError`, a decomposition does not make sense
+    in this context. This can be raised if the bloq is "atomic" -- that is, considered part
+    of the compilation target gateset. This can be raised if certain bloq attributes do not
+    permit a decomposition, most commonly if an attribute is symbolic.
+    """
 
 
 class Bloq(metaclass=abc.ABCMeta):
@@ -107,7 +117,7 @@ class Bloq(metaclass=abc.ABCMeta):
             The soquets corresponding to the outputs of the Bloq (keyed by name) or
             `NotImplemented` if there is no decomposition.
         """
-        raise DecomposeNotImplementedError(f"{self}.")
+        raise DecomposeNotImplementedError(f"{self}")
 
     def decompose_bloq(self) -> 'CompositeBloq':
         """Decompose this Bloq into its constituent parts contained in a CompositeBloq.

--- a/qualtran/_infra/bloq_example.py
+++ b/qualtran/_infra/bloq_example.py
@@ -1,0 +1,75 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import Callable, Optional, Type
+
+from attrs import field, frozen
+
+from .bloq import Bloq
+
+
+@frozen
+class BloqExample:
+    _func: Callable[[], Bloq] = field(repr=False, hash=False)
+    name: str
+    bloq_cls: Type[Bloq]
+    generalizer: Callable[[Bloq], Optional[Bloq]] = lambda x: x
+
+    def make(self) -> Bloq:
+        """Make the bloq."""
+        return self._func()
+
+    def __call__(self) -> Bloq:
+        """This class is callable: it will make the bloq.
+
+        This makes the `bloq_example` decorator make sense: we wrap a function, so this
+        callable should do the same thing when called.
+        """
+        return self.make()
+
+
+def _name_from_func_name(func: Callable[[], Bloq]):
+    return func.__name__.lstrip('_')
+
+
+def _bloq_cls_from_func_annotation(func: Callable[[], Bloq]):
+    anno = func.__annotations__
+    if 'return' not in anno:
+        raise ValueError(f'{func} must have a return type annotation.')
+
+    cls = anno['return']
+    assert issubclass(cls, Bloq), cls
+    return cls
+
+
+def bloq_example(
+    _func: Callable[[], Bloq] = None, *, generalizer: Callable[[Bloq], Optional[Bloq]] = lambda x: x
+):
+    """Decorator to turn a function into a `BloqExample`.
+
+    This will set `name` to the name of the function and `bloq_cls` according to the return-type
+    annotation. You can also call the decorator with keyword arguments, which will be passed
+    through to the `BloqExample` constructor.
+    """
+
+    def _inner(func: Callable[[], Bloq]) -> BloqExample:
+        return BloqExample(
+            func=func,
+            name=_name_from_func_name(func),
+            bloq_cls=_bloq_cls_from_func_annotation(func),
+            generalizer=generalizer,
+        )
+
+    if _func is None:
+        return _inner
+    return _inner(_func)

--- a/qualtran/_infra/bloq_example.py
+++ b/qualtran/_infra/bloq_example.py
@@ -20,6 +20,21 @@ from .bloq import Bloq
 
 @frozen
 class BloqExample:
+    """An instantiation of a bloq and its metadata.
+
+    In particular, this class wraps a callable that returns a bloq instantiation with
+    explicit attribute values.
+
+    Consider using the decorator `@bloq_example` to construct a `BloqExample` from a function.
+
+    Args:
+        func: The function that returns the bloq instantiation. Calling the `BloqExample` instance
+            will call this function.
+        name: A name for the bloq instantiation.
+        bloq_cls: The `Bloq` class that this instantiation is an instance of.
+        generalizer: Passed to `get_bloq_counts_graph` calls for bloq-counts equivalence checking.
+    """
+
     _func: Callable[[], Bloq] = field(repr=False, hash=False)
     name: str
     bloq_cls: Type[Bloq]
@@ -38,11 +53,13 @@ class BloqExample:
         return self.make()
 
 
-def _name_from_func_name(func: Callable[[], Bloq]):
+def _name_from_func_name(func: Callable[[], Bloq]) -> str:
+    """Use the name of the function as the `BloqExample.name` when using the decorator."""
     return func.__name__.lstrip('_')
 
 
-def _bloq_cls_from_func_annotation(func: Callable[[], Bloq]):
+def _bloq_cls_from_func_annotation(func: Callable[[], Bloq]) -> Type[Bloq]:
+    """Use the function return type annotation as the `BloqExample.bloq_cls` with the decorator."""
     anno = func.__annotations__
     if 'return' not in anno:
         raise ValueError(f'{func} must have a return type annotation.')

--- a/qualtran/_infra/bloq_example_test.py
+++ b/qualtran/_infra/bloq_example_test.py
@@ -1,0 +1,47 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from functools import cached_property
+
+from attrs import frozen
+
+from qualtran import Bloq, bloq_example, BloqExample, Signature
+
+
+@frozen
+class TesterBloq(Bloq):
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature.build(x=10, y=10)
+
+
+def _tester_bloq_func() -> TesterBloq:
+    return TesterBloq()
+
+
+@bloq_example
+def _tester_bloq() -> TesterBloq:
+    return TesterBloq()
+
+
+def test_bloq_example_explicit():
+    be = BloqExample(func=_tester_bloq_func, name='tester_bloq', bloq_cls=TesterBloq)
+    assert be.name == 'tester_bloq'
+
+    assert be.bloq_cls == TesterBloq
+
+
+def test_bloq_example_decorator():
+    be = _tester_bloq
+    assert be.name == 'tester_bloq'
+    assert be.bloq_cls == TesterBloq

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -373,7 +373,7 @@ def decompose_from_cirq_op(bloq: 'Bloq') -> 'CompositeBloq':
         cirq.is_parameterized(reg.bitsize) or cirq.is_parameterized(reg.side)
         for reg in bloq.signature
     ):
-        raise DecomposeTypeError(f"{bloq} does not support decomposition.")
+        raise DecomposeTypeError(f"Cannot decompose parameterized {bloq}.")
 
     qubit_manager = InteropQubitManager()
     in_quregs = get_cirq_quregs(bloq.signature, qubit_manager)
@@ -383,7 +383,7 @@ def decompose_from_cirq_op(bloq: 'Bloq') -> 'CompositeBloq':
     if cirq_op is None or (
         isinstance(cirq_op, cirq.Operation) and isinstance(cirq_op.gate, BloqAsCirqGate)
     ):
-        raise NotImplementedError(f"{bloq} does not support decomposition.")
+        raise ValueError(f"Cannot decompose from cirq op: {bloq} doesn't have a cirq op.")
 
     return cirq_optree_to_cbloq(
         cirq_op, signature=bloq.signature, in_quregs=in_quregs, out_quregs=out_quregs

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -25,7 +25,17 @@ import quimb.tensor as qtn
 from attrs import field, frozen
 from numpy.typing import NDArray
 
-from qualtran import Bloq, BloqBuilder, CompositeBloq, Register, Side, Signature, Soquet, SoquetT
+from qualtran import (
+    Bloq,
+    BloqBuilder,
+    CompositeBloq,
+    DecomposeTypeError,
+    Register,
+    Side,
+    Signature,
+    Soquet,
+    SoquetT,
+)
 from qualtran.cirq_interop._interop_qubit_manager import InteropQubitManager
 
 if TYPE_CHECKING:
@@ -363,7 +373,7 @@ def decompose_from_cirq_op(bloq: 'Bloq') -> 'CompositeBloq':
         cirq.is_parameterized(reg.bitsize) or cirq.is_parameterized(reg.side)
         for reg in bloq.signature
     ):
-        raise NotImplementedError(f"{bloq} does not support decomposition.")
+        raise DecomposeTypeError(f"{bloq} does not support decomposition.")
 
     qubit_manager = InteropQubitManager()
     in_quregs = get_cirq_quregs(bloq.signature, qubit_manager)

--- a/qualtran/cirq_interop/_cirq_to_bloq_test.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq_test.py
@@ -22,7 +22,7 @@ import sympy
 from attrs import frozen
 
 import qualtran
-from qualtran import Bloq, BloqBuilder, CompositeBloq, Side, Signature
+from qualtran import Bloq, BloqBuilder, CompositeBloq, DecomposeTypeError, Side, Signature
 from qualtran.bloqs.basic_gates import OneState
 from qualtran.bloqs.util_bloqs import Allocate, Free, Join, Split
 from qualtran.cirq_interop import (
@@ -107,7 +107,7 @@ def test_bloq_decompose_from_cirq_op():
     assert circuit == cirq.Circuit(cirq.CNOT(*cirq_quregs['control'], *cirq_quregs['target']))
     assert tb.t_complexity() == cirq_ft.TComplexity(clifford=1)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(DecomposeTypeError):
         TestCNOTSymbolic().decompose_bloq()
 
 

--- a/qualtran/conftest.py
+++ b/qualtran/conftest.py
@@ -31,6 +31,10 @@ from qualtran import BloqExample
 
 
 def assert_bloq_example_make(bloq_ex: BloqExample):
+    """Wrap `check_bloq_example_make`.
+
+    Anything other than PASS is a test failure.
+    """
     status, err = qlt_testing.check_bloq_example_make(bloq_ex)
     if status is qlt_testing.BloqCheckResult.PASS:
         return
@@ -39,6 +43,10 @@ def assert_bloq_example_make(bloq_ex: BloqExample):
 
 
 def assert_bloq_example_decompose(bloq_ex: BloqExample):
+    """Wrap `check_bloq_example_decompose`.
+
+    `NA` or `MISSING` result in the test being skipped.
+    """
     status, err = qlt_testing.check_bloq_example_decompose(bloq_ex)
     if status is qlt_testing.BloqCheckResult.PASS:
         return

--- a/qualtran/conftest.py
+++ b/qualtran/conftest.py
@@ -1,0 +1,62 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+import qualtran.testing as qlt_testing
+from qualtran import BloqExample
+
+
+def assert_bloq_example_make(bloq_ex: BloqExample):
+    status, err = qlt_testing.check_bloq_example_make(bloq_ex)
+    if status is qlt_testing.BloqCheckResult.PASS:
+        return
+
+    raise AssertionError(err)
+
+
+def assert_bloq_example_decompose(bloq_ex: BloqExample):
+    status, err = qlt_testing.check_bloq_example_decompose(bloq_ex)
+    if status is qlt_testing.BloqCheckResult.PASS:
+        return
+    if status is qlt_testing.BloqCheckResult.NA:
+        pytest.skip(err)
+    if status is qlt_testing.BloqCheckResult.MISSING:
+        pytest.skip(err)
+
+    raise AssertionError(err)
+
+
+_TESTFUNCS = [('make', assert_bloq_example_make), ('decompose', assert_bloq_example_decompose)]
+
+
+@pytest.fixture(
+    scope="module",
+    params=[func for name, func in _TESTFUNCS],
+    ids=[name for name, func in _TESTFUNCS],
+)
+def bloq_autotester(request):
+    return request.param

--- a/qualtran/drawing/graphviz_test.py
+++ b/qualtran/drawing/graphviz_test.py
@@ -20,7 +20,7 @@ import IPython.display
 import pytest
 from attrs import frozen
 
-from qualtran import Bloq, BloqBuilder, Signature, Soquet
+from qualtran import Bloq, BloqBuilder, DecomposeTypeError, Signature, Soquet
 from qualtran.drawing.graphviz import _assign_ids_to_bloqs_and_soqs, GraphDrawer, PrettyGraphDrawer
 from qualtran.testing import execute_notebook
 
@@ -30,6 +30,9 @@ class Atom(Bloq):
     @cached_property
     def signature(self) -> Signature:
         return Signature.build(q=1)
+
+    def decompose_bloq(self) -> 'CompositeBloq':
+        raise DecomposeTypeError(f"{self} is atomic")
 
 
 class TestParallelBloq(Bloq):

--- a/qualtran/testing.py
+++ b/qualtran/testing.py
@@ -14,9 +14,22 @@
 
 import itertools
 import traceback
+from enum import Enum
 from pathlib import Path
+from typing import Tuple
 
-from qualtran import Bloq, BloqError, CompositeBloq, DanglingT, LeftDangle, RightDangle, Side
+from qualtran import (
+    Bloq,
+    BloqError,
+    BloqExample,
+    CompositeBloq,
+    DanglingT,
+    DecomposeNotImplementedError,
+    DecomposeTypeError,
+    LeftDangle,
+    RightDangle,
+    Side,
+)
 from qualtran._infra.composite_bloq import _get_flat_dangling_soqs
 
 
@@ -204,3 +217,63 @@ def execute_notebook(name: str):
         nb = nbformat.read(f, as_version=4)
     ep = ExecutePreprocessor(timeout=600, kernel_name="python3")
     ep.preprocess(nb)
+
+
+class BloqCheckResult(Enum):
+    PASS = 0
+    FAIL = 1
+    MISSING = 2
+    NA = 3
+    UNVERIFIED = 4
+    ERROR = 5
+
+
+def _check_bloq_example_make_impl(bloq_ex: BloqExample) -> Tuple[BloqCheckResult, str]:
+    """Implementation for `check_bloq_example_make`.
+
+    This function may throw an uncaught exception, which is handled by the wrapping function.
+    """
+    bloq = bloq_ex.make()
+    if not isinstance(bloq, Bloq):
+        return BloqCheckResult.FAIL, f'{bloq} is not an instance of Bloq'
+    if not isinstance(bloq, bloq_ex.bloq_cls):
+        return BloqCheckResult.FAIL, f'{bloq} is not an instance of {bloq_ex.bloq_cls}'
+    return BloqCheckResult.PASS, ''
+
+
+def check_bloq_example_make(bloq_ex: BloqExample) -> Tuple[BloqCheckResult, str]:
+    """Check that the BloqExample returns the desired bloq."""
+    try:
+        return _check_bloq_example_make_impl(bloq_ex)
+    except Exception as e:
+        return BloqCheckResult.ERROR, f'{bloq_ex.name}: {e}'
+
+
+def _check_bloq_example_decompose_impl(bloq_ex: BloqExample) -> Tuple[BloqCheckResult, str]:
+    """Implementation for `check_bloq_example_decompose`.
+
+    This function may throw an uncaught exception, which is handled by the wrapping function.
+    """
+    try:
+        bloq = bloq_ex.make()
+        assert_valid_bloq_decomposition(bloq)
+        return BloqCheckResult.PASS, ''
+    except DecomposeTypeError as e:
+        return BloqCheckResult.NA, str(e)
+    except DecomposeNotImplementedError as e:
+        return BloqCheckResult.MISSING, str(e)
+    except BloqError as e:
+        return BloqCheckResult.FAIL, str(e)
+
+
+def check_bloq_example_decompose(bloq_ex: BloqExample) -> Tuple[BloqCheckResult, str]:
+    """Check that the BloqExample has a valid decomposition.
+
+    This will use `assert_valid_decomposition` which has a variety of sub-checks. A failure
+    in any of those checks will result in `FAIL`. `DecomposeTypeError` results in a
+    not-applicable `NA` status. `DecomposeNotImplementedError` results in a `MISSING` status.
+    """
+    try:
+        return _check_bloq_example_decompose_impl(bloq_ex)
+    except Exception as e:
+        return BloqCheckResult.ERROR, f'{bloq_ex.name}: {e}'

--- a/qualtran/testing.py
+++ b/qualtran/testing.py
@@ -220,12 +220,26 @@ def execute_notebook(name: str):
 
 
 class BloqCheckResult(Enum):
+    """The status result of the `check_bloq_example_xxx` functions."""
+
     PASS = 0
+    """The check passed and is an unqualified success."""
+
     FAIL = 1
+    """The check failed with a broken assertion or invariant."""
+
     MISSING = 2
+    """The check did not pass because the required functionality is missing."""
+
     NA = 3
+    """The check is not applicable in the current context."""
+
     UNVERIFIED = 4
+    """The bloq protocol has provided a value, but some functionality is missing so we can't
+    verify the result."""
+
     ERROR = 5
+    """An unexpected error occurred during execution of the check."""
 
 
 def _check_bloq_example_make_impl(bloq_ex: BloqExample) -> Tuple[BloqCheckResult, str]:
@@ -242,7 +256,12 @@ def _check_bloq_example_make_impl(bloq_ex: BloqExample) -> Tuple[BloqCheckResult
 
 
 def check_bloq_example_make(bloq_ex: BloqExample) -> Tuple[BloqCheckResult, str]:
-    """Check that the BloqExample returns the desired bloq."""
+    """Check that the BloqExample returns the desired bloq.
+
+    Returns:
+        result: The `BloqCheckResult`.
+        msg: A message providing details from the check.
+    """
     try:
         return _check_bloq_example_make_impl(bloq_ex)
     except Exception as e:
@@ -272,6 +291,10 @@ def check_bloq_example_decompose(bloq_ex: BloqExample) -> Tuple[BloqCheckResult,
     This will use `assert_valid_decomposition` which has a variety of sub-checks. A failure
     in any of those checks will result in `FAIL`. `DecomposeTypeError` results in a
     not-applicable `NA` status. `DecomposeNotImplementedError` results in a `MISSING` status.
+
+    Returns:
+        result: The `BloqCheckResult`.
+        msg: A message providing details from the check.
     """
     try:
         return _check_bloq_example_decompose_impl(bloq_ex)


### PR DESCRIPTION
 - `BloqExample` for encapsulating instantiations of bloqs on which we can perform tests (and eventually: document). Consider this an extension of the `_make_xx()` functions currently used in `dev_tools/autogenerate-bloqs-notebooks.py`. Follow-on work will port all these make functions and the autodoc infrastructure to use `BloqExample`.
 - "check" functions that return not only "pass" or "fail" but also "na", "missing", or "unverified" to form the basis of a bloq "report card": a matrix of bloq examples on one axis and checks on the other
 - wrap the check functions in a `pytest` fixture so all the checks can be run on a given bloq example, simplifying running unit tests. Just like the notebook checks: I imagine that each bloq will have a unit test that runs the checks on that bloq for interactive or incremental developing and debugging. Additionally: there will be a script that will run all the tests on all the bloqs. 
 - use bespoke exceptions to indicate failure modes. For example: `DecomposeNotImplementedError` is different than a general exception. 


ptal. I'll add some more docstrings and tester tests. Next PR will make bloq examples for each bloq