### PR TITLE
Add `XPow/YPow/ZPow` rotations gate

### DIFF
--- a/qualtran/bloqs/basic_gates/__init__.py
+++ b/qualtran/bloqs/basic_gates/__init__.py
@@ -23,7 +23,7 @@ requirements.
 
 from .cnot import CNOT
 from .hadamard import Hadamard
-from .rotation import Rx, Ry, Rz
+from .rotation import Rx, Ry, Rz, XPowGate, YPowGate, ZPowGate
 from .swap import CSwap, TwoBitCSwap, TwoBitSwap
 from .t_gate import TGate
 from .toffoli import Toffoli

--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -14,12 +14,13 @@
 
 import abc
 from functools import cached_property
-from typing import Dict, Set, Tuple, TYPE_CHECKING
+from typing import Dict, Protocol, Set, Tuple, TYPE_CHECKING
 
+import cirq
 import numpy as np
 from attrs import frozen
 
-from qualtran import Bloq, Signature
+from qualtran import GateWithRegisters, Signature
 from qualtran.bloqs.basic_gates.t_gate import TGate
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 
@@ -30,16 +31,18 @@ if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 
 
-@frozen
-class RotationBloq(Bloq, metaclass=abc.ABCMeta):
-    angle: float
-    eps: float = 1e-11
+class _HasEps(Protocol):
+    """Protocol for typing `RotationBloq` base class mixin that has accuracy specified as eps."""
 
+    eps: float
+
+
+class RotationBloq(GateWithRegisters, metaclass=abc.ABCMeta):
     @cached_property
     def signature(self) -> 'Signature':
         return Signature.build(q=1)
 
-    def t_complexity(self):
+    def t_complexity(self: _HasEps):
         # TODO Determine precise clifford count and/or ignore.
         # This is an improvement over Ref. 2 from the docstring which provides
         # a bound of 3 log(1/eps).
@@ -48,17 +51,40 @@ class RotationBloq(Bloq, metaclass=abc.ABCMeta):
         num_t = int(np.ceil(1.149 * np.log2(1.0 / self.eps) + 9.2))
         return TComplexity(t=num_t)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        num_t = int(np.ceil(1.149 * np.log2(1.0 / self.eps) + 9.2))
