### PR TITLE
Cleanup Cirq interop after Cirq-FT / Qualtran integration

### DIFF
--- a/qualtran/_infra/bloq_test.py
+++ b/qualtran/_infra/bloq_test.py
@@ -20,6 +20,7 @@ import pytest
 from attrs import frozen
 
 from qualtran import Bloq, CompositeBloq, Side, Signature
+from qualtran._infra.gate_with_registers import get_named_qubits
 from qualtran.cirq_interop import CirqQuregT
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.testing import execute_notebook
@@ -50,7 +51,7 @@ def test_bloq():
     assert ctrl.side == Side.THRU
     assert tb.pretty_name() == 'TestCNOT'
 
-    quregs = tb.signature.get_cirq_quregs()
+    quregs = get_named_qubits(tb.signature.lefts())
     op, _ = tb.as_cirq_op(cirq.ops.SimpleQubitManager(), **quregs)
     circuit = cirq.Circuit(op)
     assert circuit == cirq.Circuit(cirq.CNOT(cirq.NamedQubit('control'), cirq.NamedQubit('target')))

--- a/qualtran/_infra/composite_bloq_test.py
+++ b/qualtran/_infra/composite_bloq_test.py
@@ -41,6 +41,7 @@ from qualtran import (
 )
 from qualtran._infra.bloq_test import TestCNOT
 from qualtran._infra.composite_bloq import _create_binst_graph, _get_dangling_soquets
+from qualtran._infra.gate_with_registers import get_named_qubits
 from qualtran.bloqs.basic_gates import IntEffect, ZeroEffect
 from qualtran.bloqs.util_bloqs import Join
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
@@ -342,7 +343,7 @@ def test_complicated_target_register():
     # note: this includes the two `Dangling` generations.
     assert len(list(nx.topological_generations(binst_graph))) == 2 * 3 + 2
 
