### PR TITLE
An assortment of generalizers

### DIFF
--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from qualtran.cirq_interop import CirqQuregT
     from qualtran.cirq_interop.t_complexity_protocol import TComplexity
     from qualtran.drawing import WireSymbol
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountT, GeneralizerT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -281,7 +281,7 @@ class Bloq(metaclass=abc.ABCMeta):
 
     def call_graph(
         self,
-        generalizer: Callable[['Bloq'], Optional['Bloq']] = None,
+        generalizer: Optional[Union['GeneralizerT', Sequence['GeneralizerT']]] = None,
         keep: Optional[Sequence['Bloq']] = None,
         max_depth: Optional[int] = None,
     ) -> Tuple['nx.DiGraph', Dict['Bloq', Union[int, 'sympy.Expr']]]:
@@ -294,7 +294,8 @@ class Bloq(metaclass=abc.ABCMeta):
         Args:
             generalizer: If provided, run this function on each (sub)bloq to replace attributes
                 that do not affect resource estimates with generic sympy symbols. If the function
-                returns `None`, the bloq is omitted from the counts graph.
+                returns `None`, the bloq is omitted from the counts graph. If a sequence of
+                generalizers is provided, each generalizer will be run in order.
             keep: If this function evaluates to True for the current bloq, keep the bloq as a leaf
                 node in the call graph instead of recursing into it.
             max_depth: If provided, build a call graph with at most this many layers.
