### PR TITLE
[autodoc/autotest] ApplyGateToLthQubit

### DIFF
--- a/dev_tools/autogenerate-bloqs-notebooks-v2.py
+++ b/dev_tools/autogenerate-bloqs-notebooks-v2.py
@@ -47,6 +47,7 @@ from typing import List
 from qualtran_dev_tools.git_tools import get_git_root
 from qualtran_dev_tools.jupyter_autogen_v2 import NotebookSpecV2, render_notebook
 
+import qualtran.bloqs.apply_gate_to_lth_target
 import qualtran.bloqs.basic_gates.swap
 import qualtran.bloqs.factoring.mod_exp
 import qualtran.bloqs.swap_network
@@ -79,6 +80,12 @@ NOTEBOOK_SPECS: List[NotebookSpecV2] = [
         path_stem='mod_mul',
         bloq_specs=[qualtran.bloqs.factoring.mod_mul._MODMUL_DOC],
         directory=f'{SOURCE_DIR}/bloqs/factoring',
+    ),
+    NotebookSpecV2(
+        title='Apply to Lth Target',
+        module=qualtran.bloqs.apply_gate_to_lth_target,
+        bloq_specs=[qualtran.bloqs.apply_gate_to_lth_target._APPLYLTH_DOC],
+        directory=f'{SOURCE_DIR}/bloqs/',
     ),
 ]
 

--- a/dev_tools/qualtran_dev_tools/cirq_ft_jupyter_autogen_factories.py
+++ b/dev_tools/qualtran_dev_tools/cirq_ft_jupyter_autogen_factories.py
@@ -37,24 +37,6 @@ import qualtran.cirq_interop.testing as cq_testing
 # a notebook template.
 
 
-def _make_ApplyGateToLthQubit():
-    from qualtran import Register, SelectionRegister
-    from qualtran.bloqs.apply_gate_to_lth_target import ApplyGateToLthQubit
-
-    def _z_to_odd(n: int):
-        if n % 2 == 1:
-            return cirq.Z
-        return cirq.I
-
-    apply_z_to_odd = ApplyGateToLthQubit(
-        SelectionRegister('selection', 3, 4),
-        nth_gate=_z_to_odd,
-        control_regs=Register('control', 2),
-    )
-
-    return apply_z_to_odd
-
-
 def _make_QROM():
     from qualtran.bloqs.qrom import QROM
 

