### PR TITLE
Add implementation of Gidney's `OutOfPlaceAdder` and use optimized `TComplexity`

### DIFF
--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -26,6 +26,8 @@ from qualtran._infra.registers import Register
 
 if TYPE_CHECKING:
     from qualtran.cirq_interop import CirqQuregT
+    from qualtran.cirq_interop.t_complexity_protocol import TComplexity
+    from qualtran.drawing import WireSymbol
 
 
 def total_bits(registers: Iterable[Register]) -> int:

--- a/qualtran/bloqs/arithmetic.py
+++ b/qualtran/bloqs/arithmetic.py
@@ -539,43 +539,83 @@ class Add(GateWithRegisters, cirq.ArithmeticGate):
 
 
 @frozen
-class OutOfPlaceAdder(Bloq):
+class OutOfPlaceAdder(GateWithRegisters, cirq.ArithmeticGate):
     r"""An n-bit addition gate.
 
     Implements $U|a\rangle|b\rangle 0\rangle \rightarrow |a\rangle|b\rangle|a+b\rangle$
-    using $4n - 4 T$ gates.
+    using $4n - 4 T$ gates. Uncomputation requires 0 T-gates.
 
     Args:
-        bitsize: Number of bits used to represent each integer. Must be large
-            enough to hold the result in the output register of a + b.
+        bitsize: Number of bits used to represent each input integer. The allocated output register
+            is of size `bitsize+1` so it has enough space to hold the sum of `a+b`.
 
     Registers:
      - a: A bitsize-sized input register (register a above).
-     - b: A bitsize-sized input/output register (register b above).
+     - b: A bitsize-sized input register (register b above).
+     - c: A bitize+1-sized LEFT/RIGHT register depending on whether the gate adjoint or not.
 
     References:
         [Halving the cost of quantum addition](https://arxiv.org/abs/1709.06648)
     """
 
     bitsize: int
+    adjoint: bool = False
 
     @property
     def signature(self):
-        return Signature.build(a=self.bitsize, b=self.bitsize, c=self.bitsize)
+        side = Side.LEFT if self.adjoint else Side.RIGHT
+        return Signature(
+            [
+                Register('a', self.bitsize),
+                Register('b', self.bitsize),
+                Register('c', self.bitsize + 1, side=side),
+            ]
+        )
+
+    def registers(self) -> Sequence[Union[int, Sequence[int]]]:
+        return [2] * self.bitsize, [2] * self.bitsize, [2] * (self.bitsize + 1)
+
+    def apply(self, a: int, b: int, c: int) -> Union[int, Iterable[int]]:
+        return a, b, c + a + b
+
+    def with_registers(self, *new_registers: Union[int, Sequence[int]]):
+        raise NotImplementedError("no need to implement with_registers.")
 
     def short_name(self) -> str:
         return "c = a + b"
 
-    def t_complexity(self):
-        # extra bitsize cliffords comes from CNOTs before adding:
-        # yield CNOT.on_each(zip(b, c))
-        # yield Add(a, c)
-        num_clifford = (self.bitsize - 2) * 19 + 16 + self.bitsize
-        num_t_gates = 4 * self.bitsize - 4
-        return TComplexity(t=num_t_gates, clifford=num_clifford)
+    def decompose_from_registers(
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+    ) -> cirq.OP_TREE:
+        a, b, c = quregs['a'][::-1], quregs['b'][::-1], quregs['c'][::-1]
+        optree = [
+            [
+                [cirq.CX(a[i], b[i]), cirq.CX(a[i], c[i])],
+                And().on(b[i], c[i], c[i + 1]),
+                [cirq.CX(a[i], b[i]), cirq.CX(a[i], c[i + 1]), cirq.CX(b[i], c[i])],
+            ]
+            for i in range(self.bitsize)
+        ]
+        return cirq.inverse(optree) if self.adjoint else optree
+
+    def t_complexity(self) -> TComplexity:
+        and_t = And(adjoint=self.adjoint).t_complexity()
+        num_clifford = self.bitsize * (5 + and_t.clifford)
+        num_t = self.bitsize * and_t.t
+        return TComplexity(t=num_t, clifford=num_clifford)
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(Add(self.bitsize), 1), (ArbitraryClifford(n=2), self.bitsize)}
+        return {
+            (And(adjoint=self.adjoint), self.bitsize),
+            (ArbitraryClifford(n=2), 5 * self.bitsize),
+        }
+
+    def __pow__(self, power: int):
+        if power == 1:
+            return self
+        if power == -1:
+            return OutOfPlaceAdder(self.bitsize, adjoint=not self.adjoint)
+        raise NotImplementedError("OutOfPlaceAdder.__pow__ defined only for +1/-1.")
 
 
 @frozen(auto_attribs=True)

