### PR TITLE
Move mean estimation code from Cirq-FT to Qualtran

### DIFF
--- a/qualtran/bloqs/mean_estimation/__init__.py
+++ b/qualtran/bloqs/mean_estimation/__init__.py
@@ -1,13 +1,13 @@
-# Copyright 2023 The Cirq Developers
+#  Copyright 2023 Google LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/qualtran/bloqs/mean_estimation/__init__.py
+++ b/qualtran/bloqs/mean_estimation/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/qualtran/bloqs/mean_estimation/arctan.py
+++ b/qualtran/bloqs/mean_estimation/arctan.py
@@ -1,0 +1,65 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from functools import cached_property
+from typing import Iterable, Sequence, Union
+
+import attrs
+import cirq
+import numpy as np
+
+from qualtran import GateWithRegisters, Signature
+from qualtran.cirq_interop.bit_tools import float_as_fixed_width_int
+from qualtran.cirq_interop.t_complexity_protocol import TComplexity
+
+
+@attrs.frozen
+class ArcTan(GateWithRegisters, cirq.ArithmeticGate):
+    r"""Applies U|x>|0>|0000...0> = |x>|sign>|abs(-2 arctan(x) / pi)>.
+
+    Args:
+        selection_bitsize: The bitsize of input register |x>.
+        target_bitsize: The bitsize of output register. The computed quantity,
+            $\abs(-2 * \arctan(x) / \pi)$ is stored as a fixed-length binary approximation
+            in the output register of size `target_bitsize`.
+    """
+
+    selection_bitsize: int
+    target_bitsize: int
+
+    @cached_property
+    def signature(self) -> 'Signature':
+        return Signature.build(select=self.selection_bitsize, sign=1, target=self.target_bitsize)
+
+    def registers(self) -> Sequence[Union[int, Sequence[int]]]:
+        return (2,) * self.selection_bitsize, (2,), (2,) * self.target_bitsize
+
+    def with_registers(self, *new_registers: Union[int, Sequence[int]]) -> "ArcTan":
+        raise NotImplementedError()
+
+    def apply(self, *register_values: int) -> Union[int, Iterable[int]]:
+        input_val, target_sign, target_val = register_values
+        output_val = -2 * np.arctan(input_val, dtype=np.double) / np.pi
+        assert -1 <= output_val <= 1
+        output_sign, output_bin = float_as_fixed_width_int(output_val, 1 + self.target_bitsize)
+        return input_val, target_sign ^ output_sign, target_val ^ output_bin
+
+    def _t_complexity_(self) -> TComplexity:
+        # Approximate T-complexity of O(target_bitsize)
+        return TComplexity(t=self.target_bitsize)
+
+    def __pow__(self, power) -> 'ArcTan':
+        if power in [+1, -1]:
+            return self
+        raise NotImplementedError("__pow__ is only implemented for +1/-1.")  # pragma: no cover

--- a/qualtran/bloqs/mean_estimation/arctan_test.py
+++ b/qualtran/bloqs/mean_estimation/arctan_test.py
@@ -1,0 +1,49 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import cirq
+import numpy as np
+import pytest
+
+from qualtran.bloqs.mean_estimation.arctan import ArcTan
+from qualtran.cirq_interop.bit_tools import iter_bits_fixed_point
+from qualtran.cirq_interop.t_complexity_protocol import t_complexity, TComplexity
+
+
+@pytest.mark.parametrize('selection_bitsize', [3, 4])
+@pytest.mark.parametrize('target_bitsize', [3, 5, 6])
+def test_arctan(selection_bitsize, target_bitsize):
+    gate = ArcTan(selection_bitsize, target_bitsize)
+    maps = {}
+    for x in range(2**selection_bitsize):
+        inp = f'0b_{x:0{selection_bitsize}b}_0_{0:0{target_bitsize}b}'
+        y = -2 * np.arctan(x) / np.pi
+        bits = [*iter_bits_fixed_point(y, target_bitsize + 1, signed=True)]
+        sign, y_bin = bits[0], bits[1:]
+        y_bin_str = ''.join(str(b) for b in y_bin)
+        out = f'0b_{x:0{selection_bitsize}b}_{sign}_{y_bin_str}'
+        maps[int(inp, 2)] = int(out, 2)
+    num_qubits = gate.num_qubits()
+    op = gate.on(*cirq.LineQubit.range(num_qubits))
+    circuit = cirq.Circuit(op)
+    cirq.testing.assert_equivalent_computational_basis_map(maps, circuit)
+    circuit += op**-1
+    cirq.testing.assert_allclose_up_to_global_phase(
+        circuit.unitary(), np.diag([1] * 2**num_qubits), atol=1e-8
+    )
+
+
+def test_arctan_t_complexity():
+    gate = ArcTan(4, 5)
+    assert t_complexity(gate) == TComplexity(t=5)