--- a/dev_tools/qualtran_dev_tools/jupyter_autogen.py
+++ b/dev_tools/qualtran_dev_tools/jupyter_autogen.py
@@ -190,7 +190,8 @@ _IMPORTS = """\
 from qualtran import Bloq, CompositeBloq, BloqBuilder, Signature, Register
 from qualtran.drawing import show_bloq
 from typing import *
-import numpy as np\
+import numpy as np
+import cirq\
 """
 
 _GATE_DISPLAY = """\

--- a/qualtran/bloqs/apply_gate_to_lth_target.ipynb
+++ b/qualtran/bloqs/apply_gate_to_lth_target.ipynb
@@ -29,7 +29,7 @@
     "cq.autogen": "title_cell"
    },
    "source": [
-    "# Apply to L-th Target"
+    "# Apply to Lth Target"
    ]
   },
   {
@@ -41,20 +41,18 @@
    },
    "outputs": [],
    "source": [
-    "import cirq\n",
+    "from qualtran import Bloq, CompositeBloq, BloqBuilder, Signature, Register\n",
+    "from qualtran.drawing import show_bloq\n",
+    "from typing import *\n",
     "import numpy as np\n",
-    "from qualtran import Signature, SelectionRegister\n",
-    "from qualtran.bloqs.apply_gate_to_lth_target import ApplyGateToLthQubit\n",
-    "import qualtran.cirq_interop.testing as cq_testing\n",
-    "from qualtran.cirq_interop.jupyter_tools import display_gate_and_compilation\n",
-    "from typing import *"
+    "import cirq"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "249829b0",
    "metadata": {
-    "cq.autogen": "_make_ApplyGateToLthQubit.md"
+    "cq.autogen": "ApplyGateToLthQubit.bloq_doc.md"
    },
    "source": [
     "## `ApplyGateToLthQubit`\n",
@@ -72,7 +70,10 @@
     "#### Parameters\n",
     " - `selection_regs`: Indexing `select` signature of type Tuple[`SelectionRegister`, ...]. It also contains information about the iteration length of each selection register.\n",
     " - `nth_gate`: A function mapping the composite selection index to a single-qubit gate.\n",
-    " - `control_regs`: Control signature for constructing a controlled version of the gate.\n"
+    " - `control_regs`: Control signature for constructing a controlled version of the gate. \n",
+    "\n",
+    "#### References\n",
+    "[Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662). Babbush et. al. (2018). Section III.A. and Figure 7.\n"
    ]
   },
   {
@@ -80,10 +81,34 @@
    "execution_count": null,
    "id": "b8d2a7bf",
    "metadata": {
-    "cq.autogen": "_make_ApplyGateToLthQubit.py"
+    "cq.autogen": "ApplyGateToLthQubit.bloq_doc.py"
    },
    "outputs": [],
    "source": [
+    "from qualtran.bloqs.apply_gate_to_lth_target import ApplyGateToLthQubit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fb12f9c",
+   "metadata": {
+    "cq.autogen": "ApplyGateToLthQubit.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ed7d01a",
+   "metadata": {
+    "cq.autogen": "ApplyGateToLthQubit.apply_z_to_odd"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran import SelectionRegister\n",
+    "\n",
     "def _z_to_odd(n: int):\n",
     "    if n % 2 == 1:\n",
     "        return cirq.Z\n",
@@ -93,7 +118,50 @@
     "    SelectionRegister('selection', 3, 4),\n",
     "    nth_gate=_z_to_odd,\n",
     "    control_regs=Signature.build(control=2),\n",
-    ")\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19527432",
+   "metadata": {
+    "cq.autogen": "ApplyGateToLthQubit.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0c83967",
+   "metadata": {
+    "cq.autogen": "ApplyGateToLthQubit.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([apply_z_to_odd],\n",
+    "           ['`apply_z_to_odd`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5dedba84",
+   "metadata": {},
+   "source": [
+    "## Decomposition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d61a8c3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qualtran.cirq_interop.testing as cq_testing\n",
+    "from qualtran.cirq_interop.jupyter_tools import display_gate_and_compilation\n",
     "\n",
     "g = cq_testing.GateHelper(\n",
     "    apply_z_to_odd\n",
@@ -119,7 +187,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/qualtran/bloqs/apply_gate_to_lth_target.py
+++ b/qualtran/bloqs/apply_gate_to_lth_target.py
@@ -20,7 +20,7 @@ import cirq
 import numpy as np
 from cirq._compat import cached_property
 
-from qualtran import Register, SelectionRegister
+from qualtran import bloq_example, BloqDocSpec, Register, SelectionRegister, Signature
 from qualtran._infra.gate_with_registers import total_bits
 from qualtran.bloqs.unary_iteration_bloq import UnaryIterationGate
 
@@ -39,14 +39,13 @@ class ApplyGateToLthQubit(UnaryIterationGate):
     `selection`-th qubit of `target` all controlled by the `control` register.
 
     Args:
-        selection_regs: Indexing `select` signature of type Tuple[`SelectionRegisters`, ...].
+        selection_regs: Indexing `select` signature of type Tuple[`SelectionRegister`, ...].
             It also contains information about the iteration length of each selection register.
         nth_gate: A function mapping the composite selection index to a single-qubit gate.
         control_regs: Control signature for constructing a controlled version of the gate.
 
     References:
-            [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity]
-        (https://arxiv.org/abs/1805.03662).
+        [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662).
         Babbush et. al. (2018). Section III.A. and Figure 7.
     """
     selection_regs: Tuple[SelectionRegister, ...] = attr.field(
@@ -102,3 +101,28 @@ class ApplyGateToLthQubit(UnaryIterationGate):
         selection_idx = tuple(selection_indices[reg.name] for reg in self.selection_regs)
         target_idx = int(np.ravel_multi_index(selection_idx, selection_shape))
         return self.nth_gate(*selection_idx).on(target[target_idx]).controlled_by(control)
+
+
+@bloq_example
+def _apply_z_to_odd() -> ApplyGateToLthQubit:
+    from qualtran import SelectionRegister
+
+    def _z_to_odd(n: int):
+        if n % 2 == 1:
+            return cirq.Z
+        return cirq.I
+
+    apply_z_to_odd = ApplyGateToLthQubit(
+        SelectionRegister('selection', 3, 4),
+        nth_gate=_z_to_odd,
+        control_regs=Signature.build(control=2),
+    )
+
+    return apply_z_to_odd
+
+
+_APPLYLTH_DOC = BloqDocSpec(
+    bloq_cls=ApplyGateToLthQubit,
+    import_line='from qualtran.bloqs.apply_gate_to_lth_target import ApplyGateToLthQubit',
+    examples=(_apply_z_to_odd,),
+)

--- a/qualtran/bloqs/apply_gate_to_lth_target_test.py
+++ b/qualtran/bloqs/apply_gate_to_lth_target_test.py
@@ -15,12 +15,20 @@
 import cirq
 import pytest
 
+import qualtran.testing as qlt_testing
 from qualtran import SelectionRegister, Signature
 from qualtran._infra.gate_with_registers import get_named_qubits, total_bits
-from qualtran.bloqs.apply_gate_to_lth_target import ApplyGateToLthQubit
+from qualtran.bloqs.apply_gate_to_lth_target import _apply_z_to_odd, ApplyGateToLthQubit
 from qualtran.cirq_interop.bit_tools import iter_bits
 from qualtran.cirq_interop.testing import assert_circuit_inp_out_cirqsim, GateHelper
-from qualtran.testing import assert_valid_bloq_decomposition, execute_notebook
+
+
+def test_apply_z_to_odd(bloq_autotester):
+    bloq_autotester(_apply_z_to_odd)
+
+
+def test_notebook():
+    qlt_testing.execute_notebook('apply_gate_to_lth_target')
 
 
 @pytest.mark.parametrize("selection_bitsize,target_bitsize", [[3, 5], [3, 7], [4, 5]])
@@ -111,8 +119,4 @@ def test_bloq_has_consistent_decomposition(selection_bitsize, target_bitsize):
         lambda n: cirq.Z if n & 1 else cirq.I,
         control_regs=Signature.build(control=2),
     )
