### PR TITLE
Fixup clean_notebooks.py

### DIFF
--- a/dev_tools/qualtran_dev_tools/clean_notebooks.py
+++ b/dev_tools/qualtran_dev_tools/clean_notebooks.py
@@ -18,7 +18,7 @@ from tempfile import NamedTemporaryFile
 from typing import List
 
 import nbformat
-from nbconvert.preprocessors import ClearMetadataPreprocessor
+from nbconvert.preprocessors import ClearMetadataPreprocessor, ClearOutputPreprocessor
 
 
 def get_nb_rel_paths(rootdir) -> List[Path]:
@@ -40,8 +40,11 @@ def clean_notebook(nb_path: Path, do_clean: bool = True):
     with nb_path.open() as f:
         nb = nbformat.read(f, as_version=4)
 
-    pp = ClearMetadataPreprocessor(preserve_cell_metadata_mask={'cq.autogen'})
-    nb, resources = pp.preprocess(nb, resources={})
+    pp1 = ClearOutputPreprocessor()
+    pp2 = ClearMetadataPreprocessor(preserve_cell_metadata_mask={'cq.autogen'})
+    resources = {}
+    nb, resources = pp1.preprocess(nb, resources=resources)
+    nb, resources = pp2.preprocess(nb, resources=resources)
 
     with NamedTemporaryFile('w', delete=False) as f:
         nbformat.write(nb, f, version=4)


### PR DESCRIPTION
In #190 I had switched from `jq` to first-party `nbconvert` which has metadata and outputs as two different things one can clear. This didn't show up in my testing since we're actually good about clearing outputs from our committed notebooks :) 