--- a/qualtran/bloqs/mean_estimation/complex_phase_oracle.py
+++ b/qualtran/bloqs/mean_estimation/complex_phase_oracle.py
@@ -1,0 +1,86 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Tuple
+
+import attrs
+import cirq
+from cirq._compat import cached_property
+from numpy.typing import NDArray
+
+from qualtran import GateWithRegisters, Register, SelectionRegister, Signature
+from qualtran._infra.gate_with_registers import merge_qubits, total_bits
+from qualtran.bloqs.mean_estimation.arctan import ArcTan
+from qualtran.bloqs.select_and_prepare import SelectOracle
+
+
+@attrs.frozen
+class ComplexPhaseOracle(GateWithRegisters):
+    r"""Applies $ROT_{y}|l>|garbage_{l}> = exp(i * -2arctan{y_{l}})|l>|garbage_{l}>$.
+
+    TODO(#6142): This currently assumes that the random variable `y_{l}` only takes integer
+    values. This constraint can be removed by using a standardized floating point to
+    binary encoding, like IEEE 754, to encode arbitrary floats in the binary target
+    register and use them to compute the more accurate $-2arctan{y_{l}}$ for any arbitrary
+    $y_{l}$.
+    """
+
+    encoder: SelectOracle
+    arctan_bitsize: int = 32
+
+    @cached_property
+    def control_registers(self) -> Tuple[Register, ...]:
+        return self.encoder.control_registers
+
+    @cached_property
+    def selection_registers(self) -> Tuple[SelectionRegister, ...]:
+        return self.encoder.selection_registers
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature([*self.control_registers, *self.selection_registers])
+
+    def decompose_from_registers(
+        self,
+        *,
+        context: cirq.DecompositionContext,
+        **quregs: NDArray[cirq.Qid],  # type:ignore[type-var]
+    ) -> cirq.OP_TREE:
+        qm = context.qubit_manager
+        target_reg = {
+            reg.name: qm.qalloc(reg.total_bits()) for reg in self.encoder.target_registers
+        }
+        target_qubits = merge_qubits(self.encoder.target_registers, **target_reg)
+        encoder_op = self.encoder.on_registers(**quregs, **target_reg)
+
+        arctan_sign, arctan_target = qm.qalloc(1), qm.qalloc(self.arctan_bitsize)
+        arctan_op = ArcTan(len(target_qubits), self.arctan_bitsize).on(
+            *target_qubits, *arctan_sign, *arctan_target
+        )
+
+        yield encoder_op
+        yield arctan_op
+        for i, q in enumerate(arctan_target):
+            yield (cirq.Z(q) ** (1 / 2 ** (1 + i))).controlled_by(*arctan_sign, control_values=[0])
+            yield (cirq.Z(q) ** (-1 / 2 ** (1 + i))).controlled_by(*arctan_sign, control_values=[1])
+
+        yield cirq.inverse(arctan_op)
+        yield cirq.inverse(encoder_op)
+
+        qm.qfree([*arctan_sign, *arctan_target, *target_qubits])
+
+    def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
+        wire_symbols = ['@'] * total_bits(self.control_registers)
+        wire_symbols += ['ROTy'] * total_bits(self.selection_registers)
+        return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)