-    circuit, _ = cbloq.to_cirq_circuit(**bloq.signature.get_cirq_quregs())
+    circuit, _ = cbloq.to_cirq_circuit(**get_named_qubits(bloq.signature.lefts()))
     cirq.testing.assert_has_diagram(
         circuit,
         """\

--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -13,13 +13,14 @@
 #  limitations under the License.
 
 import abc
+import itertools
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import cirq
 import numpy as np
 from numpy.typing import NDArray
 
-from qualtran._infra.bloq import Bloq, DecomposeNotImplementedError
+from qualtran._infra.bloq import Bloq, DecomposeNotImplementedError, DecomposeTypeError
 from qualtran._infra.composite_bloq import CompositeBloq
 from qualtran._infra.quantum_graph import Soquet
 from qualtran._infra.registers import Register, Side
@@ -211,9 +212,7 @@ class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
                 - `build_composite_bloq` raises a `DecomposeNotImplementedError` and
                 - `decompose_from_registers` raises a `DecomposeNotImplementedError`.
         """
-        import itertools
 
-        from qualtran._infra.bloq import DecomposeTypeError
         from qualtran.cirq_interop._cirq_to_bloq import cirq_optree_to_cbloq, InteropQubitManager
 
         try:

--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -22,7 +22,7 @@ from numpy.typing import NDArray
 from qualtran._infra.bloq import Bloq, DecomposeNotImplementedError
 from qualtran._infra.composite_bloq import CompositeBloq
 from qualtran._infra.quantum_graph import Soquet
-from qualtran._infra.registers import Register
+from qualtran._infra.registers import Register, Side
 
 if TYPE_CHECKING:
     from qualtran.cirq_interop import CirqQuregT
@@ -93,6 +93,37 @@ def get_named_qubits(registers: Iterable[Register]) -> Dict[str, NDArray[cirq.Qi
         )
 
     return {reg.name: _qubits_for_reg(reg) for reg in registers}
+
+
+def _get_all_and_output_quregs_from_input(
+    registers: Iterable[Register],
+    qubit_manager: cirq.QubitManager,
+    in_quregs: Dict[str, 'CirqQuregT'],
+) -> Tuple[Dict[str, 'CirqQuregT'], Dict[str, 'CirqQuregT']]:
+    all_quregs: Dict[str, 'CirqQuregT'] = {}
+    out_quregs: Dict[str, 'CirqQuregT'] = {}
+    for reg in registers:
+        full_shape = reg.shape + (reg.bitsize,)
+        if reg.side & Side.LEFT:
+            if reg.name not in in_quregs or in_quregs[reg.name].shape != full_shape:
+                # Left registers should exist as input to `as_cirq_op`.
+                raise ValueError(f'Compatible {reg=} must exist in {in_quregs=}')
+            all_quregs[reg.name] = in_quregs[reg.name]
+        if reg.side == Side.RIGHT:
+            # Right only registers will get allocated as part of `as_cirq_op`.
+            if reg.name in in_quregs:
+                raise ValueError(f"RIGHT register {reg=} shouldn't exist in {in_quregs=}.")
+            all_quregs[reg.name] = np.array(qubit_manager.qalloc(reg.total_bits())).reshape(
+                full_shape
+            )
+        if reg.side == Side.LEFT:
+            # LEFT only registers should be de-allocated and not be part of output.
+            qubit_manager.qfree(in_quregs[reg.name].flatten())
+
+        if reg.side & Side.RIGHT:
+            # Right registers should be part of the output.
+            out_quregs[reg.name] = all_quregs[reg.name]
+    return all_quregs, out_quregs
 
 
 class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
@@ -180,23 +211,54 @@ class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
                 - `build_composite_bloq` raises a `DecomposeNotImplementedError` and
                 - `decompose_from_registers` raises a `DecomposeNotImplementedError`.
         """
-        from qualtran.cirq_interop._cirq_to_bloq import decompose_from_cirq_op
+        import itertools
+
+        from qualtran._infra.bloq import DecomposeTypeError
+        from qualtran.cirq_interop._cirq_to_bloq import cirq_optree_to_cbloq, InteropQubitManager
 
         try:
             return Bloq.decompose_bloq(self)
         except DecomposeNotImplementedError:
-            return decompose_from_cirq_op(self, decompose_once=True)
+            if any(
+                cirq.is_parameterized(reg.bitsize) or cirq.is_parameterized(reg.side)
+                for reg in self.signature
+            ):
+                raise DecomposeTypeError(f"Cannot decompose parameterized {self}.")
+
+            qm = InteropQubitManager()
+            in_quregs = get_named_qubits(self.signature.lefts())
+            qm.manage_qubits(
+                itertools.chain.from_iterable(qreg.flatten() for qreg in in_quregs.values())
+            )
+            all_quregs, out_quregs = _get_all_and_output_quregs_from_input(
+                self.signature, qm, in_quregs
+            )
+            context = cirq.DecompositionContext(qubit_manager=qm)
+            decomposed_optree = self.decompose_from_registers(context=context, **all_quregs)
+            return cirq_optree_to_cbloq(
+                decomposed_optree,
+                signature=self.signature,
+                in_quregs=in_quregs,
+                out_quregs=out_quregs,
+            )
 
     def as_cirq_op(
-        self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'
+        self, qubit_manager: 'cirq.QubitManager', **in_quregs: 'CirqQuregT'
     ) -> Tuple[Union['cirq.Operation', None], Dict[str, 'CirqQuregT']]:
-        from qualtran.cirq_interop._bloq_to_cirq import _construct_op_from_gate
+        """Allocates/Deallocates qubits for RIGHT/LEFT only registers to construct a Cirq operation
 
-        return _construct_op_from_gate(
-            self,
-            in_quregs={k: np.array(v) for k, v in cirq_quregs.items()},
-            qubit_manager=qubit_manager,
+        Args:
+            qubit_manager: For allocating/deallocating qubits for RIGHT/LEFT only registers.
+            in_quregs: Mapping from LEFT register names to corresponding cirq qubits.
+
+        Returns:
+            A cirq operation constructed using `self` and a mapping from RIGHT register names to
+            corresponding Cirq qubits.
+        """
+        all_quregs, out_quregs = _get_all_and_output_quregs_from_input(
+            self.signature, qubit_manager, in_quregs
         )
+        return self.on_registers(**all_quregs), out_quregs
 
     def t_complexity(self) -> 'TComplexity':
         from qualtran.cirq_interop.t_complexity_protocol import t_complexity
@@ -221,16 +283,27 @@ class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
     def _decompose_with_context_(
         self, qubits: Sequence[cirq.Qid], context: Optional[cirq.DecompositionContext] = None
     ) -> cirq.OP_TREE:
-        qubit_regs = split_qubits(self.signature, qubits)
+        quregs = split_qubits(self.signature, qubits)
         if context is None:
             context = cirq.DecompositionContext(cirq.ops.SimpleQubitManager())
         try:
-            return self.decompose_from_registers(context=context, **qubit_regs)
+            return self.decompose_from_registers(context=context, **quregs)
         except DecomposeNotImplementedError as e:
             pass
         try:
             qm = context.qubit_manager
-            return Bloq.decompose_bloq(self).to_cirq_circuit(qubit_manager=qm, **qubit_regs)[0]
+            cbloq = self.decompose_bloq()
+            circuit, out_quregs = cbloq.to_cirq_circuit(qubit_manager=qm, **quregs)
+            qubit_map = {q: q for q in circuit.all_qubits()}
+            for reg in self.signature.rights():
+                if reg.side == Side.RIGHT:
+                    # Right only registers can get mapped to newly allocated output qubits in `out_regs`.
+                    # Map them back to the original system qubits and deallocate newly allocated qubits.
+                    assert reg.name in quregs and reg.name in out_quregs
+                    assert quregs[reg.name].shape == out_quregs[reg.name].shape
+                    qm.qfree([q for q in out_quregs[reg.name].flatten()])
+                    qubit_map |= zip(out_quregs[reg.name].flatten(), quregs[reg.name].flatten())
+            return circuit.unfreeze(copy=False).transform_qubits(qubit_map)
         except DecomposeNotImplementedError as e:
             pass
         return NotImplemented

--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -103,6 +103,30 @@ def _get_all_and_output_quregs_from_input(
     qubit_manager: cirq.QubitManager,
     in_quregs: Dict[str, 'CirqQuregT'],
 ) -> Tuple[Dict[str, 'CirqQuregT'], Dict[str, 'CirqQuregT']]:
+    """Takes care of necessary (de-/)allocations to obtain output & all qubit registers from input.
+
+    For every register `reg` in `registers`, this method checks:
+    - If `reg.side == Side.LEFT`:
+        - Ensure that `in_quregs` has a an entry corresponding to `reg`
+        - Deallocate the corresponding qubits using `qubit_manager.deallocate`.
+        - These qubits are part of `all_quregs` but not `out_quregs`.
+    - If `reg.side == Side.RIGHT`:
+        - Ensure that `in_quregs` does not have an entry corresponding to `reg`.
+        - Allocate new multi-dimensional qubit array of shape `(*reg.shape, reg.bitsize)`.
+        - These qubits are part of `all_quregs` and `out_quregs`.
+    - If `reg.side == Side.THRU`:
+        - Ensure that `in_quregs` has a an entry corresponding to `reg`
+        - These qubits are part of `all_quregs` and `out_quregs`.
+
+    Args:
+        registers: An iterable of `Register` objects specifying the signature of a Bloq.
+        qubit_manager: An instance of `cirq.QubitManager` to allocate/deallocate qubits.
+        in_quregs: A dictionary mapping LEFT register names from `registers` to corresponding
+            cirq-style multidimensional qubit array of shape `(*left_reg.shape, left_reg.bitsize)`.
+
+    Returns:
+        A tuple of `(all_quregs, out_quregs)`
+    """
     all_quregs: Dict[str, 'CirqQuregT'] = {}
     out_quregs: Dict[str, 'CirqQuregT'] = {}
     for reg in registers:

--- a/qualtran/_infra/registers.py
+++ b/qualtran/_infra/registers.py
@@ -16,14 +16,10 @@
 import enum
 import itertools
 from collections import defaultdict
-from typing import Dict, Iterable, Iterator, List, overload, Tuple, TYPE_CHECKING
+from typing import Dict, Iterable, Iterator, List, overload, Tuple
 
 import numpy as np
 from attrs import field, frozen
-from numpy.typing import NDArray
-
-if TYPE_CHECKING:
-    import cirq
 
 
 class Side(enum.Flag):
@@ -232,13 +228,6 @@ class Signature:
 
     def __len__(self) -> int:
         return len(self._registers)
-
-    def get_cirq_quregs(self) -> Dict[str, 'NDArray[cirq.Qid]']:
-        """Get arrays of cirq qubits for these registers."""
-        # TODO(gh/Qualtran/issues/398): Make `get_cirq_quregs` an independent method.
-        from qualtran._infra.gate_with_registers import get_named_qubits
-
-        return get_named_qubits(self.lefts())
 
     def __hash__(self):
         return hash(self._registers)

--- a/qualtran/_infra/registers_test.py
+++ b/qualtran/_infra/registers_test.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 
 from qualtran import Register, SelectionRegister, Side, Signature
+from qualtran._infra.gate_with_registers import get_named_qubits
 
 
 def test_register():
@@ -99,15 +100,19 @@ def test_signature():
         "r2": cirq.NamedQubit.range(2, prefix="r2"),
         "r3": [cirq.NamedQubit("r3")],
     }
-    assert list(signature.get_cirq_quregs().keys()) == list(expected_named_qubits.keys())
+    assert list(get_named_qubits(signature.lefts())) == list(expected_named_qubits.keys())
     assert all(
         (a == b).all()
-        for a, b in zip(signature.get_cirq_quregs().values(), expected_named_qubits.values())
+        for a, b in zip(
+            get_named_qubits(signature.lefts()).values(), expected_named_qubits.values()
+        )
     )
     # Python dictionaries preserve insertion order, which should be same as insertion order of
     # initial registers.
     for reg_order in [[r1, r2, r3], [r2, r3, r1]]:
-        flat_named_qubits = [q for v in Signature(reg_order).get_cirq_quregs().values() for q in v]
+        flat_named_qubits = [
+            q for v in get_named_qubits(Signature(reg_order).lefts()).values() for q in v
+        ]
         expected_qubits = [q for r in reg_order for q in expected_named_qubits[r.name]]
         assert flat_named_qubits == expected_qubits
 
@@ -144,7 +149,7 @@ def test_agg_split():
 
 def test_get_named_qubits_multidim():
     regs = Signature([Register('q', shape=(2, 3), bitsize=4)])
-    quregs = regs.get_cirq_quregs()
+    quregs = get_named_qubits(regs.lefts())
     assert quregs['q'].shape == (2, 3, 4)
     assert quregs['q'][1, 2, 3] == cirq.NamedQubit('q[1, 2][3]')
 

--- a/qualtran/bloqs/basic_gates/rotation_test.py
+++ b/qualtran/bloqs/basic_gates/rotation_test.py
@@ -16,6 +16,7 @@ import cirq
 import numpy as np
 from cirq.ops import SimpleQubitManager
 
+from qualtran._infra.gate_with_registers import get_named_qubits
 from qualtran.bloqs.basic_gates import Rx, Ry, Rz
 
 
@@ -47,17 +48,17 @@ def test_rotation_gates():
 
 def test_as_cirq_op():
     bloq = Rx(angle=np.pi / 4.0, eps=1e-8)
-    quregs = bloq.signature.get_cirq_quregs()
+    quregs = get_named_qubits(bloq.signature.lefts())
     op, _ = bloq.as_cirq_op(SimpleQubitManager(), **quregs)
     circuit = cirq.Circuit(op)
     assert circuit == cirq.Circuit(cirq.Rx(rads=bloq.angle).on(cirq.NamedQubit("q")))
     bloq = Ry(angle=np.pi / 4.0, eps=1e-8)
-    quregs = bloq.signature.get_cirq_quregs()
+    quregs = get_named_qubits(bloq.signature.lefts())
     op, _ = bloq.as_cirq_op(SimpleQubitManager(), **quregs)
     circuit = cirq.Circuit(op)
     assert circuit == cirq.Circuit(cirq.Ry(rads=bloq.angle).on(cirq.NamedQubit("q")))
     bloq = Rz(angle=np.pi / 4.0, eps=1e-8)
-    quregs = bloq.signature.get_cirq_quregs()
+    quregs = get_named_qubits(bloq.signature.lefts())
     op, _ = bloq.as_cirq_op(SimpleQubitManager(), **quregs)
     circuit = cirq.Circuit(op)
     assert circuit == cirq.Circuit(cirq.Rz(rads=bloq.angle).on(cirq.NamedQubit("q")))

--- a/qualtran/bloqs/swap_network.py
+++ b/qualtran/bloqs/swap_network.py
@@ -43,9 +43,6 @@ if TYPE_CHECKING:
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
-# TODO(gh/Qualtran/issues/398): Replace with `swap_network.py` from Cirq-FT
-
-
 @frozen
 class CSwapApprox(GateWithRegisters):
     r"""Approximately implements a multi-target controlled swap unitary using only $4n$ T-gates.

--- a/qualtran/cirq_interop/__init__.py
+++ b/qualtran/cirq_interop/__init__.py
@@ -17,6 +17,6 @@
 isort:skip_file
 """
 
-from ._cirq_to_bloq import CirqQuregT, CirqGateAsBloq, cirq_optree_to_cbloq, decompose_from_cirq_op
+from ._cirq_to_bloq import CirqQuregT, CirqGateAsBloq, cirq_optree_to_cbloq
 
 from ._bloq_to_cirq import BloqAsCirqGate

--- a/qualtran/cirq_interop/_bloq_to_cirq.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from qualtran import (
     Bloq,
+    CompositeBloq,
     Connection,
     GateWithRegisters,
     LeftDangle,
@@ -84,38 +85,10 @@ class BloqAsCirqGate(GateWithRegisters):
             op: A cirq operation whose gate is the `BloqAsCirqGate`-wrapped version of `bloq`.
             cirq_quregs: The output cirq qubit registers.
         """
-        return _construct_op_from_gate(
-            BloqAsCirqGate(bloq=bloq), in_quregs=cirq_quregs, qubit_manager=qubit_manager
-        )
+        return BloqAsCirqGate(bloq=bloq).as_cirq_op(qubit_manager=qubit_manager, **cirq_quregs)
 
-    def decompose_from_registers(
-        self, context: cirq.DecompositionContext, **quregs: CirqQuregT
-    ) -> cirq.OP_TREE:
-        """Implementation of the GatesWithRegisters decompose method.
-
-        This delegates to `self.bloq.decompose_bloq()` and converts the result to a cirq circuit.
-
-        Args:
-            context: `cirq.DecompositionContext` stores options for decomposing gates (eg:
-                cirq.QubitManager).
-            **quregs: Appropriately shaped qubit arrays corresponding to Cirq-FT registers defined
-                as per `self.signature`.
-
-        Returns:
-            A cirq circuit containing the cirq-exported version of the bloq decomposition.
-        """
-        cbloq = self._bloq.decompose_bloq()
-        circuit, out_quregs = cbloq.to_cirq_circuit(qubit_manager=context.qubit_manager, **quregs)
-        qubit_map = {q: q for q in circuit.all_qubits()}
-        for reg in self.bloq.signature.rights():
-            if reg.side == Side.RIGHT:
-                # Right only registers can get mapped to newly allocated output qubits in `out_regs`.
-                # Map them back to the original system qubits and deallocate newly allocated qubits.
-                assert reg.name in quregs and reg.name in out_quregs
-                assert quregs[reg.name].shape == out_quregs[reg.name].shape
-                context.qubit_manager.qfree([q for q in out_quregs[reg.name].flatten()])
-                qubit_map |= zip(out_quregs[reg.name].flatten(), quregs[reg.name].flatten())
-        return circuit.unfreeze(copy=False).transform_qubits(qubit_map)
+    def decompose_bloq(self) -> 'CompositeBloq':
+        return self.bloq.decompose_bloq()
 
     def _t_complexity_(self):
         """Delegate to the bloq's t complexity."""
@@ -250,45 +223,3 @@ def _cbloq_to_cirq_circuit(
     out_quregs = {reg.name: _f_quregs(reg) for reg in signature.rights()}
 
     return cirq.FrozenCircuit(moments), out_quregs
-
-
-def _construct_op_from_gate(
-    gate: GateWithRegisters, in_quregs: Dict[str, 'CirqQuregT'], qubit_manager: cirq.QubitManager
-) -> Tuple[cirq.Operation, Dict[str, 'CirqQuregT']]:
-    """Allocates / Deallocates qubits for RIGHT / LEFT only registers to construct a Cirq operation
-
-    Args:
-        gate: A `GateWithRegisters` which specifies a signature.
-        in_quregs: Mapping from LEFT register names of `gate` and corresponding cirq qubits.
-        qubit_manager: For allocating / deallocating qubits for RIGHT / LEFT only registers.
-
-    Returns:
-        A cirq operation constructed using `gate` and a mapping from RIGHT register names to
-        corresponding Cirq qubits.
-    """
-    all_quregs: Dict[str, 'CirqQuregT'] = {}
-    out_quregs: Dict[str, 'CirqQuregT'] = {}
-    # TODO(gh/Qualtran/issues/398): Replace Side(reg.side.value) with `reg.side` once Side from
-    # Cirq-FT is deprecated.
-    for reg in gate.signature:
-        full_shape = reg.shape + (reg.bitsize,)
-        if Side(reg.side.value) & Side.LEFT:
-            if reg.name not in in_quregs or in_quregs[reg.name].shape != full_shape:
-                # Left registers should exist as input to `as_cirq_op`.
-                raise ValueError(f'Compatible {reg=} must exist in {in_quregs=}')
-            all_quregs[reg.name] = in_quregs[reg.name]
-        if Side(reg.side.value) == Side.RIGHT:
-            # Right only registers will get allocated as part of `as_cirq_op`.
-            if reg.name in in_quregs:
-                raise ValueError(f"RIGHT register {reg=} shouldn't exist in {in_quregs=}.")
-            all_quregs[reg.name] = np.array(qubit_manager.qalloc(reg.total_bits())).reshape(
-                full_shape
-            )
-        if Side(reg.side.value) == Side.LEFT:
-            # LEFT only registers should be de-allocated and not be part of output.
-            qubit_manager.qfree(in_quregs[reg.name].flatten())
-
-        if Side(reg.side.value) & Side.RIGHT:
-            # Right registers should be part of the output.
-            out_quregs[reg.name] = all_quregs[reg.name]
-    return gate.on_registers(**all_quregs), out_quregs

--- a/qualtran/cirq_interop/_bloq_to_cirq.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq.py
@@ -88,6 +88,13 @@ class BloqAsCirqGate(GateWithRegisters):
         return BloqAsCirqGate(bloq=bloq).as_cirq_op(qubit_manager=qubit_manager, **cirq_quregs)
 
     def decompose_bloq(self) -> 'CompositeBloq':
+        """Delegate decomposition to wrapped Bloq's decomposition.
+
+        Since `BloqAsCirqGate` derives from `GateWithRegisters`, it is sufficient to override either
+        Bloq-style `decompose_bloq` or Cirq-style `decompose_from_registers` to obtain the other one
+        for free. Thus, a cirq-style `_decompose_` is auto generated here using the bloq-style
+        `decompose_bloq`.
+        """
         return self.bloq.decompose_bloq()
 
     def _t_complexity_(self):

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -30,13 +30,14 @@ from qualtran import (
     CompositeBloq,
     DecomposeNotImplementedError,
     DecomposeTypeError,
+    GateWithRegisters,
     Register,
     Side,
     Signature,
     Soquet,
     SoquetT,
 )
-from qualtran._infra.gate_with_registers import split_qubits
+from qualtran._infra.gate_with_registers import get_named_qubits, split_qubits
 from qualtran.cirq_interop._interop_qubit_manager import InteropQubitManager
 from qualtran.cirq_interop.t_complexity_protocol import t_complexity, TComplexity
 
@@ -47,15 +48,15 @@ CirqQuregT = NDArray[cirq.Qid]
 CirqQuregInT = Union[NDArray[cirq.Qid], Sequence[cirq.Qid]]
 
 
-def get_cirq_quregs(signature: Signature, qm: InteropQubitManager):
-    ret = signature.get_cirq_quregs()
+def _get_cirq_quregs(signature: Signature, qm: InteropQubitManager):
+    ret = get_named_qubits(signature.lefts())
     qm.manage_qubits(itertools.chain.from_iterable(qreg.flatten() for qreg in ret.values()))
     return ret
 
 
 @frozen
-class CirqGateAsBloq(Bloq):
-    """A Bloq wrapper around a `cirq.Gate`, preserving signature if gate is a `GateWithRegisters`."""
+class CirqGateAsBloq(GateWithRegisters):
+    """A Bloq wrapper around a `cirq.Gate`"""
 
     gate: cirq.Gate
 
@@ -74,8 +75,18 @@ class CirqGateAsBloq(Bloq):
             else Signature([])
         )
 
-    def decompose_bloq(self) -> 'CompositeBloq':
-        return decompose_from_cirq_op(self, decompose_once=True)
+    def decompose_from_registers(
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+    ) -> cirq.OP_TREE:
+        op = (
+            self.gate.on_registers(**quregs)
+            if isinstance(self.gate, GateWithRegisters)
+            else self.gate.on(*quregs.get('qubits', np.array(())).flatten())
+        )
+        try:
+            return cirq.decompose_once(op)
+        except TypeError as e:
+            raise DecomposeNotImplementedError(f"{self} does not declare a decomposition.")
 
     def add_my_tensors(
         self,
@@ -95,25 +106,16 @@ class CirqGateAsBloq(Bloq):
             outgoing=outgoing,
         )
 
-    def as_cirq_op(
-        self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'
-    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
-        from qualtran import GateWithRegisters
-        from qualtran.cirq_interop._bloq_to_cirq import _construct_op_from_gate
-
-        if not isinstance(self.gate, GateWithRegisters):
-            return self.gate.on(*cirq_quregs['qubits'].flatten()), cirq_quregs
-        return _construct_op_from_gate(
-            self.gate,
-            in_quregs={k: np.array(v) for k, v in cirq_quregs.items()},
-            qubit_manager=qubit_manager,
-        )
-
     def t_complexity(self) -> 'TComplexity':
         return t_complexity(self.gate)
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        return _wire_symbol_from_gate(self.gate, self.signature, soq)
+    def as_cirq_op(
+        self, qubit_manager: 'cirq.QubitManager', **in_quregs: 'CirqQuregT'
+    ) -> Tuple[Union['cirq.Operation', None], Dict[str, 'CirqQuregT']]:
+        if isinstance(self.gate, GateWithRegisters):
+            return self.gate.as_cirq_op(qubit_manager, **in_quregs)
+        qubits = in_quregs.get('qubits', ()).flatten()
+        return self.gate.on(*qubits), in_quregs
 
 
 def _wire_symbol_from_gate(gate: cirq.Gate, signature: Signature, soq: 'Soquet') -> 'WireSymbol':
@@ -366,34 +368,3 @@ def cirq_optree_to_cbloq(
         if qvar not in final_soqs_set:
             bb.free(qvar)
     return bb.finalize(**final_soqs_dict)
-
-
-def decompose_from_cirq_op(bloq: 'Bloq', *, decompose_once: bool = False) -> 'CompositeBloq':
-    """Returns a CompositeBloq constructed using Cirq operations obtained via `bloq.as_cirq_op`.
-
-    This method first checks whether `bloq.signature` is parameterized. If yes, it raises a
-    NotImplementedError. If not, it uses `cirq_optree_to_cbloq` to wrap the operations obtained
-    from `bloq.as_cirq_op` into a `CompositeBloq` which has the same signature as `bloq` and returns
-    the corresponding `CompositeBloq`.
-    """
-
-    if any(
-        cirq.is_parameterized(reg.bitsize) or cirq.is_parameterized(reg.side)
-        for reg in bloq.signature
-    ):
-        raise DecomposeTypeError(f"Cannot decompose parameterized {bloq}.")
-
-    qubit_manager = InteropQubitManager()
-    in_quregs = get_cirq_quregs(bloq.signature, qubit_manager)
-    cirq_op, out_quregs = bloq.as_cirq_op(qubit_manager, **in_quregs)
-    context = cirq.DecompositionContext(qubit_manager=qubit_manager)
-    decomposed_optree = (
-        cirq.decompose_once(cirq_op, context=context, default=None) if decompose_once else cirq_op
-    )
-
-    if decomposed_optree is None:
-        raise DecomposeNotImplementedError(f"{bloq} does not have a decomposition.")
-
-    return cirq_optree_to_cbloq(
-        decomposed_optree, signature=bloq.signature, in_quregs=in_quregs, out_quregs=out_quregs
-    )

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -29,7 +29,6 @@ from qualtran import (
     BloqBuilder,
     CompositeBloq,
     DecomposeNotImplementedError,
-    DecomposeTypeError,
     GateWithRegisters,
     Register,
     Side,

--- a/qualtran/cirq_interop/cirq_interop.ipynb
+++ b/qualtran/cirq_interop/cirq_interop.ipynb
@@ -250,7 +250,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "SwapTwoBits().signature.get_cirq_quregs()"
+    "from qualtran._infra.gate_with_registers import get_named_qubits\n",
+    "\n",
+    "get_named_qubits(SwapTwoBits().signature.lefts())"
    ]
   },
   {
@@ -269,7 +271,7 @@
     "cbloq = bb.finalize(x=x, y=y)\n",
     "\n",
     "# Turn it into a cirq circuit\n",
-    "quregs = cbloq.signature.get_cirq_quregs()\n",
+    "quregs = get_named_qubits(cbloq.signature.lefts())\n",
     "circuit, _ = cbloq.to_cirq_circuit(**quregs)\n",
     "\n",
     "# Observe\n",
@@ -419,7 +421,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cirq_quregs = multi_and.signature.get_cirq_quregs()\n",
+    "cirq_quregs = get_named_qubits(multi_and.signature.lefts())\n",
     "cirq_quregs"
    ]
   },


### PR DESCRIPTION
Makes a bunch of simplifications to the `cirq_interop` directory, makes `GateWithRegisters` implementation more robust and removes legacy code after Cirq-FT / Qualtran code integration is completed. 

Fixes https://github.com/quantumlib/Qualtran/issues/398

The only thing left after this PR is documentation improvements for `GateWithRegisters`, `CirqGateAsBloq` and `BloqAsCirqGate`. 