### PR TITLE
Fix CSwap wiresymbols.

### DIFF
--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -34,6 +34,7 @@ from qualtran import (
 )
 from qualtran.bloqs.util_bloqs import ArbitraryClifford
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
+from qualtran.drawing import Circle, TextBox, WireSymbol
 
 from .t_gate import TGate
 
@@ -228,6 +229,14 @@ class CSwap(GateWithRegisters):
                 ("@",) + ("swap_x",) * self.bitsize + ("swap_y",) * self.bitsize
             )
         return cirq.CircuitDiagramInfo(("@",) + ("×(x)",) * self.bitsize + ("×(y)",) * self.bitsize)
+
+    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+        if soq.reg.name == 'x':
+            return TextBox('×(x)')
+        elif soq.reg.name == 'y':
+            return TextBox('×(y)')
+        else:
+            return Circle(filled=True)
 
     def _t_complexity_(self) -> TComplexity:
         return TComplexity(t=7 * self.bitsize, clifford=10 * self.bitsize)


### PR DESCRIPTION
I think there's a more general issue with `wire_symbol_from_gate` in GateWithRegisters (I'll open an issue / take a look), but for sure the CSwap was diagram was not being constructed properly.

Before:
![Screenshot 2023-11-20 at 5 25 06 PM](https://github.com/quantumlib/Qualtran/assets/12097876/0b9df25b-795a-48cb-a6f8-9ae4f6e6d941)

After:
![Screenshot 2023-11-20 at 5 26 05 PM](https://github.com/quantumlib/Qualtran/assets/12097876/dd7e2258-de0a-42f6-996e-e8b4fe3d75e5)
