### PR TITLE
[autotest] Check equivalent bloq counts

### DIFF
--- a/dev_tools/bloq-report-card.ipynb
+++ b/dev_tools/bloq-report-card.ipynb
@@ -19,18 +19,31 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c63cf7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_card = get_bloq_report_card()\n",
+    "show_bloq_report_card(report_card.query('name != \"-\"'))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "27f47a4c",
    "metadata": {},
    "source": [
-    "### All"
+    "### Including 'missing' bloqs"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "d154a421",
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "report_card = get_bloq_report_card()\n",

--- a/dev_tools/qualtran_dev_tools/bloq_report_card.py
+++ b/dev_tools/qualtran_dev_tools/bloq_report_card.py
@@ -17,7 +17,12 @@ import pandas as pd
 import pandas.io.formats.style
 
 from qualtran import Bloq, BloqExample
-from qualtran.testing import BloqCheckResult, check_bloq_example_decompose, check_bloq_example_make
+from qualtran.testing import (
+    BloqCheckResult,
+    check_bloq_example_decompose,
+    check_bloq_example_make,
+    check_equivalent_bloq_example_counts,
+)
 
 from .bloq_finder import get_bloq_classes, get_bloq_examples
 
@@ -60,7 +65,7 @@ def bloq_classes_with_no_examples(
 
 
 IDCOLS = ['package', 'bloq_cls', 'name']
-CHECKCOLS = ['make', 'decomp']
+CHECKCOLS = ['make', 'decomp', 'counts']
 
 
 def record_for_class_with_no_examples(k: Type[Bloq]) -> Dict[str, Any]:
@@ -70,18 +75,18 @@ def record_for_class_with_no_examples(k: Type[Bloq]) -> Dict[str, Any]:
         'name': '-',
         'make': BloqCheckResult.MISSING,
         'decomp': BloqCheckResult.MISSING,
-        # 'counts': BloqCheckResult.MISSING,
+        'counts': BloqCheckResult.MISSING,
     }
 
 
-def records_for_bloq_example(be: BloqExample) -> Dict[str, Any]:
+def record_for_bloq_example(be: BloqExample) -> Dict[str, Any]:
     return {
         'bloq_cls': be.bloq_cls.__name__,
         'package': _get_package(be.bloq_cls),
         'name': be.name,
         'make': check_bloq_example_make(be)[0],
         'decomp': check_bloq_example_decompose(be)[0],
-        # 'counts': check_equivalent_bloq_example_counts(be)[0],
+        'counts': check_equivalent_bloq_example_counts(be)[0],
     }
 
 
@@ -100,6 +105,6 @@ def get_bloq_report_card(
     records = []
     missing_bclasses = bloq_classes_with_no_examples(bclasses, bexamples)
     records.extend(record_for_class_with_no_examples(k) for k in missing_bclasses)
-    records.extend(records_for_bloq_example(be) for be in bexamples)
+    records.extend(record_for_bloq_example(be) for be in bexamples)
 
     return pd.DataFrame(records).sort_values(by=IDCOLS).loc[:, IDCOLS + CHECKCOLS]

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from qualtran.cirq_interop import CirqQuregT
     from qualtran.cirq_interop.t_complexity_protocol import TComplexity
     from qualtran.drawing import WireSymbol
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountT, GeneralizerT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -267,7 +267,7 @@ class Bloq(metaclass=abc.ABCMeta):
 
     def call_graph(
         self,
-        generalizer: Callable[['Bloq'], Optional['Bloq']] = None,
+        generalizer: Optional['GeneralizerT', Sequence['GeneralizerT']] = None,
         keep: Optional[Sequence['Bloq']] = None,
         max_depth: Optional[int] = None,
     ) -> Tuple['nx.DiGraph', Dict['Bloq', Union[int, 'sympy.Expr']]]:
@@ -280,7 +280,8 @@ class Bloq(metaclass=abc.ABCMeta):
         Args:
             generalizer: If provided, run this function on each (sub)bloq to replace attributes
                 that do not affect resource estimates with generic sympy symbols. If the function
-                returns `None`, the bloq is omitted from the counts graph.
+                returns `None`, the bloq is omitted from the counts graph. If a sequence of
+                generalizers is provided, each generalizer will be run in order.
             keep: If this function evaluates to True for the current bloq, keep the bloq as a leaf
                 node in the call graph instead of recursing into it.
             max_depth: If provided, build a call graph with at most this many layers.
@@ -297,7 +298,7 @@ class Bloq(metaclass=abc.ABCMeta):
         return get_bloq_call_graph(self, generalizer=generalizer, keep=keep, max_depth=max_depth)
 
     def bloq_counts(
-        self, generalizer: Callable[['Bloq'], Optional['Bloq']] = None
+        self, generalizer: Optional['GeneralizerT', Sequence['GeneralizerT']] = None
     ) -> Dict['Bloq', Union[int, 'sympy.Expr']]:
         """The number of subbloqs directly called by this bloq.
 
@@ -308,7 +309,8 @@ class Bloq(metaclass=abc.ABCMeta):
         Args:
             generalizer: If provided, run this function on each (sub)bloq to replace attributes
                 that do not affect resource estimates with generic sympy symbols. If the function
-                returns `None`, the bloq is omitted from the counts graph.
+                returns `None`, the bloq is omitted from the counts graph. If a sequence of
+                generalizers is provided, each generalizer will be run in order.
 
         Returns:
             A dictionary mapping subbloq to the number of times they appear in the decomposition.

--- a/qualtran/_infra/bloq_example.py
+++ b/qualtran/_infra/bloq_example.py
@@ -12,11 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import typing
-from typing import Any, Callable, Iterable, Optional, Tuple, Type
+from typing import Any, Callable, Iterable, Sequence, Tuple, Type, TYPE_CHECKING, Union
 
 from attrs import field, frozen
 
 from .bloq import Bloq
+
+if TYPE_CHECKING:
+    from qualtran.resource_counting import GeneralizerT
 
 
 @frozen
@@ -39,7 +42,7 @@ class BloqExample:
     _func: Callable[[], Bloq] = field(repr=False, hash=False)
     name: str
     bloq_cls: Type[Bloq]
-    generalizer: Callable[[Bloq], Optional[Bloq]] = lambda x: x
+    generalizer: Union['GeneralizerT', Sequence['GeneralizerT']] = lambda x: x
 
     def make(self) -> Bloq:
         """Make the bloq."""
@@ -77,13 +80,15 @@ def bloq_example(_func: Callable[[], Bloq], **kwargs: Any) -> BloqExample:
 
 @typing.overload
 def bloq_example(
-    _func: None, *, generalizer: Callable[[Bloq], Optional[Bloq]] = lambda x: x
+    _func: None, *, generalizer: 'GeneralizerT' = lambda x: x
 ) -> Callable[[Callable[[], Bloq]], BloqExample]:
     ...
 
 
 def bloq_example(
-    _func: Callable[[], Bloq] = None, *, generalizer: Callable[[Bloq], Optional[Bloq]] = lambda x: x
+    _func: Callable[[], Bloq] = None,
+    *,
+    generalizer: Union['GeneralizerT', Sequence['GeneralizerT']] = lambda x: x,
 ):
     """Decorator to turn a function into a `BloqExample`.
 

--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -35,6 +35,7 @@ from qualtran import (
 from qualtran.bloqs.util_bloqs import ArbitraryClifford
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, TextBox, WireSymbol
+from qualtran.resource_counting.generalizers import ignore_split_join
 
 from .t_gate import TGate
 
@@ -251,14 +252,14 @@ def _cswap_symb() -> CSwap:
     return cswap_symb
 
 
-@bloq_example
+@bloq_example(generalizer=ignore_split_join)
 def _cswap_small() -> CSwap:
     # A small version on four bits.
     cswap_small = CSwap(bitsize=4)
     return cswap_small
 
 
-@bloq_example
+@bloq_example(generalizer=ignore_split_join)
 def _cswap_large() -> CSwap:
     # A large version that swaps 64-bit registers.
     cswap_large = CSwap(bitsize=64)

--- a/qualtran/bloqs/basic_gates/swap_test.py
+++ b/qualtran/bloqs/basic_gates/swap_test.py
@@ -38,7 +38,7 @@ from qualtran.bloqs.basic_gates.swap import (
     _cswap_symb,
     _swap_matrix,
 )
-from qualtran.bloqs.util_bloqs import Join, Split
+from qualtran.resource_counting.generalizers import ignore_split_join
 
 
 def _make_CSwap():
@@ -186,13 +186,7 @@ def test_cswap_bloq_counts():
     bloq = CSwap(bitsize=8)
     counts1 = bloq.bloq_counts()
 
-    def generalize(b: Bloq) -> Optional[Bloq]:
-        if isinstance(b, (Split, Join)):
-            # Ignore these
-            return
-        return b
-
-    counts2 = bloq.decompose_bloq().bloq_counts(generalizer=generalize)
+    counts2 = bloq.decompose_bloq().bloq_counts(generalizer=ignore_split_join)
     assert counts1 == counts2
 
 

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Any, Dict, Set, Tuple, TYPE_CHECKING, Union
+from typing import Any, Dict, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import numpy as np
@@ -33,16 +33,13 @@ from qualtran import (
     Signature,
     SoquetT,
 )
-from qualtran.bloqs.util_bloqs import ArbitraryClifford
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
-from qualtran.resource_counting import big_O
 from qualtran.simulation.classical_sim import ints_to_bits
 
 if TYPE_CHECKING:
     import cirq
 
     from qualtran.cirq_interop import CirqQuregT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 _ZERO = np.array([1, 0], dtype=np.complex128)
@@ -113,7 +110,6 @@ class _ZVector(Bloq):
     def as_cirq_op(
         self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'
     ) -> Tuple[Union['cirq.Operation', None], Dict[str, 'CirqQuregT']]:
-
         if not self.state:
             raise ValueError(f"There is no Cirq equivalent for {self}")
 
@@ -336,9 +332,6 @@ class _IntVector(Bloq):
 
     def t_complexity(self) -> 'TComplexity':
         return TComplexity()
-
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(ArbitraryClifford(self.bitsize), big_O(1))}
 
     def short_name(self) -> str:
         return f'{self.val}'

--- a/qualtran/bloqs/chemistry/thc/notebook_utils.py
+++ b/qualtran/bloqs/chemistry/thc/notebook_utils.py
@@ -12,12 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, Optional
 
-import attrs
 import cirq
 
-from qualtran.bloqs.and_bloq import And
+from qualtran import Bloq
 from qualtran.bloqs.arithmetic import (
     EqualsAConstant,
     GreaterThan,
@@ -33,6 +32,12 @@ from qualtran.bloqs.select_swap_qrom import SelectSwapQROM
 from qualtran.bloqs.util_bloqs import Allocate, ArbitraryClifford, Free, Join, Split
 from qualtran.cirq_interop import CirqGateAsBloq
 from qualtran.resource_counting import SympySymbolAllocator
+from qualtran.resource_counting.generalizers import (
+    generalize_cvs,
+    generalize_rotation_angle,
+    ignore_alloc_free,
+    ignore_split_join,
+)
 
 # this code will be cleaned up post cirq_ft alignment:
 # https://github.com/quantumlib/Qualtran/issues/425
@@ -65,24 +70,20 @@ def custom_qroam_repr(self) -> str:
     return f"SelectSwapQROM(target_bitsizes={target_repr}, block_size={self.block_size})"
 
 
+# TODO: better way of customizing label
+SelectSwapQROM.__repr__ = custom_qroam_repr
+
+
 def custom_qrom_repr(self) -> str:
     target_repr = repr(self.target_bitsizes)
     selection_repr = repr(self.selection_bitsizes)
     return f"QROM(selection_bitsizes={selection_repr}, target_bitsizes={target_repr})"
 
 
-def generalize(bloq):
-    """Genereralizer for THC prepare bloqs."""
-    if isinstance(bloq, (Allocate, Free, Split, Join)):
-        return None
-    if isinstance(bloq, (Rx, Ry, Rz)):
-        return attrs.evolve(bloq, angle=phi_sym)
-    if isinstance(bloq, And):
-        return attrs.evolve(bloq, cv1=and_cv0, cv2=and_cv1)
-    if isinstance(bloq, SelectSwapQROM):
-        bloq.__class__.__repr__ = custom_qroam_repr
-    if isinstance(bloq, QROM):
-        bloq.__class__.__repr__ = custom_qrom_repr
+QROM.__repr__ = custom_qrom_repr
+
+
+def custom_generalizations(bloq: Bloq) -> Optional[Bloq]:
     if isinstance(bloq, CirqGateAsBloq):
         if isinstance(bloq.gate, single_qubit_clifford):
             return ArbitraryClifford(n=1)
@@ -95,6 +96,15 @@ def generalize(bloq):
         ):
             return ArbitraryClifford(n=2)
     return bloq
+
+
+GENERALIZERS = [
+    ignore_split_join,
+    ignore_alloc_free,
+    generalize_rotation_angle,
+    generalize_cvs,
+    custom_generalizations,
+]
 
 
 def bin_bloq_counts(bloq) -> Dict[str, int]:
@@ -113,7 +123,7 @@ def bin_bloq_counts(bloq) -> Dict[str, int]:
     for bloq, num_calls in bloq.bloq_counts().items():
         if isinstance(bloq, (Split, Join, Allocate, Free)):
             continue
-        num_t = bloq.call_graph(generalizer=generalize)[1].get(TGate())
+        num_t = bloq.call_graph(generalizer=GENERALIZERS)[1].get(TGate())
         if num_t is not None:
             num_t = int(num_t)
             if isinstance(bloq, bloq_comparators):

--- a/qualtran/bloqs/chemistry/thc/prepare_test.py
+++ b/qualtran/bloqs/chemistry/thc/prepare_test.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 
 import qualtran.testing as qlt_testing
-from qualtran.bloqs.chemistry.thc.notebook_utils import generalize as thc_generalize
+from qualtran.bloqs.chemistry.thc.notebook_utils import GENERALIZERS as THC_GENERALIZERS
 from qualtran.bloqs.chemistry.thc.prepare import (
     _thc_prep,
     _thc_uni,
@@ -76,7 +76,7 @@ def test_prepare_graph():
     num_mu = 10
     num_spin_orb = 4
     uniform_bloq = UniformSuperpositionTHC(num_mu=num_mu, num_spin_orb=num_spin_orb)
-    graph, sigma = uniform_bloq.call_graph(generalizer=thc_generalize)
+    graph, sigma = uniform_bloq.call_graph(generalizer=THC_GENERALIZERS)
     assert isinstance(graph, nx.DiGraph)
     assert isinstance(sigma, dict)
 

--- a/qualtran/bloqs/factoring/mod_exp.py
+++ b/qualtran/bloqs/factoring/mod_exp.py
@@ -11,10 +11,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 from functools import cached_property
-from typing import Dict, Set, Union
+from typing import Dict, Optional, Set, Union
 
+import attrs
 import numpy as np
 import sympy
 from attrs import frozen
@@ -33,6 +33,7 @@ from qualtran import (
 from qualtran.bloqs.basic_gates import IntState
 from qualtran.bloqs.factoring.mod_mul import CtrlModMul
 from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting.generalizers import ignore_split_join
 
 
 @frozen
@@ -123,13 +124,23 @@ class ModExp(Bloq):
         return f'{self.base}^e % {self.mod}'
 
 
-@bloq_example
+_K = sympy.Symbol('k_exp')
+
+
+def _generalize_k(b: Bloq) -> Optional[Bloq]:
+    if isinstance(b, CtrlModMul):
+        return attrs.evolve(b, k=_K)
+
+    return b
+
+
+@bloq_example(generalizer=(ignore_split_join, _generalize_k))
 def _modexp_small() -> ModExp:
     modexp_small = ModExp(base=3, mod=15, exp_bitsize=3, x_bitsize=2048)
     return modexp_small
 
 
-@bloq_example
+@bloq_example(generalizer=(ignore_split_join, _generalize_k))
 def _modexp() -> ModExp:
     modexp = ModExp.make_for_shor(big_n=15 * 17, g=9)
     return modexp

--- a/qualtran/bloqs/swap_network.py
+++ b/qualtran/bloqs/swap_network.py
@@ -39,6 +39,7 @@ from qualtran.bloqs.multi_control_multi_target_pauli import MultiTargetCNOT
 from qualtran.bloqs.unary_iteration_bloq import UnaryIterationGate
 from qualtran.bloqs.util_bloqs import ArbitraryClifford
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
+from qualtran.resource_counting.generalizers import ignore_split_join
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
@@ -242,13 +243,13 @@ class SwapWithZero(GateWithRegisters):
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
 
-@bloq_example
+@bloq_example(generalizer=ignore_split_join)
 def _swz() -> SwapWithZero:
     swz = SwapWithZero(selection_bitsize=8, target_bitsize=32, n_target_registers=4)
     return swz
 
 
-@bloq_example
+@bloq_example(generalizer=ignore_split_join)
 def _swz_small() -> SwapWithZero:
     # A small version on four bits.
     swz_small = SwapWithZero(selection_bitsize=3, target_bitsize=2, n_target_registers=2)

--- a/qualtran/bloqs/swap_network_test.py
+++ b/qualtran/bloqs/swap_network_test.py
@@ -39,6 +39,7 @@ from qualtran.bloqs.util_bloqs import ArbitraryClifford
 from qualtran.cirq_interop.bit_tools import iter_bits
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.cirq_interop.testing import assert_circuit_inp_out_cirqsim, GateHelper
+from qualtran.resource_counting.generalizers import ignore_cliffords
 from qualtran.simulation.tensor import flatten_for_tensor_contraction
 from qualtran.testing import assert_valid_bloq_decomposition, execute_notebook
 
@@ -184,12 +185,7 @@ def test_swap_with_zero_bloq_counts(selection_bitsize, target_bitsize, n_target_
 
     n = sympy.Symbol('n')
 
-    def _gen_clif(bloq: Bloq) -> Bloq:
-        if isinstance(bloq, ArbitraryClifford):
-            return ArbitraryClifford(n)
-        return bloq
-
-    _, sigma = gate.call_graph(generalizer=_gen_clif)
+    _, sigma = gate.call_graph(generalizer=ignore_cliffords)
     assert sigma[TGate()] == want.t
     assert sigma[ArbitraryClifford(n)] == want.clifford
 

--- a/qualtran/conftest.py
+++ b/qualtran/conftest.py
@@ -58,9 +58,24 @@ def assert_bloq_example_decompose_for_pytest(bloq_ex: BloqExample):
         raise bce from bce
 
 
+def assert_equivalent_bloq_example_counts_for_pytest(bloq_ex: BloqExample):
+    try:
+        qlt_testing.assert_equivalent_bloq_example_counts(bloq_ex)
+    except qlt_testing.BloqCheckException as bce:
+        if bce.check_result in [
+            qlt_testing.BloqCheckResult.UNVERIFIED,
+            qlt_testing.BloqCheckResult.NA,
+            qlt_testing.BloqCheckResult.MISSING,
+        ]:
+            pytest.skip(bce.msg)
+
+        raise bce from bce
+
+
 _TESTFUNCS = [
     ('make', assert_bloq_example_make_for_pytest),
     ('decompose', assert_bloq_example_decompose_for_pytest),
+    ('counts', assert_equivalent_bloq_example_counts_for_pytest),
 ]
 
 

--- a/qualtran/resource_counting/__init__.py
+++ b/qualtran/resource_counting/__init__.py
@@ -19,8 +19,11 @@ isort:skip_file
 
 from .bloq_counts import (
     BloqCountT,
+    GeneralizerT,
     big_O,
     SympySymbolAllocator,
     get_bloq_call_graph,
     print_counts_graph,
 )
+
+from . import generalizers

--- a/qualtran/resource_counting/bloq_counts.ipynb
+++ b/qualtran/resource_counting/bloq_counts.ipynb
@@ -246,6 +246,56 @@
     "show_call_graph(graph)\n",
     "show_counts_sigma(sigma)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "250474d1",
+   "metadata": {},
+   "source": [
+    "## Testing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9555fdbf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.generalizers import ignore_cliffords, generalize_cvs\n",
+    "\n",
+    "bloq = MultiAnd(cvs=(1,0,1,0,1,0))\n",
+    "generalizer = (ignore_cliffords, generalize_cvs)\n",
+    "\n",
+    "counts_from_bloq = bloq.bloq_counts(generalizer=generalizer)\n",
+    "print('counts_from_bloq', counts_from_bloq)\n",
+    "cbloq = bloq.decompose_bloq()\n",
+    "counts_from_cbloq = cbloq.bloq_counts(generalizer=generalizer)\n",
+    "print('counts_from_cbloq', counts_from_cbloq)\n",
+    "print(\"Equivalent:\", counts_from_bloq == counts_from_cbloq)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c88072d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.and_bloq import _multi_and\n",
+    "_multi_and"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bf51829",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qualtran.testing as qlt_testing\n",
+    "qlt_testing.check_equivalent_bloq_example_counts(_multi_and)"
+   ]
   }
  ],
  "metadata": {

--- a/qualtran/resource_counting/generalizers.py
+++ b/qualtran/resource_counting/generalizers.py
@@ -1,0 +1,114 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Bloq counting generalizers.
+
+`Bloq.get_bloq_counts_graph(...)` takes a `generalizer` argument which can combine
+multiple bloqs whose attributes differ in ways that do not affect the cost estimates
+into one, more general bloq. The functions in this module can be used as generalizers
+for this argument.
+"""
+from typing import Optional
+
+import attrs
+import sympy
+
+from qualtran import Bloq
+
+PHI = sympy.Symbol(r'\phi')
+CV = sympy.Symbol("cv")
+
+
+def ignore_split_join(b: Bloq) -> Optional[Bloq]:
+    """A generalizer that ignores split and join operations."""
+    from qualtran.bloqs.util_bloqs import Join, Split
+
+    if isinstance(b, (Split, Join)):
+        return None
+    return b
+
+
+def ignore_alloc_free(b: Bloq) -> Optional[Bloq]:
+    """A generalizer that ignores allocations and frees."""
+    from qualtran.bloqs.util_bloqs import Allocate, Free
+
+    if isinstance(b, (Allocate, Free)):
+        return None
+    return b
+
+
+def generalize_rotation_angle(b: Bloq) -> Optional[Bloq]:
+    """A generalizer that replaces rotation angles with a shared symbol."""
+    from qualtran.bloqs.basic_gates import Rx, Ry, Rz
+
+    if isinstance(b, (Rx, Ry, Rz)):
+        return attrs.evolve(b, angle=PHI)
+
+    return b
+
+
+def generalize_cvs(b: Bloq) -> Optional[Bloq]:
+    """A generalizer that replaces control variables with a shared symbol."""
+    from qualtran.bloqs.and_bloq import And
+
+    if isinstance(b, And):
+        return attrs.evolve(b, cv1=CV, cv2=CV)
+
+    return b
+
+
+def ignore_cliffords(b: Bloq) -> Optional[Bloq]:
+    """A generalizer that ignores known clifford bloqs."""
+    from qualtran.bloqs.basic_gates import CNOT, Hadamard, TwoBitSwap, XGate, ZGate
+    from qualtran.bloqs.util_bloqs import ArbitraryClifford
+
+    if isinstance(b, (TwoBitSwap, Hadamard, XGate, ZGate, ArbitraryClifford, CNOT)):
+        return None
+
+    return b
+
+
+def cirq_to_bloqs(b: Bloq) -> Optional[Bloq]:
+    """A generalizer that replaces Cirq gates with their equivalent bloq."""
+    import cirq
+
+    from qualtran.bloqs.basic_gates import CNOT, Hadamard, TGate, Toffoli, TwoBitSwap, XGate, ZGate
+    from qualtran.bloqs.util_bloqs import ArbitraryClifford
+    from qualtran.cirq_interop import CirqGateAsBloq
+
+    if not isinstance(b, CirqGateAsBloq):
+        return b
+
+    gate = b.gate
+    if gate == cirq.T:
+        return TGate()
+    if gate == cirq.T**-1:
+        # TODO
+        return TGate()
+    if gate == cirq.H:
+        return Hadamard()
+    if gate == cirq.CNOT:
+        return CNOT()
+    if gate == cirq.TOFFOLI:
+        return Toffoli()
+    if gate == cirq.X:
+        return XGate()
+    if gate == cirq.Z:
+        return ZGate()
+    if gate == cirq.SWAP:
+        return TwoBitSwap()
+    if gate == cirq.S:
+        return ArbitraryClifford(n=1)
+
+    return b


### PR DESCRIPTION
As part of the autotesting infrastructure, add an automatic check (over all bloq_examples) that checks whether `bloq.bloq_counts() == bloq.decompose_bloq().bloq_counts()`. In addition to PASS or MISSING; this can be UNVERIFIED if only one of (build_call_graph; decomposition) is provided.

This also includes a suite of generalizers to help reconcile any negligible differences between build_call_graph and decomposition. 