### PR TITLE
Add `SelectSwapQROM` Bloq from Cirq-FT

### DIFF
--- a/qualtran/bloqs/qrom.py
+++ b/qualtran/bloqs/qrom.py
@@ -100,15 +100,14 @@ class QROM(UnaryIterationGate):
 
     @cached_property
     def selection_registers(self) -> Tuple[SelectionRegister, ...]:
-        if len(self.data[0].shape) == 1:
-            return (
-                SelectionRegister('selection', self.selection_bitsizes[0], self.data[0].shape[0]),
-            )
-        else:
-            return tuple(
-                SelectionRegister(f'selection{i}', sb, l)
-                for i, (l, sb) in enumerate(zip(self.data[0].shape, self.selection_bitsizes))
-            )
+        ret = tuple(
+            SelectionRegister(f'selection{i}', sb, l)
+            for i, (l, sb) in enumerate(zip(self.data[0].shape, self.selection_bitsizes))
+            if sb > 0
+        )
+        if len(self.data[0].shape) == 1 and len(ret) == 1:
+            ret = (SelectionRegister('selection', ret[0].bitsize, ret[0].iteration_length),)
+        return ret
 
     @cached_property
     def target_registers(self) -> Tuple[Register, ...]:

--- a/qualtran/bloqs/qrom_test.py
+++ b/qualtran/bloqs/qrom_test.py
@@ -41,7 +41,7 @@ def test_qrom_1d(data, num_controls):
 
     assert (
         len(inverse.all_qubits())
-        <= total_bits(g.r) + g.r.get_left('selection').total_bits() + num_controls
+        <= total_bits(g.r) + total_bits(qrom.selection_registers) + num_controls
     )
     assert inverse.all_qubits() == decomposed_circuit.all_qubits()
 
@@ -50,8 +50,8 @@ def test_qrom_1d(data, num_controls):
             qubit_vals = {x: 0 for x in g.all_qubits}
             qubit_vals.update(
                 zip(
-                    g.quregs['selection'],
-                    iter_bits(selection_integer, g.r.get_left('selection').total_bits()),
+                    g.quregs.get('selection', ()),
+                    iter_bits(selection_integer, total_bits(qrom.selection_registers)),
                 )
             )
             if num_controls:

--- a/qualtran/bloqs/select_swap_qrom.py
+++ b/qualtran/bloqs/select_swap_qrom.py
@@ -1,0 +1,239 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import List, Optional, Sequence, Tuple
+
+import cirq
+import numpy as np
+from cirq._compat import cached_property
+from numpy.typing import NDArray
+
+from qualtran import GateWithRegisters, Register, SelectionRegister, Signature
+from qualtran._infra.gate_with_registers import merge_qubits, split_qubits, total_bits
+from qualtran.bloqs.qrom import QROM
+from qualtran.bloqs.swap_network import SwapWithZero
+
+
+def find_optimal_log_block_size(iteration_length: int, target_bitsize: int) -> int:
+    """Find optimal block size, which is a power of 2, for SelectSwapQROM.
+
+    This functions returns the optimal `k` s.t.
+        * k is in an integer and k >= 0.
+        * iteration_length/2^k + target_bitsize*(2^k - 1) is minimized.
+    The corresponding block size for SelectSwapQROM would be 2^k.
+    """
+    k = 0.5 * np.log2(iteration_length / target_bitsize)
+    if k < 0:
+        return 1
+
+    def value(kk: List[int]):
+        return iteration_length / np.power(2, kk) + target_bitsize * (np.power(2, kk) - 1)
+
+    k_int = [np.floor(k), np.ceil(k)]  # restrict optimal k to integers
+    return int(k_int[np.argmin(value(k_int))])  # obtain optimal k
+
+
+@cirq.value_equality()
+class SelectSwapQROM(GateWithRegisters):
+    """Gate to load data[l] in the target register when the selection register stores integer l.
+
+    Let
+        N:= Number of data elements to load.
+        b:= Bit-length of the target register in which data elements should be loaded.
+
+    The `SelectSwapQROM` is a hybrid of the following two existing primitives:
+
+        * Unary Iteration based `cirq_ft.QROM` requires O(N) T-gates to load `N` data
+        elements into a b-bit target register. Note that the T-complexity is independent of `b`.
+        * `cirq_ft.SwapWithZeroGate` can swap a `b` bit register indexed `x` with a `b`
+        bit register at index `0` using O(b) T-gates, if the selection register stores integer `x`.
+        Note that the swap complexity is independent of the iteration length `N`.
+
+    The `SelectSwapQROM` uses square root decomposition by combining the above two approaches to
+    further optimize the T-gate complexity of loading `N` data elements, each into a `b` bit
+    target register as follows:
+
+        * Divide the `N` data elements into batches of size `B` (a variable) and
+        load each batch simultaneously into `B` distinct target signature using the conventional
+        QROM. This has T-complexity `O(N / B)`.
+        * Use `SwapWithZeroGate` to swap the `i % B`'th target register in batch number `i / B`
+        to load `data[i]` in the 0'th target register. This has T-complexity `O(B * b)`.
+
+    This, the final T-complexity of `SelectSwapQROM` is `O(B * b + N / B)` T-gates; where `B` is
+    the block-size with an optimal value of `O(sqrt(N / b))`.
+
+    This improvement in T-complexity is achieved at the cost of using an additional `O(B * b)`
+    ancilla qubits, with a nice property that these additional ancillas can be `dirty`; i.e.
+    they don't need to start in the |0> state and thus can be borrowed from other parts of the
+    algorithm. The state of these dirty ancillas would be unaffected after the operation has
+    finished.
+
+    For more details, see the reference below:
+
+    References:
+        [Trading T-gates for dirty qubits in state preparation and unitary synthesis]
+        (https://arxiv.org/abs/1812.00954).
+            Low, Kliuchnikov, Schaeffer. 2018.
+    """
+
+    def __init__(
+        self,
+        *data: Sequence[int],
+        target_bitsizes: Optional[Sequence[int]] = None,
+        block_size: Optional[int] = None,
+    ):
+        """Initializes SelectSwapQROM
+
+        For a single data sequence of length `N`, maximum target bitsize `b` and block size `B`;
+        SelectSwapQROM requires:
+            - Selection register & ancilla of size `logN` for QROM data load.
+            - 1 clean target register of size `b`.
+            - `B` dirty target signature, each of size `b`.
+
+        Similarly, to load `M` such data sequences, `SelectSwapQROM` requires:
+            - Selection register & ancilla of size `logN` for QROM data load.
+            - 1 clean target register of size `sum(target_bitsizes)`.
+            - `B` dirty target signature, each of size `sum(target_bitsizes)`.
+
+        Args:
+            data: Sequence of integers to load in the target register. If more than one sequence
+                is provided, each sequence must be of the same length.
+            target_bitsizes: Sequence of integers describing the size of target register for each
+                data sequence to load. Defaults to `max(data[i]).bit_length()` for each i.
+            block_size(B): Load batches of `B` data elements in each iteration of traditional QROM
+                (N/B iterations required). Complexity of SelectSwap QROAM scales as
+                `O(B * b + N / B)`, where `B` is the block_size. Defaults to optimal value of
+                 `O(sqrt(N / b))`.
+
+        Raises:
+            ValueError: If all target data sequences to load do not have the same length.
+        """
+        # Validate input.
+        if len(set(len(d) for d in data)) != 1:
+            raise ValueError("All data sequences to load must be of equal length.")
+        if target_bitsizes is None:
+            target_bitsizes = [max(d).bit_length() for d in data]
+        assert len(target_bitsizes) == len(data)
+        assert all(t >= max(d).bit_length() for t, d in zip(target_bitsizes, data))
+        self._num_sequences = len(data)
+        self._target_bitsizes = tuple(target_bitsizes)
+        self._iteration_length = len(data[0])
+        if block_size is None:
+            # Figure out optimal value of block_size
+            block_size = 2 ** find_optimal_log_block_size(len(data[0]), sum(target_bitsizes))
+        assert 0 < block_size <= self._iteration_length
+        self._block_size = block_size
+        self._num_blocks = int(np.ceil(self._iteration_length / self.block_size))
+        self.selection_q, self.selection_r = tuple(
+            (L - 1).bit_length() for L in [self.num_blocks, self.block_size]
+        )
+        self._data = tuple(tuple(d) for d in data)
+
+    @cached_property
+    def selection_registers(self) -> Tuple[SelectionRegister, ...]:
+        return (
+            SelectionRegister(
+                'selection', self.selection_q + self.selection_r, self._iteration_length
+            ),
+        )
+
+    @cached_property
+    def target_registers(self) -> Tuple[Register, ...]:
+        return tuple(
+            Register(f'target{sequence_id}', self._target_bitsizes[sequence_id])
+            for sequence_id in range(self._num_sequences)
+        )
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature([*self.selection_registers, *self.target_registers])
+
+    @property
+    def data(self) -> Tuple[Tuple[int, ...], ...]:
+        return self._data
+
+    @property
+    def block_size(self) -> int:
+        return self._block_size
+
+    @property
+    def num_blocks(self) -> int:
+        return self._num_blocks
+
+    def decompose_from_registers(
+        self,
+        *,
+        context: cirq.DecompositionContext,
+        **quregs: NDArray[cirq.Qid],  # type:ignore[type-var]
+    ) -> cirq.OP_TREE:
+        # Divide each data sequence and corresponding target registers into
+        # `self.num_blocks` batches of size `self.block_size`.
+        selection, targets = quregs.pop('selection'), quregs
+        qrom_data: List[NDArray] = []
+        qrom_target_bitsizes: List[int] = []
+        ordered_target_qubits: List[cirq.Qid] = []
+        for block_id in range(self.block_size):
+            for sequence_id in range(self._num_sequences):
+                data = self.data[sequence_id]
+                target_bitsize = self._target_bitsizes[sequence_id]
+                ordered_target_qubits.extend(context.qubit_manager.qborrow(target_bitsize))
+                data_for_current_block = data[block_id :: self.block_size]
+                if len(data_for_current_block) < self.num_blocks:
+                    zero_pad = (0,) * (self.num_blocks - len(data_for_current_block))
+                    data_for_current_block = data_for_current_block + zero_pad
+                qrom_data.append(np.array(data_for_current_block))
+                qrom_target_bitsizes.append(target_bitsize)
+        # Construct QROM, SwapWithZero and CX operations using the batched data and qubits.
+        k = (self.block_size - 1).bit_length()
+        q, r = selection[: self.selection_q], selection[self.selection_q :]
+        qrom_op, swap_with_zero_op = [], []
+        qrom_gate = QROM(
+            qrom_data,
+            selection_bitsizes=(self.selection_q,),
+            target_bitsizes=tuple(qrom_target_bitsizes),
+        )
+        qrom_op = qrom_gate.on_registers(
+            selection=q, **split_qubits(qrom_gate.target_registers, ordered_target_qubits)
+        )
+        if self.block_size > 1:
+            swap_with_zero_gate = SwapWithZero(
+                k, total_bits(self.target_registers), self.block_size
+            )
+            swap_with_zero_op = swap_with_zero_gate.on_registers(
+                selection=r,
+                **split_qubits(swap_with_zero_gate.target_registers, ordered_target_qubits),
+            )
+        clean_targets = merge_qubits(self.target_registers, **targets)
+        cnot_op = cirq.Moment(cirq.CNOT(s, t) for s, t in zip(ordered_target_qubits, clean_targets))
+        # Yield the operations in correct order.
+        yield qrom_op
+        yield swap_with_zero_op
+        yield cnot_op
+        yield cirq.inverse(swap_with_zero_op)
+        yield cirq.inverse(qrom_op)
+        yield swap_with_zero_op
+        yield cnot_op
+        yield cirq.inverse(swap_with_zero_op)
+
+        context.qubit_manager.qfree(ordered_target_qubits)
+
+    def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
+        wire_symbols = ["In_q"] * self.selection_q
+        wire_symbols += ["In_r"] * self.selection_r
+        for i, target in enumerate(self.target_registers):
+            wire_symbols += [f"QROAM_{i}"] * target.total_bits()
+        return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
+
+    def _value_equality_values_(self):
+        return self.block_size, self._target_bitsizes, self.data