+    def build_call_graph(self: _HasEps, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+        num_t = RotationBloq.t_complexity(self).t
         return {(TGate(), num_t)}
 
 
 @frozen
-class Rz(RotationBloq):
-    """Single-qubit Rz gate.
+class ZPowGate(RotationBloq):
+    r"""A gate that rotates around the Z axis of the Bloch sphere.
+
+    The unitary matrix of `ZPowGate(exponent=t, global_shift=s)` is:
+    $$
+        e^{i \pi s t}
+        \begin{bmatrix}
+            1 & 0 \\
+            0 & e^{i \pi t}
+        \end{bmatrix}
+    $$
+
+    Note in particular that this gate has a global phase factor of
+    $e^{i\pi t/2}$ vs the traditionally defined rotation matrices
+    about the Pauli Z axis. See `Rz` for rotations without the global
+    phase. The global phase factor can be adjusted by using the `global_shift`
+    parameter when initializing.
 
     Args:
-        angle: Rotation angle.
+        exponent: The t in gate**t. Determines how much the eigenvalues of
+            the gate are phased by. For example, eigenvectors phased by -1
+            when `gate**1` is applied will gain a relative phase of
+            e^{i pi exponent} when `gate**exponent` is applied (relative to
+            eigenvectors unaffected by `gate**1`).
+        global_shift: Offsets the eigenvalues of the gate at exponent=1.
+            In effect, this controls a global phase factor on the gate's
+            unitary matrix. The factor for global_shift=s is:
+                exp(i * pi * s * t)
         eps: precision for implementation of rotation.
 
     Registers:
@@ -71,17 +97,160 @@ class Rz(RotationBloq):
         of z-rotations](https://arxiv.org/pdf/1403.2975.pdf).
     """
 
+    exponent: float = 1.0
+    global_shift: float = 0.0
+    eps: float = 1e-11
+
     def as_cirq_op(
         self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'
     ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
-        import cirq
+        (q,) = q
+        return cirq.ZPowGate(exponent=self.exponent, global_shift=self.global_shift).on(q), {
+            'q': np.array([q])
+        }
 
+
+@frozen
+class XPowGate(RotationBloq):
+    r"""A gate that rotates around the X axis of the Bloch sphere.
+
+    The unitary matrix of `XPowGate(exponent=t, global_shift=s)` is:
+    $$
+    e^{i \pi t (s + 1/2)}
+    \begin{bmatrix}
+      \cos(\pi t /2) & -i \sin(\pi t /2) \\
+      -i \sin(\pi t /2) & \cos(\pi t /2)
+    \end{bmatrix}
+    $$
+
+    Note in particular that this gate has a global phase factor of
+    $e^{i \pi t / 2}$ vs the traditionally defined rotation matrices
+    about the Pauli X axis. See `Rx` for rotations without the global
+    phase. The global phase factor can be adjusted by using the `global_shift`
+    parameter when initializing.
+
+    Args:
+        exponent: The t in gate**t. Determines how much the eigenvalues of
+            the gate are phased by. For example, eigenvectors phased by -1
+            when `gate**1` is applied will gain a relative phase of
+            e^{i pi exponent} when `gate**exponent` is applied (relative to
+            eigenvectors unaffected by `gate**1`).
+        global_shift: Offsets the eigenvalues of the gate at exponent=1.
+            In effect, this controls a global phase factor on the gate's
+            unitary matrix. The factor for global_shift=s is:
+
+                exp(i * pi * s * t)
+        eps: precision for implementation of rotation.
+
+    Registers:
+        q: One-bit register.
+
+    References:
+        [Efficient synthesis of universal Repeat-Until-Success
+        circuits](https://arxiv.org/abs/1404.5320), which offers a small improvement
+        [Optimal ancilla-free Clifford+T approximation
+        of z-rotations](https://arxiv.org/pdf/1403.2975.pdf).
+    """
+    exponent: float = 1.0
+    global_shift: float = 0.0
+    eps: float = 1e-11
+
+    def as_cirq_op(
+        self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
+        (q,) = q
+        return cirq.XPowGate(exponent=self.exponent, global_shift=self.global_shift).on(q), {
+            'q': np.array([q])
+        }
+
+
+@frozen
+class YPowGate(RotationBloq):
+    r"""A gate that rotates around the Y axis of the Bloch sphere.
+
+    The unitary matrix of `YPowGate(exponent=t)` is:
+    $$
+        \begin{bmatrix}
+            e^{i \pi t /2} \cos(\pi t /2) & - e^{i \pi t /2} \sin(\pi t /2) \\
+            e^{i \pi t /2} \sin(\pi t /2) & e^{i \pi t /2} \cos(\pi t /2)
+        \end{bmatrix}
+    $$
+
+    Note in particular that this gate has a global phase factor of
+    $e^{i \pi t / 2}$ vs the traditionally defined rotation matrices
+    about the Pauli Y axis. See `Ry` for rotations without the global
+    phase. The global phase factor can be adjusted by using the `global_shift`
+    parameter when initializing.
+
+    Args:
+        exponent: The t in gate**t. Determines how much the eigenvalues of
+            the gate are phased by. For example, eigenvectors phased by -1
+            when `gate**1` is applied will gain a relative phase of
+            e^{i pi exponent} when `gate**exponent` is applied (relative to
+            eigenvectors unaffected by `gate**1`).
+
+        global_shift: Offsets the eigenvalues of the gate at exponent=1.
+            In effect, this controls a global phase factor on the gate's
+            unitary matrix. The factor for global_shift=s is:
+
+                exp(i * pi * s * t)
+        eps: precision for implementation of rotation.
+
+    Registers:
+        q: One-bit register.
+
+    References:
+        [Efficient synthesis of universal Repeat-Until-Success
+        circuits](https://arxiv.org/abs/1404.5320), which offers a small improvement
+        [Optimal ancilla-free Clifford+T approximation
+        of z-rotations](https://arxiv.org/pdf/1403.2975.pdf).
+    """
+    exponent: float = 1.0
+    global_shift: float = 0.0
+    eps: float = 1e-11
+
+    def as_cirq_op(
+        self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
+        (q,) = q
+        return cirq.YPowGate(exponent=self.exponent, global_shift=self.global_shift).on(q), {
+            'q': np.array([q])
+        }
+
+
+@frozen
+class Rz(RotationBloq):
+    """Single-qubit Rz gate.
+
+    Args:
+        angle: Rotation angle in radians.
+        eps: precision for implementation of rotation.
+
+    Registers:
+        q: One-bit register.
+
+    References:
+        [Efficient synthesis of universal Repeat-Until-Success
+        circuits](https://arxiv.org/abs/1404.5320), which offers a small improvement
+        [Optimal ancilla-free Clifford+T approximation
+        of z-rotations](https://arxiv.org/pdf/1403.2975.pdf).
+    """
+
+    angle: float
+    eps: float = 1e-11
+
+    def as_cirq_op(
+        self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
         (q,) = q
         return cirq.rz(self.angle).on(q), {'q': np.array([q])}
 
 
 @frozen
 class Rx(RotationBloq):
+    angle: float
+    eps: float = 1e-11
+
     def as_cirq_op(
         self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'
     ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
@@ -93,6 +262,9 @@ class Rx(RotationBloq):
 
 @frozen
 class Ry(RotationBloq):
+    angle: float
+    eps: float = 1e-11
+
     def as_cirq_op(
         self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'
     ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:

--- a/qualtran/bloqs/basic_gates/rotation_test.py
+++ b/qualtran/bloqs/basic_gates/rotation_test.py
@@ -16,8 +16,8 @@ import cirq
 import numpy as np
 from cirq.ops import SimpleQubitManager
 
-from qualtran.bloqs.basic_gates import Rx, Ry, Rz, XPowGate, YPowGate, ZPowGate
 from qualtran._infra.gate_with_registers import get_named_qubits
+from qualtran.bloqs.basic_gates import Rx, Ry, Rz, XPowGate, YPowGate, ZPowGate
 
 
 def _make_Rx():

--- a/qualtran/bloqs/basic_gates/rotation_test.py
+++ b/qualtran/bloqs/basic_gates/rotation_test.py
@@ -16,7 +16,7 @@ import cirq
 import numpy as np
 from cirq.ops import SimpleQubitManager
 
-from qualtran.bloqs.basic_gates import Rx, Ry, Rz
+from qualtran.bloqs.basic_gates import Rx, Ry, Rz, XPowGate, YPowGate, ZPowGate
 
 
 def _make_Rx():
@@ -61,3 +61,24 @@ def test_as_cirq_op():
     op, _ = bloq.as_cirq_op(SimpleQubitManager(), **quregs)
     circuit = cirq.Circuit(op)
     assert circuit == cirq.Circuit(cirq.Rz(rads=bloq.angle).on(cirq.NamedQubit("q")))
+    bloq = XPowGate(exponent=1 / 5, global_shift=-0.5)
+    quregs = bloq.signature.get_cirq_quregs()
+    op, _ = bloq.as_cirq_op(SimpleQubitManager(), **quregs)
+    circuit = cirq.Circuit(op)
+    assert circuit == cirq.Circuit(
+        cirq.XPowGate(exponent=1 / 5, global_shift=-0.5).on(cirq.NamedQubit("q"))
+    )
+    bloq = YPowGate(exponent=1 / 5, global_shift=-0.5)
+    quregs = bloq.signature.get_cirq_quregs()
+    op, _ = bloq.as_cirq_op(SimpleQubitManager(), **quregs)
+    circuit = cirq.Circuit(op)
+    assert circuit == cirq.Circuit(
+        cirq.YPowGate(exponent=1 / 5, global_shift=-0.5).on(cirq.NamedQubit("q"))
+    )
+    bloq = ZPowGate(exponent=1 / 5, global_shift=-0.5)
+    quregs = bloq.signature.get_cirq_quregs()
+    op, _ = bloq.as_cirq_op(SimpleQubitManager(), **quregs)
+    circuit = cirq.Circuit(op)
+    assert circuit == cirq.Circuit(
+        cirq.ZPowGate(exponent=1 / 5, global_shift=-0.5).on(cirq.NamedQubit("q"))
+    )

--- a/qualtran/bloqs/chemistry/thc/prepare.py
+++ b/qualtran/bloqs/chemistry/thc/prepare.py
@@ -335,10 +335,10 @@ class PrepareTHC(Bloq):
         less_than = bb.allocate(1)
         keep, sigma, less_than = bb.add(lte_gate, x=keep, y=sigma, target=less_than)
         cz = CirqGateAsBloq(cirq.ControlledGate(cirq.Z))
-        alt_theta, less_than = bb.add(cz, qubits=[alt_theta, less_than])
+        alt_theta, less_than = bb.add(cz, q=[alt_theta, less_than])
         cz = CirqGateAsBloq(cirq.ControlledGate(cirq.Z, control_values=(0,)))
         # negative control on the less_than register
-        less_than, theta = bb.add(cz, qubits=[less_than, theta])
+        less_than, theta = bb.add(cz, q=[less_than, theta])
         less_than, alt_mu, mu = bb.add(CSwapApprox(bitsize=log_mu), ctrl=less_than, x=alt_mu, y=mu)
         less_than, alt_nu, nu = bb.add(CSwapApprox(bitsize=log_mu), ctrl=less_than, x=alt_nu, y=nu)
         keep, sigma, less_than = bb.add(lte_gate, x=keep, y=sigma, target=less_than)

--- a/qualtran/bloqs/chemistry/thc/select.py
+++ b/qualtran/bloqs/chemistry/thc/select.py
@@ -183,7 +183,7 @@ class SelectTHC(Bloq):
         )
         # Controlled Z_0
         split_sys = bb.split(sys_a)
-        succ, split_sys[0] = bb.add(CirqGateAsBloq(cirq.CZ), qubits=[succ, split_sys[0]])
+        succ, split_sys[0] = bb.add(CirqGateAsBloq(cirq.CZ), q=[succ, split_sys[0]])
         sys_a = bb.join(split_sys)
         # Undo rotations
         eq_nu_mp1, data, mu, sys_a = bb.add(
@@ -235,7 +235,7 @@ class SelectTHC(Bloq):
         )
         # Controlled Z_0
         split_sys = bb.split(sys_a)
-        succ, split_sys[0] = bb.add(CirqGateAsBloq(cirq.CZ), qubits=[succ, split_sys[0]])
+        succ, split_sys[0] = bb.add(CirqGateAsBloq(cirq.CZ), q=[succ, split_sys[0]])
         sys_a = bb.join(split_sys)
         # Undo rotations
         eq_nu_mp1, data, nu, sys_a = bb.add(

--- a/qualtran/bloqs/chemistry/trotter/qvr.py
+++ b/qualtran/bloqs/chemistry/trotter/qvr.py
@@ -20,7 +20,6 @@ from attrs import frozen
 
 from qualtran import Bloq, Register, Signature
 from qualtran.bloqs.basic_gates import Rz
-from qualtran.bloqs.basic_gates.rotation import RotationBloq
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 
 if TYPE_CHECKING:
@@ -64,4 +63,4 @@ class QuantumVariableRotation(Bloq):
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         theta = ssa.new_symbol('theta')
         # need to update rotation bloq.
-        return {(RotationBloq(theta), self.phi_bitsize)}
+        return {(Rz(theta), self.phi_bitsize)}

--- a/qualtran/bloqs/chemistry/trotter/trotter.ipynb
+++ b/qualtran/bloqs/chemistry/trotter/trotter.ipynb
@@ -601,7 +601,7 @@
     "from qualtran.resource_counting import SympySymbolAllocator\n",
     "from qualtran.drawing import GraphvizCounts\n",
     "from qualtran.bloqs.util_bloqs import Split, Join, Allocate, Free\n",
-    "from qualtran.bloqs.basic_gates.rotation import RotationBloq\n",
+    "from qualtran.bloqs.basic_gates.rotation import Rx, Ry, Rz\n",
     "from qualtran.cirq_interop import CirqGateAsBloq\n",
     "from qualtran.bloqs.and_bloq import And\n",
     "\n",
@@ -633,7 +633,7 @@
     "            return None\n",
     "    if isinstance(bloq, (Join, Split, Allocate, Free)):\n",
     "        return None\n",
-    "    if isinstance(bloq, RotationBloq):\n",
+    "    if isinstance(bloq, (Rx, Ry, Rz)):\n",
     "        return attrs.evolve(bloq, angle=phi)\n",
     "    return bloq"
    ]

--- a/qualtran/cirq_interop/__init__.py
+++ b/qualtran/cirq_interop/__init__.py
@@ -17,6 +17,6 @@
 isort:skip_file
 """
 
-from ._cirq_to_bloq import CirqQuregT, CirqGateAsBloq, cirq_optree_to_cbloq
+from ._cirq_to_bloq import CirqQuregT, CirqGateAsBloq, CirqGateAsBloqBase, cirq_optree_to_cbloq
 
 from ._bloq_to_cirq import BloqAsCirqGate

--- a/qualtran/cirq_interop/_cirq_to_bloq_test.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq_test.py
@@ -45,7 +45,7 @@ class TestCNOT(Bloq):
 
     def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
         ctrl, target = soqs['control'], soqs['target']
-        ctrl, target = bb.add(CirqGateAsBloq(cirq.CNOT), qubits=[ctrl, target])
+        ctrl, target = bb.add(CirqGateAsBloq(cirq.CNOT), q=[ctrl, target])
         return {'control': ctrl, 'target': target}
 
     def as_cirq_op(
@@ -65,7 +65,7 @@ def test_cirq_gate_as_bloq_for_trivial_gates():
         assert len(b.signature) == 1
         assert b.signature[0].side == Side.THRU
 
-    assert x.signature[0].shape == (1,)
+    assert x.signature[0].shape == ()
     assert toffoli.signature[0].shape == (3,)
 
     assert str(x) == 'CirqGateAsBloq(gate=cirq.X)'


### PR DESCRIPTION
This PR does a bunch of changes/improvements in cirq interop
- Introduces a new `CirqGateAsBloqBase` abstract class which has all the functionality to auto populate the bloq methods using underlying Cirq gates. There is one abstract method called `cirq_gate` which can be over-riden by derived classes. 
- The wrapper class `CirqGateAsBloq` simply derives from `CirqGateAsBloqBase` and uses the user specified `self.gate` as the corresponding `cirq_gate`.
- However, users can now also derive from `CirqGateAsBloqBase` class and specify a custom cirq gate as the `cirq_gate` property. For commonly used gates in Cirq-Core, this inheritance based method for wrapping cirq gates solves the discoverability issue and reduces boilerplace code. 
- This is now used in the `rotations.py` file to wrap `Rx / Ry / Rz / XPow / YPow / ZPow` gates.  As you can see, the wrapper code is now much simpler. 
- Another drive-thru change is to change the default signature of wrapped gates from `Register(qubits, shape=(nqubits), bitsize=1)` to `Register('q', shape=(nqubits), bitsize=1)` if `nqubits > 1` or `Register('q', shape=(), bitsize=1)` if nqbits = 1. Changing `qubits` to `q` is nicer because we don't need to worry about singular / plural when number of qubits are > 1 or = 1. 



The `XPow/YPow/ZPow` gates have an option to configure the global phase and follow a pattern similar to Cirq. These gates are useful when implementing phase gradient states.  Docstrings for these gates are copied over from Cirq. 

As a follow up, we can also consider making these new gates implementation more robust so we can get rid of `XGate` / `YGate` / `ZGate` that also currently exist. 