--- a/qualtran/bloqs/arithmetic.py
+++ b/qualtran/bloqs/arithmetic.py
@@ -575,8 +575,13 @@ class OutOfPlaceAdder(GateWithRegisters, cirq.ArithmeticGate):
     def registers(self) -> Sequence[Union[int, Sequence[int]]]:
         return [2] * self.bitsize, [2] * self.bitsize, [2] * (self.bitsize + 1)
 
-    def apply(self, a: int, b: int, c: int) -> Union[int, Iterable[int]]:
+    def apply(self, a: int, b: int, c: int) -> Tuple[int, int, int]:
         return a, b, c + a + b
+
+    def on_classical_vals(
+        self, a: 'ClassicalValT', b: 'ClassicalValT'
+    ) -> Dict[str, 'ClassicalValT']:
+        return dict(zip('abc', (a, b, a + b)))
 
     def with_registers(self, *new_registers: Union[int, Sequence[int]]):
         raise NotImplementedError("no need to implement with_registers.")

--- a/qualtran/bloqs/arithmetic_test.py
+++ b/qualtran/bloqs/arithmetic_test.py
@@ -406,11 +406,11 @@ def test_add_mod_n_protocols():
 
 def test_out_of_place_adder():
     basis_map = {}
+    gate = OutOfPlaceAdder(bitsize=3)
     for x in range(2**3):
         for y in range(2**3):
             basis_map[int(f'0b_{x:03b}_{y:03b}_0000', 2)] = int(f'0b_{x:03b}_{y:03b}_{x+y:04b}', 2)
-    gate = OutOfPlaceAdder(bitsize=3)
-    # ops = GateHelper(gate).operation
+            assert gate.call_classically(a=x, b=y, c=0) == (x, y, x + y)
     op = GateHelper(gate).operation
     op_inv = cirq.inverse(op)
     cirq.testing.assert_equivalent_computational_basis_map(basis_map, cirq.Circuit(op))
@@ -425,7 +425,6 @@ def test_out_of_place_adder():
         assert_circuit_inp_out_cirqsim(circuit, qubit_order, bits, bits)
     assert gate.t_complexity().t == 3 * 4
     assert (gate**-1).t_complexity().t == 0
-    # gate.t_complexity() == cirq.Circuit(cirq.decompse_once(op))
     assert_decompose_is_consistent_with_t_complexity(gate**-1)
     assert_valid_bloq_decomposition(gate)
     assert_valid_bloq_decomposition(gate**-1)

--- a/qualtran/bloqs/arithmetic_test.py
+++ b/qualtran/bloqs/arithmetic_test.py
@@ -42,6 +42,7 @@ from qualtran.cirq_interop.bit_tools import iter_bits, iter_bits_twos_complement
 from qualtran.cirq_interop.testing import (
     assert_circuit_inp_out_cirqsim,
     assert_decompose_is_consistent_with_t_complexity,
+    GateHelper,
 )
 from qualtran.testing import assert_valid_bloq_decomposition, execute_notebook
 
@@ -404,14 +405,30 @@ def test_add_mod_n_protocols():
 
 
 def test_out_of_place_adder():