--- a/qualtran/bloqs/select_swap_qrom_test.py
+++ b/qualtran/bloqs/select_swap_qrom_test.py
@@ -1,16 +1,16 @@
-# Copyright 2023 The Cirq Developers
+#  Copyright 2023 Google LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 import cirq
 import numpy as np

--- a/qualtran/bloqs/select_swap_qrom_test.py
+++ b/qualtran/bloqs/select_swap_qrom_test.py
@@ -1,0 +1,110 @@
+# Copyright 2023 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cirq
+import numpy as np
+import pytest
+
+from qualtran._infra.gate_with_registers import get_named_qubits, split_qubits
+from qualtran.bloqs.select_swap_qrom import SelectSwapQROM
+from qualtran.cirq_interop.bit_tools import iter_bits
+from qualtran.cirq_interop.t_complexity_protocol import t_complexity, TComplexity
+from qualtran.cirq_interop.testing import assert_circuit_inp_out_cirqsim
+from qualtran.testing import assert_valid_bloq_decomposition
+
+
+@pytest.mark.parametrize("data", [[[1, 2, 3, 4, 5]], [[1, 2, 3], [3, 2, 1]]])
+@pytest.mark.parametrize("block_size", [None, 1, 2, 3])
+def test_select_swap_qrom(data, block_size):
+    qrom = SelectSwapQROM(*data, block_size=block_size)
+
+    assert_valid_bloq_decomposition(qrom)
+
+    qubit_regs = get_named_qubits(qrom.signature)
+    selection = qubit_regs["selection"]
+    selection_q, selection_r = selection[: qrom.selection_q], selection[qrom.selection_q :]
+    targets = [qubit_regs[f"target{i}"] for i in range(len(data))]
+
+    greedy_mm = cirq.GreedyQubitManager(prefix="_a", maximize_reuse=True)
+    context = cirq.DecompositionContext(greedy_mm)
+    qrom_circuit = cirq.Circuit(cirq.decompose(qrom.on_registers(**qubit_regs), context=context))
+
+    dirty_target_ancilla = [
+        q for q in qrom_circuit.all_qubits() if isinstance(q, cirq.ops.BorrowableQubit)
+    ]
+
+    circuit = cirq.Circuit(
+        # Prepare dirty ancillas in an arbitrary state.
+        cirq.H.on_each(*dirty_target_ancilla),
+        cirq.T.on_each(*dirty_target_ancilla),
+        # The dirty ancillas should remain unaffected by qroam.
+        *qrom_circuit,
+        # Bring back the dirty ancillas to their original state.
+        (cirq.T**-1).on_each(*dirty_target_ancilla),
+        cirq.H.on_each(*dirty_target_ancilla),
+    )
+    all_qubits = sorted(circuit.all_qubits())
+    for selection_integer in range(qrom.selection_registers[0].iteration_length):
+        svals_q = list(iter_bits(selection_integer // qrom.block_size, len(selection_q)))
+        svals_r = list(iter_bits(selection_integer % qrom.block_size, len(selection_r)))
+        qubit_vals = {x: 0 for x in all_qubits}
+        qubit_vals.update({s: sval for s, sval in zip(selection_q, svals_q)})
+        qubit_vals.update({s: sval for s, sval in zip(selection_r, svals_r)})
+
+        dvals = np.random.randint(2, size=len(dirty_target_ancilla))
+        qubit_vals.update({d: dval for d, dval in zip(dirty_target_ancilla, dvals)})
+
+        initial_state = [qubit_vals[x] for x in all_qubits]
+        for target, d in zip(targets, data):
+            for q, b in zip(target, iter_bits(d[selection_integer], len(target))):
+                qubit_vals[q] = b
+        final_state = [qubit_vals[x] for x in all_qubits]
+        assert_circuit_inp_out_cirqsim(circuit, all_qubits, initial_state, final_state)
+
+
+def test_qroam_diagram():
+    data = [[1, 2, 3], [4, 5, 6]]
+    blocksize = 2
+    qrom = SelectSwapQROM(*data, block_size=blocksize)
+    q = cirq.LineQubit.range(cirq.num_qubits(qrom))
+    circuit = cirq.Circuit(qrom.on_registers(**split_qubits(qrom.signature, q)))
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+0: ───In_q──────
+      │
+1: ───In_r──────
+      │
+2: ───QROAM_0───
+      │
+3: ───QROAM_0───
+      │
+4: ───QROAM_1───
+      │
+5: ───QROAM_1───
+      │
+6: ───QROAM_1───
+""",
+    )
+
+
+def test_qroam_raises():
+    with pytest.raises(ValueError, match="must be of equal length"):
+        _ = SelectSwapQROM([1, 2], [1, 2, 3])
+
+
+def test_qroam_hashable():
+    qrom = SelectSwapQROM([1, 2, 5, 6, 7, 8])
+    assert hash(qrom) is not None
+    assert t_complexity(qrom) == TComplexity(32, 160, 0)


### PR DESCRIPTION
Part of [Qualtran & Cirq-FT Integration](https://docs.google.com/document/d/1miypjcCNt6JV_qAypUVPy5eH3EmKadLqeZomA5QoWK0/edit?usp=sharing&resourcekey=0-ciQ8jPfQmK8gtey2lNKesw)

This PR also updates the signature method of `QROM` to make sure we don't instantiate a register of bitsize 0. Going forward, we should raise an error from constructor of `Signature` if any register of `bitsize 0` is provided. 