--- a/qualtran/bloqs/mean_estimation/complex_phase_oracle_test.py
+++ b/qualtran/bloqs/mean_estimation/complex_phase_oracle_test.py
@@ -1,0 +1,88 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import math
+from typing import Optional, Tuple
+
+import cirq
+import numpy as np
+import pytest
+from attrs import frozen
+from cirq._compat import cached_property
+
+from qualtran import Register, SelectionRegister
+from qualtran.bloqs.mean_estimation.complex_phase_oracle import ComplexPhaseOracle
+from qualtran.bloqs.select_and_prepare import SelectOracle
+from qualtran.cirq_interop import bit_tools
+from qualtran.cirq_interop import testing as cq_testing
+from qualtran.testing import assert_valid_bloq_decomposition
+
+
+@frozen
+class DummySelect(SelectOracle):
+    bitsize: int
+    control_val: Optional[int] = None
+
+    @cached_property
+    def control_registers(self) -> Tuple[Register, ...]:
+        return () if self.control_val is None else (Register('control', 1),)
+
+    @cached_property
+    def selection_registers(self) -> Tuple[SelectionRegister, ...]:
+        return (SelectionRegister('selection', self.bitsize),)
+
+    @cached_property
+    def target_registers(self) -> Tuple[Register, ...]:
+        return (Register('target', self.bitsize),)
+
+    def decompose_from_registers(self, context, selection, target):
+        yield [cirq.CNOT(s, t) for s, t in zip(selection, target)]
+
+
+@pytest.mark.parametrize('bitsize', [2, 3, 4, 5])
+@pytest.mark.parametrize('arctan_bitsize', [5, 6, 7])
+def test_phase_oracle(bitsize: int, arctan_bitsize: int):
+    phase_oracle = ComplexPhaseOracle(DummySelect(bitsize), arctan_bitsize)
+    g = cq_testing.GateHelper(phase_oracle)
+
+    assert_valid_bloq_decomposition(phase_oracle)
+
+    # Prepare uniform superposition state on selection register and apply phase oracle.
+    circuit = cirq.Circuit(cirq.H.on_each(*g.quregs['selection']))
+    circuit += cirq.Circuit(cirq.decompose_once(g.operation))
+
+    # Simulate the circut and test output.
+    qubit_order = cirq.QubitOrder.explicit(g.quregs['selection'], fallback=cirq.QubitOrder.DEFAULT)
+    result = cirq.Simulator(dtype=np.complex128).simulate(circuit, qubit_order=qubit_order)
+    state_vector = result.final_state_vector
+    state_vector = state_vector.reshape(2**bitsize, len(state_vector) // 2**bitsize)
+    prepared_state = state_vector.sum(axis=1)
+    for x in range(2**bitsize):
+        output_val = -2 * np.arctan(x, dtype=np.double) / np.pi
+        output_bits = [*bit_tools.iter_bits_fixed_point(np.abs(output_val), arctan_bitsize)]
+        approx_val = np.sign(output_val) * math.fsum(
+            [b * (1 / 2 ** (1 + i)) for i, b in enumerate(output_bits)]
+        )
+
+        assert math.isclose(output_val, approx_val, abs_tol=1 / 2**bitsize), output_bits
+
+        y = np.exp(1j * approx_val * np.pi) / np.sqrt(2**bitsize)
+        assert np.isclose(prepared_state[x], y)
+
+
+def test_phase_oracle_consistent_protocols():
+    bitsize, arctan_bitsize = 3, 5
+    gate = ComplexPhaseOracle(DummySelect(bitsize, 1), arctan_bitsize)
+    expected_symbols = ('@',) + ('ROTy',) * bitsize
+    assert cirq.circuit_diagram_info(gate).wire_symbols == expected_symbols

--- a/qualtran/bloqs/mean_estimation/mean_estimation_operator.py
+++ b/qualtran/bloqs/mean_estimation/mean_estimation_operator.py
@@ -1,0 +1,177 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Collection, Optional, Sequence, Tuple, Union
+
+import attrs
+import cirq
+from cirq._compat import cached_property
+from numpy.typing import NDArray
+
+from qualtran import GateWithRegisters, Register, SelectionRegister, Signature
+from qualtran._infra.gate_with_registers import total_bits
+from qualtran.bloqs.mean_estimation.complex_phase_oracle import ComplexPhaseOracle
+from qualtran.bloqs.reflection_using_prepare import ReflectionUsingPrepare
+from qualtran.bloqs.select_and_prepare import PrepareOracle, SelectOracle
+
+
+@attrs.frozen
+class CodeForRandomVariable:
+    r"""A collection of `encoder` and `synthesizer` for a random variable y.
+
+    We say we have "the code" for a random variable $y$ defined on a probability space
+    $(W, p)$ if we have both, a synthesizer and an encoder defined as follows:
+
+    The synthesizer is responsible to "prepare" the state
+    $\sum_{w \in W} \sqrt{p(w)} |w> |garbage_{w}>$ on the "selection register" $w$ and potentially
+    using a "junk register" corresponding to $|garbage_{w}>$. Thus, for convenience, the synthesizer
+    follows the LCU PREPARE Oracle API.
+    $$
+    synthesizer|0> = \sum_{w \in W} \sqrt{p(w)} |w> |garbage_{w}>
+    $$
+
+
+    The encoder is responsible to encode the value of random variable $y(w)$ in a "target register"
+    when the corresponding "selection register" stores integer $w$. Thus, for convenience, the
+    encoder follows the LCU SELECT Oracle API.
+    $$
+    encoder|w>|0^b> = |w>|y(w)>
+    $$
+    where b is the number of bits required to encode the real range of random variable y.
+
+    References:
+        https://arxiv.org/abs/2208.07544, Definition 2.2 for synthesizer (P) and
+        Definition 2.10 for encoder (Y).
+    """
+
+    synthesizer: PrepareOracle
+    encoder: SelectOracle
+
+    def __attrs_post_init__(self):
+        assert self.synthesizer.selection_registers == self.encoder.selection_registers
+
+
+@attrs.frozen
+class MeanEstimationOperator(GateWithRegisters):
+    r"""Mean estimation operator $U=REFL_{p} ROT_{y}$ as per Sec 3.1 of arxiv.org:2208.07544.
+
+    The MeanEstimationOperator (aka KO Operator) expects `CodeForRandomVariable` to specify the
+    synthesizer and encoder, that follows LCU SELECT/PREPARE API for convenience. It is composed
+    of two unitaries:
+
+        - REFL_{p}: Reflection around the state prepared by synthesizer $P$. It applies the unitary
+            $P^{\dagger}(2|0><0| - I)P$.
+        - ROT_{y}: Applies a complex phase $\exp(i * -2\arctan{y_{w}})$ when the selection register
+            stores $w$. This is achieved by using the encoder to encode $y(w)$ in a temporary target
+            register.
+
+    Note that both $REFL_{p}$ and $ROT_{y}$ only act upon a selection register, thus mean estimation
+    operator expects only a selection register (and a control register, for a controlled version for
+    phase estimation).
+    """
+
+    code: CodeForRandomVariable
+    cv: Tuple[int, ...] = attrs.field(
+        converter=lambda v: (v,) if isinstance(v, int) else tuple(v), default=()
+    )
+    power: int = 1
+    arctan_bitsize: int = 32
+
+    @cv.validator
+    def _validate_cv(self, attribute, value):
+        assert value in [(), (0,), (1,)]
+
+    @cached_property
+    def reflect(self) -> ReflectionUsingPrepare:
+        return ReflectionUsingPrepare(
+            self.code.synthesizer, control_val=None if self.cv == () else self.cv[0]
+        )
+
+    @cached_property
+    def select(self) -> ComplexPhaseOracle:
+        return ComplexPhaseOracle(self.code.encoder, self.arctan_bitsize)
+
+    @cached_property
+    def control_registers(self) -> Tuple[Register, ...]:
+        return self.code.encoder.control_registers
+
+    @cached_property
+    def selection_registers(self) -> Tuple[SelectionRegister, ...]:
+        return self.code.encoder.selection_registers
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature([*self.control_registers, *self.selection_registers])
+
+    def decompose_from_registers(
+        self,
+        *,
+        context: cirq.DecompositionContext,
+        **quregs: NDArray[cirq.Qid],  # type:ignore[type-var]
+    ) -> cirq.OP_TREE:
+        select_reg = {reg.name: quregs[reg.name] for reg in self.select.signature}
+        reflect_reg = {reg.name: quregs[reg.name] for reg in self.reflect.signature}
+        select_op = self.select.on_registers(**select_reg)
+        reflect_op = self.reflect.on_registers(**reflect_reg)
+        for _ in range(self.power):
+            yield select_op
+            # Add a -1 global phase since `ReflectUsingPrepare` applies $R_{s} = I - 2|s><s|$
+            # but we want to apply $R_{s} = 2|s><s| - I$ and this algorithm is sensitive to global
+            # phase.
+            yield [reflect_op, cirq.global_phase_operation(-1)]
+
+    def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
+        wire_symbols = [] if self.cv == () else [["@(0)", "@"][self.cv[0]]]
+        wire_symbols += ['U_ko'] * (total_bits(self.signature) - total_bits(self.control_registers))
+        if self.power != 1:
+            wire_symbols[-1] = f'U_ko^{self.power}'
+        return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
+
+    def controlled(
+        self,
+        num_controls: Optional[int] = None,
+        control_values: Optional[
+            Union[cirq.ops.AbstractControlValues, Sequence[Union[int, Collection[int]]]]
+        ] = None,
+        control_qid_shape: Optional[Tuple[int, ...]] = None,
+    ) -> 'MeanEstimationOperator':
+        if num_controls is None:
+            num_controls = 1
+        if control_values is None:
+            control_values = [1] * num_controls
+        if (
+            isinstance(control_values, Sequence)
+            and len(control_values) == 1
+            and isinstance(control_values[0], int)
+            and not self.cv
+        ):
+            c_select = self.code.encoder.controlled(control_values=control_values)
+            assert isinstance(c_select, SelectOracle)
+            return MeanEstimationOperator(
+                CodeForRandomVariable(encoder=c_select, synthesizer=self.code.synthesizer),
+                cv=self.cv + (control_values[0],),
+                power=self.power,
+                arctan_bitsize=self.arctan_bitsize,
+            )
+        raise NotImplementedError(
+            f'Cannot create a controlled version of {self} with control_values={control_values}.'
+        )
+
+    def with_power(self, new_power: int) -> 'MeanEstimationOperator':
+        return MeanEstimationOperator(
+            self.code, cv=self.cv, power=new_power, arctan_bitsize=self.arctan_bitsize
+        )
+
+    def __pow__(self, power: int):
+        return self.with_power(self.power * power)

--- a/qualtran/bloqs/mean_estimation/mean_estimation_operator_test.py
+++ b/qualtran/bloqs/mean_estimation/mean_estimation_operator_test.py
@@ -1,0 +1,302 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Optional, Sequence, Tuple
+
+import cirq
+import numpy as np
+import pytest
+from attrs import frozen
+from cirq._compat import cached_property
+
+from qualtran import Register, SelectionRegister
+from qualtran._infra.gate_with_registers import get_named_qubits, total_bits
+from qualtran.bloqs.mean_estimation.mean_estimation_operator import (
+    CodeForRandomVariable,
+    MeanEstimationOperator,
+)
+from qualtran.bloqs.select_and_prepare import PrepareOracle, SelectOracle
+from qualtran.cirq_interop import bit_tools
+from qualtran.testing import assert_valid_bloq_decomposition
+
+
+@frozen
+class BernoulliSynthesizer(PrepareOracle):
+    r"""Synthesizes the state $sqrt(1 - p)|00..00> + sqrt(p)|11..11>$"""
+
+    p: float
+    nqubits: int
+
+    @cached_property
+    def selection_registers(self) -> Tuple[SelectionRegister, ...]:
+        return (SelectionRegister('q', self.nqubits, 2),)
+
+    def decompose_from_registers(  # type:ignore[override]
+        self, context, q: Sequence[cirq.Qid]
+    ) -> cirq.OP_TREE:
+        theta = np.arccos(np.sqrt(1 - self.p))
+        yield cirq.ry(2 * theta).on(q[0])
+        yield [cirq.CNOT(q[0], q[i]) for i in range(1, len(q))]
+
+
+@frozen
+class BernoulliEncoder(SelectOracle):
+    r"""Encodes Bernoulli random variable y0/y1 as $Enc|ii..i>|0> = |ii..i>|y_{i}>$ where i=0/1."""
+
+    p: float
+    y: Tuple[int, int]
+    selection_bitsize: int
+    target_bitsize: int
+    control_val: Optional[int] = None
+
+    @cached_property
+    def control_registers(self) -> Tuple[Register, ...]:
+        return () if self.control_val is None else (Register('control', 1),)
+
+    @cached_property
+    def selection_registers(self) -> Tuple[SelectionRegister, ...]:
+        return (SelectionRegister('q', self.selection_bitsize, 2),)
+
+    @cached_property
+    def target_registers(self) -> Tuple[Register, ...]:
+        return (Register('t', self.target_bitsize),)
+
+    def decompose_from_registers(  # type:ignore[override]
+        self, context, q: Sequence[cirq.Qid], t: Sequence[cirq.Qid]
+    ) -> cirq.OP_TREE:
+        y0_bin = bit_tools.iter_bits(self.y[0], self.target_bitsize)
+        y1_bin = bit_tools.iter_bits(self.y[1], self.target_bitsize)
+
+        for y0, y1, tq in zip(y0_bin, y1_bin, t):
+            if y0:
+                yield cirq.X(tq).controlled_by(  # pragma: no cover
+                    *q, control_values=[0] * self.selection_bitsize  # pragma: no cover
+                )  # pragma: no cover
+            if y1:
+                yield cirq.X(tq).controlled_by(*q, control_values=[1] * self.selection_bitsize)
+
+    def controlled(self, *args, **kwargs):
+        cv = kwargs['control_values'][0]
+        return BernoulliEncoder(self.p, self.y, self.selection_bitsize, self.target_bitsize, cv)
+
+    @cached_property
+    def mu(self) -> float:
+        return self.p * self.y[1] + (1 - self.p) * self.y[0]
+
+    @cached_property
+    def s_square(self) -> float:
+        return self.p * (self.y[1] ** 2) + (1 - self.p) * (self.y[0] ** 2)
+
+
+def overlap(v1: np.ndarray, v2: np.ndarray) -> float:
+    return np.abs(np.vdot(v1, v2)) ** 2
+
+
+def satisfies_theorem_321(
+    synthesizer: PrepareOracle,
+    encoder: SelectOracle,
+    c: float,
+    s: float,
+    mu: float,
+    arctan_bitsize: int,
+):
+    r"""Verifies Theorem 3.21 of https://arxiv.org/abs/2208.07544
+
+    Pr[∣sin(θ/2)∣ ∈ ∣µ∣ / √(1 + s ** 2) . [1 / (1 + cs), 1 / (1 - cs)]] >= (1 - 2 / c**2)
+    """
+    code = CodeForRandomVariable(synthesizer=synthesizer, encoder=encoder)
+    mean_gate = MeanEstimationOperator(code, arctan_bitsize=arctan_bitsize)
+
+    assert_valid_bloq_decomposition(synthesizer)
+    assert_valid_bloq_decomposition(encoder)
+    assert_valid_bloq_decomposition(mean_gate)
+
+    # Compute a reduced unitary for mean_op.
+    u = cirq.unitary(mean_gate)
+    assert cirq.is_unitary(u)
+
+    # Compute the final state vector obtained using the synthesizer `Prep |0>`
+    prep_op = synthesizer.on_registers(**get_named_qubits(synthesizer.signature))
+    prep_state = cirq.Circuit(prep_op).final_state_vector()
+
+    expected_hav = abs(mu) * np.sqrt(1 / (1 + s**2))
+    expected_hav_low = expected_hav / (1 + c * s)
+    expected_hav_high = expected_hav / (1 - c * s)
+
+    overlap_sum = 0.0
+    eigvals, eigvects = cirq.linalg.unitary_eig(u)
+    for eig_val, eig_vect in zip(eigvals, eigvects.T):
+        theta = np.abs(np.angle(eig_val))
+        hav_theta = np.sin(theta / 2)
+        overlap_prob = overlap(prep_state, eig_vect)
+        if expected_hav_low <= hav_theta <= expected_hav_high:
+            overlap_sum += overlap_prob
+    return overlap_sum >= 1 - 2 / (c**2) > 0
+
+
+@pytest.mark.parametrize('selection_bitsize', [1, 2])
+@pytest.mark.parametrize(
+    'p, y_1, target_bitsize, c',
+    [
+        (1 / 100 * 1 / 100, 3, 2, 100 / 7),
+        (1 / 50 * 1 / 50, 2, 2, 50 / 4),
+        (1 / 50 * 1 / 50, 1, 1, 50 / 10),
+        (1 / 4 * 1 / 4, 1, 1, 1.5),
+    ],
+)
+def test_mean_estimation_bernoulli(
+    p: int, y_1: int, selection_bitsize: int, target_bitsize: int, c: float, arctan_bitsize: int = 5
+):
+    synthesizer = BernoulliSynthesizer(p, selection_bitsize)
+    encoder = BernoulliEncoder(p, (0, y_1), selection_bitsize, target_bitsize)
+
+    s = np.sqrt(encoder.s_square)
+    # For hav_theta interval to be reasonably wide, 1/(1-cs) term should be <=2; thus cs <= 0.5.
+    # The theorem assumes that C >= 1 and s <= 1 / c.
+    assert c * s <= 0.5 and c >= 1 >= s
+
+    assert satisfies_theorem_321(
+        synthesizer=synthesizer,
+        encoder=encoder,
+        c=c,
+        s=s,
+        mu=encoder.mu,
+        arctan_bitsize=arctan_bitsize,
+    )
+
+
+@frozen
+class GroverSynthesizer(PrepareOracle):
+    r"""Prepare a uniform superposition over the first $2^n$ elements."""
+
+    n: int
+
+    @cached_property
+    def selection_registers(self) -> Tuple[SelectionRegister, ...]:
+        return (SelectionRegister('selection', self.n),)
+
+    def decompose_from_registers(  # type:ignore[override]
+        self, *, context, selection: Sequence[cirq.Qid]
+    ) -> cirq.OP_TREE:
+        yield cirq.H.on_each(*selection)
+
+    def __pow__(self, power):
+        if power in [+1, -1]:
+            return self
+        return NotImplemented  # pragma: no cover
+
+
+@frozen
+class GroverEncoder(SelectOracle):
+    """Enc|marked_item>|0> --> |marked_item>|marked_val>"""
+
+    n: int
+    marked_item: int
+    marked_val: int
+
+    @cached_property
+    def control_registers(self) -> Tuple[Register, ...]:
+        return ()
+
+    @cached_property
+    def selection_registers(self) -> Tuple[SelectionRegister, ...]:
+        return (SelectionRegister('selection', self.n),)
+
+    @cached_property
+    def target_registers(self) -> Tuple[Register, ...]:
+        return (Register('target', self.marked_val.bit_length()),)
+
+    def decompose_from_registers(  # type:ignore[override]
+        self, context, *, selection: Sequence[cirq.Qid], target: Sequence[cirq.Qid]
+    ) -> cirq.OP_TREE:
+        selection_cv = [
+            *bit_tools.iter_bits(self.marked_item, total_bits(self.selection_registers))
+        ]
+        yval_bin = [*bit_tools.iter_bits(self.marked_val, total_bits(self.target_registers))]
+
+        for b, q in zip(yval_bin, target):
+            if b:
+                yield cirq.X(q).controlled_by(*selection, control_values=selection_cv)
+
+    @cached_property
+    def mu(self) -> float:
+        return self.marked_val / 2**self.n
+
+    @cached_property
+    def s_square(self) -> float:
+        return (self.marked_val**2) / 2**self.n
+
+
+@pytest.mark.parametrize('n, marked_val, c', [(5, 1, 4), (4, 1, 2), (2, 1, np.sqrt(2))])
+def test_mean_estimation_grover(
+    n: int, marked_val: int, c: float, marked_item: int = 1, arctan_bitsize: int = 5
+):
+    synthesizer = GroverSynthesizer(n)
+    encoder = GroverEncoder(n, marked_item=marked_item, marked_val=marked_val)
+    s = np.sqrt(encoder.s_square)
+    assert c * s < 1 and c >= 1 >= s
+
+    assert satisfies_theorem_321(
+        synthesizer=synthesizer,
+        encoder=encoder,
+        c=c,
+        s=s,
+        mu=encoder.mu,
+        arctan_bitsize=arctan_bitsize,
+    )
+
+
+def test_mean_estimation_operator_consistent_protocols():
+    p, selection_bitsize, y_1, target_bitsize, arctan_bitsize = 0.1, 2, 1, 1, 4
+    synthesizer = BernoulliSynthesizer(p, selection_bitsize)
+    encoder = BernoulliEncoder(p, (0, y_1), selection_bitsize, target_bitsize)
+    code = CodeForRandomVariable(synthesizer=synthesizer, encoder=encoder)
+    mean_gate = MeanEstimationOperator(code, arctan_bitsize=arctan_bitsize)
+    op = mean_gate.on_registers(**get_named_qubits(mean_gate.signature))
+
+    # Test controlled gate.
+    equals_tester = cirq.testing.EqualsTester()
+    equals_tester.add_equality_group(
+        mean_gate.controlled(),
+        mean_gate.controlled(num_controls=1),
+        mean_gate.controlled(control_values=(1,)),
+        op.controlled_by(cirq.q("control")).gate,
+    )
+    equals_tester.add_equality_group(
+        mean_gate.controlled(control_values=(0,)),
+        mean_gate.controlled(num_controls=1, control_values=(0,)),
+        op.controlled_by(cirq.q("control"), control_values=(0,)).gate,
+    )
+    with pytest.raises(NotImplementedError, match="Cannot create a controlled version"):
+        _ = mean_gate.controlled(num_controls=2)
+
+    # Test with_power
+    assert mean_gate.with_power(5) ** 2 == MeanEstimationOperator(
+        code, arctan_bitsize=arctan_bitsize, power=10
+    )
+    # Test diagrams
+    expected_symbols = ['U_ko'] * cirq.num_qubits(mean_gate)
+    assert cirq.circuit_diagram_info(mean_gate).wire_symbols == tuple(expected_symbols)
+    control_symbols = ['@']
+    assert cirq.circuit_diagram_info(mean_gate.controlled()).wire_symbols == tuple(
+        control_symbols + expected_symbols
+    )
+    control_symbols = ['@(0)']
+    assert cirq.circuit_diagram_info(
+        mean_gate.controlled(control_values=(0,))
+    ).wire_symbols == tuple(control_symbols + expected_symbols)
+    expected_symbols[-1] = 'U_ko^2'
+    assert cirq.circuit_diagram_info(
+        mean_gate.with_power(2).controlled(control_values=(0,))
+    ).wire_symbols == tuple(control_symbols + expected_symbols)


### PR DESCRIPTION
Part of [Qualtran & Cirq-FT Integration](https://docs.google.com/document/d/1miypjcCNt6JV_qAypUVPy5eH3EmKadLqeZomA5QoWK0/edit?usp=sharing&resourcekey=0-ciQ8jPfQmK8gtey2lNKesw)

Mostly a copy / paste. Moves all mean estimation code from Cirq-FT to Qualtran. 