-    bb = BloqBuilder()
-    bitsize = 4
-    q0 = bb.add_register('a', bitsize)
-    q1 = bb.add_register('b', bitsize)
-    q2 = bb.add_register('c', bitsize)
-    a, b, c = bb.add(OutOfPlaceAdder(bitsize), a=q0, b=q1, c=q2)
-    cbloq = bb.finalize(a=a, b=b, c=c)
-    cbloq.t_complexity()
+    basis_map = {}
+    for x in range(2**3):
+        for y in range(2**3):
+            basis_map[int(f'0b_{x:03b}_{y:03b}_0000', 2)] = int(f'0b_{x:03b}_{y:03b}_{x+y:04b}', 2)
+    gate = OutOfPlaceAdder(bitsize=3)
+    # ops = GateHelper(gate).operation
+    op = GateHelper(gate).operation
+    op_inv = cirq.inverse(op)
+    cirq.testing.assert_equivalent_computational_basis_map(basis_map, cirq.Circuit(op))
+    cirq.testing.assert_equivalent_computational_basis_map(
+        basis_map, cirq.Circuit(cirq.decompose_once(op))
+    )
+    # Check that inverse un-computes correctly
+    qubit_order = op.qubits
+    circuit = cirq.Circuit(cirq.decompose_once(op), cirq.decompose_once(op_inv))
+    for x in range(2**6):
+        bits = [*iter_bits(x, 10)][::-1]
+        assert_circuit_inp_out_cirqsim(circuit, qubit_order, bits, bits)
+    assert gate.t_complexity().t == 3 * 4
+    assert (gate**-1).t_complexity().t == 0
+    # gate.t_complexity() == cirq.Circuit(cirq.decompse_once(op))
+    assert_decompose_is_consistent_with_t_complexity(gate**-1)
+    assert_valid_bloq_decomposition(gate)
+    assert_valid_bloq_decomposition(gate**-1)
 
 
 def test_square():

--- a/qualtran/cirq_interop/testing.py
+++ b/qualtran/cirq_interop/testing.py
@@ -129,8 +129,8 @@ def assert_decompose_is_consistent_with_t_complexity(val: Any):
     for method in ['_t_complexity_', 't_complexity']:
         t_complexity_method = getattr(val, method, None)
         expected = NotImplemented if t_complexity_method is None else t_complexity_method()
-        if expected is NotImplemented or expected is None:
-            continue
+        if not (expected is NotImplemented or expected is None):
+            break
     if expected is NotImplemented or expected is None:
         return
     decomposition = _decompose_once_considering_known_decomposition(val)

--- a/qualtran/cirq_interop/testing.py
+++ b/qualtran/cirq_interop/testing.py
@@ -92,7 +92,7 @@ def assert_circuit_inp_out_cirqsim(
             that are 0 or 1.
     """
     actual, should_be = get_circuit_inp_out_cirqsim(circuit, qubit_order, inputs, outputs, decimals)
-    assert actual == should_be
+    assert actual == should_be, f'\n{actual=}\n{should_be=}'
 
 
 def get_circuit_inp_out_cirqsim(
@@ -126,8 +126,11 @@ def get_circuit_inp_out_cirqsim(
 
 
 def assert_decompose_is_consistent_with_t_complexity(val: Any):
-    t_complexity_method = getattr(val, '_t_complexity_', None)
-    expected = NotImplemented if t_complexity_method is None else t_complexity_method()
+    for method in ['_t_complexity_', 't_complexity']:
+        t_complexity_method = getattr(val, method, None)
+        expected = NotImplemented if t_complexity_method is None else t_complexity_method()
+        if expected is NotImplemented or expected is None:
+            continue
     if expected is NotImplemented or expected is None:
         return
     decomposition = _decompose_once_considering_known_decomposition(val)


### PR DESCRIPTION
Adds an implementation and tests for `OutOfPlaceAdder` described in Figure 4b of https://arxiv.org/abs/1709.06648

Makes the following drive by changes
1. Changes signature of `OutOfPlaceAdder` such that the output register `c` is a newly allocated RIGHT (or LEFT for adjoint) register of size `bitsize+1`. Uncomputing the `c` register now takes 0 T-gates.
2. Fixes a bug in `PairPotential` where the register `c` was not getting uncomputed. There are potentially still more bugs in this implementation. See https://github.com/quantumlib/Qualtran/issues/482
3. Improves `assert_decompose_is_consistent_with_t_complexity` so that it checks for both `_t_complexity_` and `t_complexity` methods because `GateWithRegisters` is now `Bloq`. We can eventually get rid of `_t_complexity_` completely.
4. Adds additional imports to `qualtran/_infra/gate_with_registers.py` which are required for type checking. 


