### PR TITLE
Don't draw axis by default in musical score figures

### DIFF
--- a/qualtran/drawing/musical_score.py
+++ b/qualtran/drawing/musical_score.py
@@ -639,6 +639,7 @@ def draw_musical_score(msd: MusicalScoreData):
 
     ax.set_xlim((-2, msd.max_x + 1))
     ax.set_ylim((-msd.max_y - 0.5, 1))
+    ax.axis('off')
     fig.tight_layout()
     return fig, ax
 


### PR DESCRIPTION
<img width="483" alt="Screenshot 2023-11-27 at 12 00 40 PM" src="https://github.com/quantumlib/Qualtran/assets/12097876/6bc16f13-b8d3-4e13-bd02-beb5686073bc">
<img width="481" alt="Screenshot 2023-11-27 at 12 00 48 PM" src="https://github.com/quantumlib/Qualtran/assets/12097876/55980d79-b14a-40a9-bcb5-efb2a19b36c8">