-    assert_valid_bloq_decomposition(bloq)
-
-
-def test_notebook():
-    execute_notebook('apply_gate_to_lth_target')
+    qlt_testing.assert_valid_bloq_decomposition(bloq)

--- a/qualtran/bloqs/factoring/mod_exp.ipynb
+++ b/qualtran/bloqs/factoring/mod_exp.ipynb
@@ -22,7 +22,8 @@
     "from qualtran import Bloq, CompositeBloq, BloqBuilder, Signature, Register\n",
     "from qualtran.drawing import show_bloq\n",
     "from typing import *\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import cirq"
    ]
   },
   {

--- a/qualtran/bloqs/factoring/mod_mul.ipynb
+++ b/qualtran/bloqs/factoring/mod_mul.ipynb
@@ -22,7 +22,8 @@
     "from qualtran import Bloq, CompositeBloq, BloqBuilder, Signature, Register\n",
     "from qualtran.drawing import show_bloq\n",
     "from typing import *\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import cirq"
    ]
   },
   {

--- a/qualtran/bloqs/swap_network_2.ipynb
+++ b/qualtran/bloqs/swap_network_2.ipynb
@@ -24,7 +24,8 @@
     "from qualtran import Bloq, CompositeBloq, BloqBuilder, Signature, Register\n",
     "from qualtran.drawing import show_bloq\n",
     "from typing import *\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import cirq"
    ]
   },
   {


### PR DESCRIPTION
Port the example for `ApplyGateToLthQubit` from old-style to new-style.

As always: the jupyter autogen will leave user-authored cells unaffected; so I kept the cirqy decomposition view