@@ -311,7 +312,7 @@ class Bloq(metaclass=abc.ABCMeta):
         return get_bloq_call_graph(self, generalizer=generalizer, keep=keep, max_depth=max_depth)
 
     def bloq_counts(
-        self, generalizer: Callable[['Bloq'], Optional['Bloq']] = None
+        self, generalizer: Optional[Union['GeneralizerT', Sequence['GeneralizerT']]] = None
     ) -> Dict['Bloq', Union[int, 'sympy.Expr']]:
         """The number of subbloqs directly called by this bloq.
 
@@ -322,7 +323,8 @@ class Bloq(metaclass=abc.ABCMeta):
         Args:
             generalizer: If provided, run this function on each (sub)bloq to replace attributes
                 that do not affect resource estimates with generic sympy symbols. If the function
-                returns `None`, the bloq is omitted from the counts graph.
+                returns `None`, the bloq is omitted from the counts graph. If a sequence of
+                generalizers is provided, each generalizer will be run in order.
 
         Returns:
             A dictionary mapping subbloq to the number of times they appear in the decomposition.

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -16,7 +16,7 @@
 """Contains the main interface for defining `Bloq`s."""
 
 import abc
-from typing import Any, Callable, Dict, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import Any, Dict, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     import cirq

--- a/qualtran/bloqs/basic_gates/swap_test.py
+++ b/qualtran/bloqs/basic_gates/swap_test.py
@@ -38,7 +38,7 @@ from qualtran.bloqs.basic_gates.swap import (
     _cswap_symb,
     _swap_matrix,
 )
-from qualtran.bloqs.util_bloqs import Join, Split
+from qualtran.resource_counting.generalizers import ignore_split_join
 
 
 def _make_CSwap():
@@ -186,13 +186,7 @@ def test_cswap_bloq_counts():
     bloq = CSwap(bitsize=8)
     counts1 = bloq.bloq_counts()
 
-    def generalize(b: Bloq) -> Optional[Bloq]:
-        if isinstance(b, (Split, Join)):
-            # Ignore these
-            return
-        return b
-
-    counts2 = bloq.decompose_bloq().bloq_counts(generalizer=generalize)
+    counts2 = bloq.decompose_bloq().bloq_counts(generalizer=ignore_split_join)
     assert counts1 == counts2
 
 

--- a/qualtran/bloqs/basic_gates/swap_test.py
+++ b/qualtran/bloqs/basic_gates/swap_test.py
@@ -12,15 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Optional
-
 import cirq
 import numpy as np
 import pytest
 import sympy
 
 import qualtran.testing as qlt_testing
-from qualtran import Bloq, BloqBuilder, DecomposeTypeError
+from qualtran import BloqBuilder, DecomposeTypeError
 from qualtran._infra.gate_with_registers import get_named_qubits
 from qualtran.bloqs.basic_gates import (
     CSwap,

--- a/qualtran/bloqs/chemistry/thc/notebook_utils.py
+++ b/qualtran/bloqs/chemistry/thc/notebook_utils.py
@@ -12,13 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, Optional
 
-import attrs
 import cirq
 
 from qualtran import Bloq
-from qualtran.bloqs.and_bloq import And
 from qualtran.bloqs.arithmetic import (
     EqualsAConstant,
     GreaterThan,
@@ -34,6 +32,12 @@ from qualtran.bloqs.select_swap_qrom import SelectSwapQROM
 from qualtran.bloqs.util_bloqs import Allocate, ArbitraryClifford, Free, Join, Split
 from qualtran.cirq_interop import CirqGateAsBloq
 from qualtran.resource_counting import SympySymbolAllocator
+from qualtran.resource_counting.generalizers import (
+    generalize_cvs,
+    generalize_rotation_angle,
+    ignore_alloc_free,
+    ignore_split_join,
+)
 
 # this code will be cleaned up post cirq_ft alignment:
 # https://github.com/quantumlib/Qualtran/issues/425
@@ -66,24 +70,20 @@ def custom_qroam_repr(self) -> str:
     return f"SelectSwapQROM(target_bitsizes={target_repr}, block_size={self.block_size})"
 
 
+# TODO: better way of customizing label
+SelectSwapQROM.__repr__ = custom_qroam_repr
+
+
 def custom_qrom_repr(self) -> str:
     target_repr = repr(self.target_bitsizes)
     selection_repr = repr(self.selection_bitsizes)
     return f"QROM(selection_bitsizes={selection_repr}, target_bitsizes={target_repr})"
 
 
-def generalize(bloq):
-    """Genereralizer for THC prepare bloqs."""
-    if isinstance(bloq, (Allocate, Free, Split, Join)):
-        return None
-    if isinstance(bloq, (Rx, Ry, Rz)):
-        return attrs.evolve(bloq, angle=phi_sym)
-    if isinstance(bloq, And):
-        return attrs.evolve(bloq, cv1=and_cv0, cv2=and_cv1)
-    if isinstance(bloq, SelectSwapQROM):
-        bloq.__class__.__repr__ = custom_qroam_repr
-    if isinstance(bloq, QROM):
-        bloq.__class__.__repr__ = custom_qrom_repr
+QROM.__repr__ = custom_qrom_repr
+
+
+def custom_generalizations(bloq: Bloq) -> Optional[Bloq]:
     if isinstance(bloq, CirqGateAsBloq):
         if isinstance(bloq.gate, single_qubit_clifford):
             return ArbitraryClifford(n=1)
@@ -96,6 +96,15 @@ def generalize(bloq):
         ):
             return ArbitraryClifford(n=2)
     return bloq
+
+
+GENERALIZERS = [
+    ignore_split_join,
+    ignore_alloc_free,
+    generalize_rotation_angle,
+    generalize_cvs,
+    custom_generalizations,
+]
 
 
 def bin_bloq_counts(bloq: Bloq) -> Dict[str, int]:
@@ -114,7 +123,7 @@ def bin_bloq_counts(bloq: Bloq) -> Dict[str, int]:
     for bloq, num_calls in bloq.bloq_counts().items():
         if isinstance(bloq, (Split, Join, Allocate, Free)):
             continue
-        num_t = bloq.call_graph(generalizer=generalize)[1].get(TGate())
+        num_t = bloq.call_graph(generalizer=GENERALIZERS)[1].get(TGate())
         if num_t is not None:
             num_t = int(num_t)
             if isinstance(bloq, bloq_comparators):

--- a/qualtran/bloqs/chemistry/thc/prepare_test.py
+++ b/qualtran/bloqs/chemistry/thc/prepare_test.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 
 import qualtran.testing as qlt_testing
-from qualtran.bloqs.chemistry.thc.notebook_utils import generalize as thc_generalize
+from qualtran.bloqs.chemistry.thc.notebook_utils import GENERALIZERS as THC_GENERALIZERS
 from qualtran.bloqs.chemistry.thc.prepare import (
     _thc_prep,
     _thc_uni,
@@ -76,7 +76,7 @@ def test_prepare_graph():
     num_mu = 10
     num_spin_orb = 4
     uniform_bloq = UniformSuperpositionTHC(num_mu=num_mu, num_spin_orb=num_spin_orb)
-    graph, sigma = uniform_bloq.call_graph(generalizer=thc_generalize)
+    graph, sigma = uniform_bloq.call_graph(generalizer=THC_GENERALIZERS)
     assert isinstance(graph, nx.DiGraph)
     assert isinstance(sigma, dict)
 

--- a/qualtran/bloqs/swap_network_test.py
+++ b/qualtran/bloqs/swap_network_test.py
@@ -15,11 +15,11 @@
 import random
 from typing import Dict, Tuple
 
+import cirq
 import numpy as np
 import pytest
 import sympy
 
-import cirq
 import qualtran.cirq_interop.testing as cq_testing
 from qualtran import Bloq, BloqBuilder, SelectionRegister
 from qualtran.bloqs.basic_gates import CSwap, TGate

--- a/qualtran/bloqs/swap_network_test.py
+++ b/qualtran/bloqs/swap_network_test.py
@@ -15,11 +15,11 @@
 import random
 from typing import Dict, Tuple
 
-import cirq
 import numpy as np
 import pytest
 import sympy
 
+import cirq
 import qualtran.cirq_interop.testing as cq_testing
 from qualtran import Bloq, BloqBuilder, SelectionRegister
 from qualtran.bloqs.basic_gates import CSwap, TGate
@@ -39,7 +39,6 @@ from qualtran.bloqs.util_bloqs import ArbitraryClifford
 from qualtran.cirq_interop.bit_tools import iter_bits
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.cirq_interop.testing import assert_circuit_inp_out_cirqsim, GateHelper
-from qualtran.resource_counting.generalizers import ignore_cliffords
 from qualtran.simulation.tensor import flatten_for_tensor_contraction
 from qualtran.testing import assert_valid_bloq_decomposition, execute_notebook
 
@@ -185,7 +184,13 @@ def test_swap_with_zero_bloq_counts(selection_bitsize, target_bitsize, n_target_
 
     n = sympy.Symbol('n')
 
-    _, sigma = gate.call_graph(generalizer=ignore_cliffords)
+    def _gen_clif(bloq: Bloq) -> Bloq:
+        if isinstance(bloq, ArbitraryClifford):
+            return ArbitraryClifford(n)
+        return bloq
+
+    _, sigma = gate.call_graph(generalizer=_gen_clif)
+
     assert sigma[TGate()] == want.t
     assert sigma[ArbitraryClifford(n)] == want.clifford
 

--- a/qualtran/bloqs/swap_network_test.py
+++ b/qualtran/bloqs/swap_network_test.py
@@ -39,6 +39,7 @@ from qualtran.bloqs.util_bloqs import ArbitraryClifford
 from qualtran.cirq_interop.bit_tools import iter_bits
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.cirq_interop.testing import assert_circuit_inp_out_cirqsim, GateHelper
+from qualtran.resource_counting.generalizers import ignore_cliffords
 from qualtran.simulation.tensor import flatten_for_tensor_contraction
 from qualtran.testing import assert_valid_bloq_decomposition, execute_notebook
 
@@ -184,12 +185,7 @@ def test_swap_with_zero_bloq_counts(selection_bitsize, target_bitsize, n_target_
 
     n = sympy.Symbol('n')
 
-    def _gen_clif(bloq: Bloq) -> Bloq:
-        if isinstance(bloq, ArbitraryClifford):
-            return ArbitraryClifford(n)
-        return bloq
-
-    _, sigma = gate.call_graph(generalizer=_gen_clif)
+    _, sigma = gate.call_graph(generalizer=ignore_cliffords)
     assert sigma[TGate()] == want.t
     assert sigma[ArbitraryClifford(n)] == want.clifford
 

--- a/qualtran/resource_counting/__init__.py
+++ b/qualtran/resource_counting/__init__.py
@@ -19,9 +19,12 @@ isort:skip_file
 
 from .bloq_counts import (
     BloqCountT,
+    GeneralizerT,
     big_O,
     SympySymbolAllocator,
     get_bloq_call_graph,
     print_counts_graph,
     build_cbloq_call_graph,
 )
+
+from . import generalizers

--- a/qualtran/resource_counting/bloq_counts.py
+++ b/qualtran/resource_counting/bloq_counts.py
@@ -15,7 +15,7 @@
 """Functionality for the `Bloq.call_graph()` protocol."""
 
 from collections import defaultdict
-from typing import Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import networkx as nx
 import sympy
@@ -23,6 +23,7 @@ import sympy
 from qualtran import Bloq, CompositeBloq, DecomposeNotImplementedError, DecomposeTypeError
 
 BloqCountT = Tuple[Bloq, Union[int, sympy.Expr]]
+GeneralizerT = Callable[[Bloq], Optional[Bloq]]
 
 
 def big_O(expr) -> sympy.Order:
@@ -67,7 +68,7 @@ def build_cbloq_call_graph(cbloq: CompositeBloq) -> Set[BloqCountT]:
 
 
 def _generalize_callees(
-    raw_callee_counts: Set[BloqCountT], generalizer: Callable[[Bloq], Optional[Bloq]]
+    raw_callee_counts: Set[BloqCountT], generalizer: GeneralizerT
 ) -> List[BloqCountT]:
     """Apply `generalizer` to the results of `bloq.build_call_graph`.
 
