### PR TITLE
`CirqGateAsBloq` should raise `DecomposeNotImplementedError` if underlying gate does not have a decomposition

### DIFF
--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -28,6 +28,7 @@ from qualtran import (
     Bloq,
     BloqBuilder,
     CompositeBloq,
+    DecomposeNotImplementedError,
     DecomposeTypeError,
     Register,
     Side,
@@ -397,7 +398,7 @@ def decompose_from_cirq_op(bloq: 'Bloq', *, decompose_once: bool = False) -> 'Co
     )
 
     if decomposed_optree is None:
-        raise ValueError(f"Cannot decompose from cirq op: {bloq} doesn't have a cirq op.")
+        raise DecomposeNotImplementedError(f"{bloq} does not have a decomposition.")
 
     return cirq_optree_to_cbloq(
         decomposed_optree, signature=bloq.signature, in_quregs=in_quregs, out_quregs=out_quregs

--- a/qualtran/cirq_interop/_cirq_to_bloq_test.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq_test.py
@@ -22,7 +22,15 @@ import sympy
 from attrs import frozen
 
 import qualtran
-from qualtran import Bloq, BloqBuilder, CompositeBloq, DecomposeTypeError, Side, Signature
+from qualtran import (
+    Bloq,
+    BloqBuilder,
+    CompositeBloq,
+    DecomposeNotImplementedError,
+    DecomposeTypeError,
+    Side,
+    Signature,
+)
 from qualtran.bloqs.basic_gates import OneState
 from qualtran.bloqs.util_bloqs import Allocate, Free, Join, Split
 from qualtran.cirq_interop import (
@@ -221,3 +229,9 @@ def test_cirq_gate_as_bloq_for_left_only_gates():
     assert bloqs_list.count(Free(1)) == 2
     assert bloqs_list.count(CirqGateAsBloq(cirq.CNOT)) == 1
     assert bloqs_list.count(CirqGateAsBloq(cirq.ResetChannel())) == 2
+
+
+def test_cirq_gate_as_bloq_decompose_raises():
+    bloq = CirqGateAsBloq(cirq.X)
+    with pytest.raises(DecomposeNotImplementedError, match="does not have a decomposition"):
+        _ = bloq.decompose_bloq()


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Qualtran/pull/350#discussion_r1362789784

A recent PR updated the error raising and handling logic where `bloq.decompose_bloq()` should raise a `DecomposeNotImplementedError` if there doesn't exist a valid decomposition. `CirqGateAsBloq` was still raising a `ValueError` in some of these cases. This PR updates the logic and thus fixes the bug mentioned in above conversation.