### PR TITLE
delete `source dev_tools/pypath` in check scripts

### DIFF
--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -68,8 +68,6 @@ else
     rev="${base}"
 fi
 
-#source dev_tools/pypath
-
 # Run tests while producing coverage files.
 check/pytest --cov \
              --cov-config=dev_tools/conf/.coveragerc \

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -72,6 +72,4 @@ if [ "${num_changed}" -eq 0 ]; then
     exit 0
 fi
 
-source dev_tools/pypath
-
 pytest "${rest[@]}" "${changed[@]}"

--- a/check/pytest-changed-files-and-incremental-coverage
+++ b/check/pytest-changed-files-and-incremental-coverage
@@ -83,8 +83,6 @@ if [ "${#changed_python_tests[@]}" -eq 0 ]; then
     exit 0
 fi
 
-source dev_tools/pypath
-
 # Run tests while producing coverage files.
 check/pytest "${changed_python_tests[@]}" \
     "${cov_changed_python_file_dirs[@]}" \


### PR DESCRIPTION
As file `dev_tools/pypath` does not exist.