@@ -86,7 +87,7 @@ def _generalize_callees(
 
 def _build_call_graph(
     bloq: Bloq,
-    generalizer: Callable[[Bloq], Optional[Bloq]],
+    generalizer: GeneralizerT,
     ssa: SympySymbolAllocator,
     keep: Callable[[Bloq], bool],
     max_depth: Optional[int],
@@ -164,9 +165,22 @@ def _compute_sigma(root_bloq: Bloq, g: nx.DiGraph) -> Dict[Bloq, Union[int, symp
     return dict(bloq_sigmas[root_bloq])
 
 
+def _make_composite_generalizer(*funcs: GeneralizerT) -> GeneralizerT:
+    """Return a generalizer that calls each `*funcs` generalizers in order."""
+
+    def _composite_generalize(b: Bloq) -> Optional[Bloq]:
+        for func in funcs:
+            b = func(b)
+            if b is None:
+                return
+        return b
+
+    return _composite_generalize
+
+
 def get_bloq_call_graph(
     bloq: Bloq,
-    generalizer: Callable[[Bloq], Optional[Bloq]] = None,
+    generalizer: Optional[Union['GeneralizerT', Sequence['GeneralizerT']]] = None,
     ssa: Optional[SympySymbolAllocator] = None,
     keep: Optional[Callable[[Bloq], bool]] = None,
     max_depth: Optional[int] = None,
@@ -179,7 +193,8 @@ def get_bloq_call_graph(
         bloq: The bloq to count sub-bloqs.
         generalizer: If provided, run this function on each (sub)bloq to replace attributes
             that do not affect resource estimates with generic sympy symbols. If the function
-            returns `None`, the bloq is omitted from the counts graph.
+            returns `None`, the bloq is omitted from the counts graph. If a sequence of
+            generalizers is provided, each generalizer will be run in order.
         ssa: a `SympySymbolAllocator` that will be passed to the `Bloq.build_call_graph` method. If
             your `generalizer` function closes over a `SympySymbolAllocator`, provide it here as
             well. Otherwise, we will create a new allocator.
@@ -200,6 +215,8 @@ def get_bloq_call_graph(
         keep = lambda b: False
     if generalizer is None:
         generalizer = lambda b: b
+    if isinstance(generalizer, (list, tuple)):
+        generalizer = _make_composite_generalizer(*generalizer)
 
     g = nx.DiGraph()
     bloq = generalizer(bloq)

--- a/qualtran/resource_counting/generalizers.py
+++ b/qualtran/resource_counting/generalizers.py
@@ -1,0 +1,110 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Bloq counting generalizers.
+
+`Bloq.get_bloq_counts_graph(...)` takes a `generalizer` argument which can combine
+multiple bloqs whose attributes differ in ways that do not affect the cost estimates
+into one, more general bloq. The functions in this module can be used as generalizers
+for this argument.
+"""
+from typing import Optional
+
+import attrs
+import sympy
+
+from qualtran import Bloq
+
+PHI = sympy.Symbol(r'\phi')
+CV = sympy.Symbol("cv")
+
+
+def ignore_split_join(b: Bloq) -> Optional[Bloq]:
+    """A generalizer that ignores split and join operations."""
+    from qualtran.bloqs.util_bloqs import Join, Split
+
+    if isinstance(b, (Split, Join)):
+        return None
+    return b
+
+
+def ignore_alloc_free(b: Bloq) -> Optional[Bloq]:
+    """A generalizer that ignores allocations and frees."""
+    from qualtran.bloqs.util_bloqs import Allocate, Free
+
+    if isinstance(b, (Allocate, Free)):
+        return None
+    return b
+
+
+def generalize_rotation_angle(b: Bloq) -> Optional[Bloq]:
+    """A generalizer that replaces rotation angles with a shared symbol."""
+    from qualtran.bloqs.basic_gates import Rx, Ry, Rz
+
+    if isinstance(b, (Rx, Ry, Rz)):
+        return attrs.evolve(b, angle=PHI)
+
+    return b
+
+
+def generalize_cvs(b: Bloq) -> Optional[Bloq]:
+    """A generalizer that replaces control variables with a shared symbol."""
+    from qualtran.bloqs.and_bloq import And, MultiAnd
+
+    if isinstance(b, And):
+        return attrs.evolve(b, cv1=CV, cv2=CV)
+    if isinstance(b, MultiAnd):
+        return attrs.evolve(b, cvs=(CV,) * len(b.cvs))
+
+    return b
+
+
+def ignore_cliffords(b: Bloq) -> Optional[Bloq]:
+    """A generalizer that ignores known clifford bloqs."""
+    from qualtran.bloqs.basic_gates import CNOT, Hadamard, TwoBitSwap, XGate, ZGate
+    from qualtran.bloqs.util_bloqs import ArbitraryClifford
+
+    if isinstance(b, (TwoBitSwap, Hadamard, XGate, ZGate, ArbitraryClifford, CNOT)):
+        return None
+
+    return b
+
+
+def cirq_to_bloqs(b: Bloq) -> Optional[Bloq]:
+    """A generalizer that replaces Cirq gates with their equivalent bloq, where possible."""
+    import cirq
+
+    from qualtran.bloqs.basic_gates import CNOT, Hadamard, TGate, Toffoli, TwoBitSwap, XGate, ZGate
+    from qualtran.cirq_interop import CirqGateAsBloq
+
+    if not isinstance(b, CirqGateAsBloq):
+        return b
+
+    gate = b.gate
+    if gate == cirq.T:
+        return TGate()
+    if gate == cirq.H:
+        return Hadamard()
+    if gate == cirq.CNOT:
+        return CNOT()
+    if gate == cirq.TOFFOLI:
+        return Toffoli()
+    if gate == cirq.X:
+        return XGate()
+    if gate == cirq.Z:
+        return ZGate()
+    if gate == cirq.SWAP:
+        return TwoBitSwap()
+
+    return b

--- a/qualtran/resource_counting/generalizers_test.py
+++ b/qualtran/resource_counting/generalizers_test.py
@@ -1,0 +1,165 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import cirq
+
+from qualtran.bloqs.and_bloq import And, MultiAnd
+from qualtran.bloqs.basic_gates import CNOT, Rx, TwoBitSwap
+from qualtran.bloqs.util_bloqs import Allocate, Free, Join, Split
+from qualtran.cirq_interop import CirqGateAsBloq
+from qualtran.resource_counting.bloq_counts import _make_composite_generalizer
+from qualtran.resource_counting.generalizers import (
+    cirq_to_bloqs,
+    CV,
+    generalize_cvs,
+    generalize_rotation_angle,
+    ignore_alloc_free,
+    ignore_cliffords,
+    ignore_split_join,
+    PHI,
+)
+
+_BLOQS_TO_FILTER = [
+    CNOT(),
+    CirqGateAsBloq(cirq.CNOT),
+    Split(n=5),
+    Join(n=5),
+    TwoBitSwap(),
+    And(0, 0),
+    MultiAnd((1, 0, 1, 0)),
+    Rx(0.123),
+    Allocate(n=5),
+    Free(n=5),
+]
+
+
+def test_ignore_split_join():
+    bloqs = [ignore_split_join(b) for b in _BLOQS_TO_FILTER]
+    assert bloqs == [
+        CNOT(),
+        CirqGateAsBloq(cirq.CNOT),
+        None,  # Split(n=5)
+        None,  # Join(n=5)
+        TwoBitSwap(),
+        And(0, 0),
+        MultiAnd((1, 0, 1, 0)),
+        Rx(0.123),
+        Allocate(n=5),
+        Free(n=5),
+    ]
+
+
+def test_ignore_alloc_free():
+    bloqs = [ignore_alloc_free(b) for b in _BLOQS_TO_FILTER]
+    assert bloqs == [
+        CNOT(),
+        CirqGateAsBloq(cirq.CNOT),
+        Split(n=5),
+        Join(n=5),
+        TwoBitSwap(),
+        And(0, 0),
+        MultiAnd((1, 0, 1, 0)),
+        Rx(0.123),
+        None,  # Allocate(n=5)
+        None,  # Free(n=5)
+    ]
+
+
+def test_generalize_rotation_angle():
+    bloqs = [generalize_rotation_angle(b) for b in _BLOQS_TO_FILTER]
+    assert bloqs == [
+        CNOT(),
+        CirqGateAsBloq(cirq.CNOT),
+        Split(n=5),
+        Join(n=5),
+        TwoBitSwap(),
+        And(0, 0),
+        MultiAnd((1, 0, 1, 0)),
+        Rx(PHI),  # this one is generalized
+        Allocate(n=5),
+        Free(n=5),
+    ]
+
+
+def test_generalize_cvs():
+    bloqs = [generalize_cvs(b) for b in _BLOQS_TO_FILTER]
+    assert bloqs == [
+        CNOT(),
+        CirqGateAsBloq(cirq.CNOT),
+        Split(n=5),
+        Join(n=5),
+        TwoBitSwap(),
+        And(CV, CV),  # changed
+        MultiAnd((CV,) * 4),  # changed
+        Rx(0.123),
+        Allocate(n=5),
+        Free(n=5),
+    ]
+
+
+def test_ignore_cliffords():
+    bloqs = [ignore_cliffords(b) for b in _BLOQS_TO_FILTER]
+    assert bloqs == [
+        None,  # CNOT(),
+        CirqGateAsBloq(cirq.CNOT),
+        Split(n=5),
+        Join(n=5),
+        None,  # TwoBitSwap(),
+        And(0, 0),
+        MultiAnd((1, 0, 1, 0)),
+        Rx(0.123),
+        Allocate(n=5),
+        Free(n=5),
+    ]
+
+
+def test_ignore_cliffords_with_cirq():
+    gg = _make_composite_generalizer(cirq_to_bloqs, ignore_cliffords)
+    bloqs = [gg(b) for b in _BLOQS_TO_FILTER]
+    assert bloqs == [
+        None,  # CNOT(),
+        None,  # CirqGateAsBloq(cirq.CNOT),
+        Split(n=5),
+        Join(n=5),
+        None,  # TwoBitSwap(),
+        And(0, 0),
+        MultiAnd((1, 0, 1, 0)),
+        Rx(0.123),
+        Allocate(n=5),
+        Free(n=5),
+    ]
+
+
+def test_many_generalizers():
+    gg = _make_composite_generalizer(
+        cirq_to_bloqs,
+        ignore_cliffords,
+        ignore_alloc_free,
+        ignore_split_join,
+        generalize_cvs,
+        generalize_rotation_angle,
+    )
+    bloqs = [gg(b) for b in _BLOQS_TO_FILTER]
+    bloqs = [b for b in bloqs if b is not None]
+    assert bloqs == [
+        # CNOT(),
+        # CirqGateAsBloq(cirq.CNOT),
+        # Split(n=5),
+        # Join(n=5),
+        # TwoBitSwap(),
+        And(CV, CV),
+        MultiAnd((CV,) * 4),
+        Rx(PHI),
+        # Allocate(n=5),
+        # Free(n=5),
+    ]


### PR DESCRIPTION
When we're computing call graphs, we can "generalize" bloqs: ignore some or lump others together. This PR provides a library of off-the-shelf generator functions and now supports passing in multiple such functions to the public api.

 - Add a type annotation for the generalizer callable interface
 - helper function to turn many generalizers into one generalizer that calls each of them
 - which is used by the new public api: can provide a sequence of generalizers
 - generalizers module contains common generalizer functions
 - use these common functions elsewhere in the library instead of always re-implementing them