### PR TITLE
Factor out generic bloqs for testing

### DIFF
--- a/qualtran/_infra/composite_bloq.ipynb
+++ b/qualtran/_infra/composite_bloq.ipynb
@@ -250,9 +250,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qualtran._infra.composite_bloq_test import Atom, TestSerialBloq, TestParallelBloq\n",
+    "from qualtran.bloqs.for_testing import TestAtom, TestSerialCombo, TestParallelCombo\n",
     "\n",
-    "cbloq = TestParallelBloq().decompose_bloq()\n",
+    "cbloq = TestParallelCombo().decompose_bloq()\n",
     "cbloq2 = cbloq.copy()\n",
     "\n",
     "# They're the same!\n",
@@ -309,7 +309,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cbloq = TestParallelBloq().decompose_bloq()\n",
+    "cbloq = TestParallelCombo().decompose_bloq()\n",
     "\n",
     "with hacked_bb_init():\n",
     "    cbloq2 = cbloq.copy()\n",
@@ -387,8 +387,8 @@
     "# Just call add\n",
     "bb = BloqBuilder()\n",
     "stuff = bb.add_register('stuff', 3)\n",
-    "stuff = bb.add(TestParallelBloq(), stuff=stuff)\n",
-    "stuff = bb.add(TestParallelBloq(), stuff=stuff)\n",
+    "stuff = bb.add(TestParallelCombo(), reg=stuff)\n",
+    "stuff = bb.add(TestParallelCombo(), reg=stuff)\n",
     "bloq = bb.finalize(stuff=stuff)\n",
     "show_bloq(bloq)"
    ]
@@ -403,8 +403,8 @@
     "# `add_from` on second one\n",
     "bb = BloqBuilder()\n",
     "stuff = bb.add_register('stuff', 3)\n",
-    "stuff, = bb.add_t(TestParallelBloq(), stuff=stuff)\n",
-    "stuff, = bb.add_from(TestParallelBloq(), stuff=stuff)\n",
+    "stuff, = bb.add_t(TestParallelCombo(), reg=stuff)\n",
+    "stuff, = bb.add_from(TestParallelCombo(), reg=stuff)\n",
     "bloq = bb.finalize(stuff=stuff)\n",
     "\n",
     "show_bloq(bloq)"
@@ -420,8 +420,8 @@
     "# `add_from` on first one\n",
     "bb = BloqBuilder()\n",
     "stuff = bb.add_register('stuff', 3)\n",
-    "stuff, = bb.add_from(TestParallelBloq(), stuff=stuff)\n",
-    "stuff, = bb.add_t(TestParallelBloq(), stuff=stuff)\n",
+    "stuff, = bb.add_from(TestParallelCombo(), reg=stuff)\n",
+    "stuff, = bb.add_t(TestParallelCombo(), reg=stuff)\n",
     "bloq = bb.finalize(stuff=stuff)\n",
     "\n",
     "show_bloq(bloq)"
@@ -437,9 +437,9 @@
     "# `add_from` on middle one\n",
     "bb = BloqBuilder()\n",
     "stuff = bb.add_register('stuff', 3)\n",
-    "stuff, = bb.add_t(TestParallelBloq(), stuff=stuff)\n",
-    "stuff, = bb.add_from(TestParallelBloq().decompose_bloq(), stuff=stuff)\n",
-    "stuff, = bb.add_t(TestParallelBloq(), stuff=stuff)\n",
+    "stuff, = bb.add_t(TestParallelCombo(), reg=stuff)\n",
+    "stuff, = bb.add_from(TestParallelCombo().decompose_bloq(), reg=stuff)\n",
+    "stuff, = bb.add_t(TestParallelCombo(), reg=stuff)\n",
     "\n",
     "bloq = bb.finalize(stuff=stuff)\n",
     "show_bloq(bloq)"
@@ -470,9 +470,9 @@
     "    def build_composite_bloq(\n",
     "            self, bb: 'BloqBuilder', stuff: 'SoquetT'\n",
     "    ) -> Dict[str, 'SoquetT']:\n",
-    "        stuff = bb.add(TestParallelBloq(), stuff=stuff)\n",
-    "        stuff = bb.add(TestParallelBloq(), stuff=stuff)\n",
-    "        stuff = bb.add(TestParallelBloq(), stuff=stuff)\n",
+    "        stuff = bb.add(TestParallelCombo(), reg=stuff)\n",
+    "        stuff = bb.add(TestParallelCombo(), reg=stuff)\n",
+    "        stuff = bb.add(TestParallelCombo(), reg=stuff)\n",
     "        return {'stuff': stuff}\n",
     "\n",
     "three_p = ThreeParallelBloqs().as_composite_bloq()\n",
@@ -581,7 +581,7 @@
    "source": [
     "from qualtran.bloqs.controlled_bloq import ControlledBloq\n",
     "\n",
-    "bloq = ControlledBloq(subbloq=Atom())\n",
+    "bloq = ControlledBloq(subbloq=TestAtom())\n",
     "show_bloq(bloq)"
    ]
   },
@@ -600,9 +600,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bloq = ControlledBloq(subbloq=TestSerialBloq())\n",
-    "display(show_bloq(bloq))\n",
-    "display(show_bloq(bloq.decompose_bloq()))"
+    "bloq = ControlledBloq(subbloq=TestSerialCombo())\n",
+    "show_bloq(bloq)\n",
+    "show_bloq(bloq.decompose_bloq())"
    ]
   },
   {
@@ -622,9 +622,9 @@
    },
    "outputs": [],
    "source": [
-    "bloq = ControlledBloq(subbloq=TestParallelBloq())\n",
-    "display(show_bloq(bloq))\n",
-    "display(show_bloq(bloq.decompose_bloq()))"
+    "bloq = ControlledBloq(subbloq=TestParallelCombo())\n",
+    "show_bloq(bloq)\n",
+    "show_bloq(bloq.decompose_bloq())"
    ]
   }
  ],

--- a/qualtran/_infra/composite_bloq_test.py
+++ b/qualtran/_infra/composite_bloq_test.py
@@ -20,7 +20,6 @@ import cirq
 import networkx as nx
 import numpy as np
 import pytest
-from attrs import frozen
 from numpy.typing import NDArray
 
 import qualtran.testing as qlt_testing
@@ -39,18 +38,18 @@ from qualtran import (
     Soquet,
     SoquetT,
 )
-from qualtran._infra.bloq_test import TestCNOT
 from qualtran._infra.composite_bloq import _create_binst_graph, _get_dangling_soquets
 from qualtran._infra.gate_with_registers import get_named_qubits
-from qualtran.bloqs.basic_gates import IntEffect, ZeroEffect
+from qualtran.bloqs.basic_gates import CNOT, IntEffect, ZeroEffect
+from qualtran.bloqs.for_testing.atom import TestAtom, TestTwoBitOp
+from qualtran.bloqs.for_testing.with_decomposition import TestParallelCombo, TestSerialCombo
 from qualtran.bloqs.util_bloqs import Join
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 
 
 def _manually_make_test_cbloq_cxns():
     signature = Signature.build(q1=1, q2=1)
     q1, q2 = signature
-    tcn = TestCNOT()
+    tcn = TestTwoBitOp()
     control, target = tcn.signature
     binst1 = BloqInstance(tcn, 1)
     binst2 = BloqInstance(tcn, 2)
@@ -74,8 +73,8 @@ class TestTwoCNOT(Bloq):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', q1: 'Soquet', q2: 'Soquet'
     ) -> Dict[str, SoquetT]:
-        q1, q2 = bb.add(TestCNOT(), control=q1, target=q2)
-        q1, q2 = bb.add(TestCNOT(), control=q2, target=q1)
+        q1, q2 = bb.add(CNOT(), ctrl=q1, target=q2)
+        q1, q2 = bb.add(CNOT(), ctrl=q2, target=q1)
         return {'q1': q1, 'q2': q2}
 
 
@@ -94,29 +93,20 @@ def test_create_binst_graph():
 def test_composite_bloq():
     cxns, signature = _manually_make_test_cbloq_cxns()
     cbloq = CompositeBloq(connections=cxns, signature=signature)
-    circuit, _ = cbloq.to_cirq_circuit(q1=[cirq.LineQubit(1)], q2=[cirq.LineQubit(2)])
-    cirq.testing.assert_has_diagram(
-        circuit,
-        desired="""\
-1: ───@───X───
-      │   │
-2: ───X───@─── \
-    """,
-    )
 
     assert (
         cbloq.debug_text()
         == """\
-TestCNOT()<1>
-  LeftDangle.q1 -> control
+TestTwoBitOp()<1>
+  LeftDangle.q1 -> ctrl
   LeftDangle.q2 -> target
-  control -> TestCNOT()<2>.target
-  target -> TestCNOT()<2>.control
+  ctrl -> TestTwoBitOp()<2>.target
+  target -> TestTwoBitOp()<2>.ctrl
 --------------------
-TestCNOT()<2>
-  TestCNOT()<1>.control -> target
-  TestCNOT()<1>.target -> control
-  control -> RightDangle.q1
+TestTwoBitOp()<2>
+  TestTwoBitOp()<1>.ctrl -> target
+  TestTwoBitOp()<1>.target -> ctrl
+  ctrl -> RightDangle.q1
   target -> RightDangle.q2"""
     )
 
@@ -136,7 +126,7 @@ def test_iter_bloqsoqs():
 
     for binst, isoqs, osoqs in cbloq.iter_bloqsoqs():
         assert isinstance(binst, BloqInstance)
-        assert sorted(isoqs.keys()) == ['control', 'target']
+        assert sorted(isoqs.keys()) == ['ctrl', 'target']
         assert len(osoqs) == 2
 
 
@@ -187,9 +177,9 @@ def test_bloq_builder():
 
     x = initial_soqs['x']
     y = initial_soqs['y']
-    x, y = bb.add(TestCNOT(), control=x, target=y)
+    x, y = bb.add(TestTwoBitOp(), ctrl=x, target=y)
 
-    x, y = bb.add(TestCNOT(), control=x, target=y)
+    x, y = bb.add(TestTwoBitOp(), ctrl=x, target=y)
 
     cbloq = bb.finalize(x=x, y=y)
 
@@ -209,55 +199,57 @@ def test_wrong_soquet():
     bb, x, y = _get_bb()
 
     with pytest.raises(BloqError, match=r'.*is not an available Soquet for .*target.*'):
-        bad_target_arg = Soquet(BloqInstance(TestCNOT(), i=12), Register('target', 2))
-        bb.add(TestCNOT(), control=x, target=bad_target_arg)
+        bad_target_arg = Soquet(BloqInstance(TestTwoBitOp(), i=12), Register('target', 2))
+        bb.add(TestTwoBitOp(), ctrl=x, target=bad_target_arg)
 
 
 def test_double_use_1():
     bb, x, y = _get_bb()
 
-    with pytest.raises(BloqError, match=r'.*is not an available Soquet for `TestCNOT.*target`.*'):
-        bb.add(TestCNOT(), control=x, target=x)
+    with pytest.raises(
+        BloqError, match=r'.*is not an available Soquet for `TestTwoBitOp.*target`.*'
+    ):
+        bb.add(TestTwoBitOp(), ctrl=x, target=x)
 
 
 def test_double_use_2():
     bb, x, y = _get_bb()
 
-    x2, y2 = bb.add(TestCNOT(), control=x, target=y)
+    x2, y2 = bb.add(TestTwoBitOp(), ctrl=x, target=y)
 
     with pytest.raises(
-        BloqError, match=r'.*is not an available Soquet for `TestCNOT\(\)\.control`\.'
+        BloqError, match=r'.*is not an available Soquet for `TestTwoBitOp\(\)\.ctrl`\.'
     ):
-        x3, y3 = bb.add(TestCNOT(), control=x, target=y)
+        x3, y3 = bb.add(TestTwoBitOp(), ctrl=x, target=y)
 
 
 def test_missing_args():
     bb, x, y = _get_bb()
 
-    with pytest.raises(BloqError, match=r'.*requires a Soquet named `control`.'):
-        bb.add(TestCNOT(), target=y)
+    with pytest.raises(BloqError, match=r'.*requires a Soquet named `ctrl`.'):
+        bb.add(TestTwoBitOp(), target=y)
 
 
 def test_too_many_args():
     bb, x, y = _get_bb()
 
     with pytest.raises(BloqError, match=r'.*does not accept Soquets.*another_control.*'):
-        bb.add(TestCNOT(), control=x, target=y, another_control=x)
+        bb.add(TestTwoBitOp(), ctrl=x, target=y, another_control=x)
 
 
 def test_finalize_wrong_soquet():
     bb, x, y = _get_bb()
-    x2, y2 = bb.add(TestCNOT(), control=x, target=y)
+    x2, y2 = bb.add(TestTwoBitOp(), ctrl=x, target=y)
     assert x != x2
     assert y != y2
 
     with pytest.raises(BloqError, match=r'.*is not an available Soquet for .*y.*'):
-        bb.finalize(x=x2, y=Soquet(BloqInstance(TestCNOT(), i=12), Register('target', 2)))
+        bb.finalize(x=x2, y=Soquet(BloqInstance(TestTwoBitOp(), i=12), Register('target', 2)))
 
 
 def test_finalize_double_use_1():
     bb, x, y = _get_bb()
-    x2, y2 = bb.add(TestCNOT(), control=x, target=y)
+    x2, y2 = bb.add(TestTwoBitOp(), ctrl=x, target=y)
 
     with pytest.raises(BloqError, match=r'.*is not an available Soquet for .*y.*'):
         bb.finalize(x=x2, y=x2)
@@ -265,7 +257,7 @@ def test_finalize_double_use_1():
 
 def test_finalize_double_use_2():
     bb, x, y = _get_bb()
-    x2, y2 = bb.add(TestCNOT(), control=x, target=y)
+    x2, y2 = bb.add(TestTwoBitOp(), ctrl=x, target=y)
 
     with pytest.raises(BloqError, match=r'.*is not an available Soquet for `RightDangle\.x`\.'):
         bb.finalize(x=x, y=y2)
@@ -273,7 +265,7 @@ def test_finalize_double_use_2():
 
 def test_finalize_missing_args():
     bb, x, y = _get_bb()
-    x2, y2 = bb.add(TestCNOT(), control=x, target=y)
+    x2, y2 = bb.add(TestTwoBitOp(), ctrl=x, target=y)
 
     with pytest.raises(BloqError, match=r'Finalizing requires a Soquet named `x`.'):
         bb.finalize(y=y2)
@@ -281,7 +273,7 @@ def test_finalize_missing_args():
 
 def test_finalize_strict_too_many_args():
     bb, x, y = _get_bb()
-    x2, y2 = bb.add(TestCNOT(), control=x, target=y)
+    x2, y2 = bb.add(TestTwoBitOp(), ctrl=x, target=y)
 
     bb.add_register_allowed = False
     with pytest.raises(BloqError, match=r'Finalizing does not accept Soquets.*z.*'):
@@ -290,7 +282,7 @@ def test_finalize_strict_too_many_args():
 
 def test_finalize_bad_args():
     bb, x, y = _get_bb()
-    x2, y2 = bb.add(TestCNOT(), control=x, target=y)
+    x2, y2 = bb.add(TestTwoBitOp(), ctrl=x, target=y)
 
     with pytest.raises(BloqError, match=r'.*is not an available Soquet.*RightDangle\.z.*'):
         bb.finalize(x=x2, y=y2, z=Soquet(RightDangle, Register('asdf', 1)))
@@ -298,7 +290,7 @@ def test_finalize_bad_args():
 
 def test_finalize_alloc():
     bb, x, y = _get_bb()
-    x2, y2 = bb.add(TestCNOT(), control=x, target=y)
+    x2, y2 = bb.add(TestTwoBitOp(), ctrl=x, target=y)
     z = bb.allocate(1)
 
     cbloq = bb.finalize(x=x2, y=y2, z=z)
@@ -330,7 +322,7 @@ class TestMultiCNOT(Bloq):
     ) -> Dict[str, SoquetT]:
         for i in range(2):
             for j in range(3):
-                control, target[i, j] = bb.add(TestCNOT(), control=control, target=target[i, j])
+                control, target[i, j] = bb.add(CNOT(), ctrl=control, target=target[i, j])
 
         return {'control': control, 'target': target}
 
@@ -396,52 +388,17 @@ def test_util_convenience_methods_errors():
         bb.free(qs)
 
 
-@frozen
-class Atom(Bloq):
-    @cached_property
-    def signature(self) -> Signature:
-        return Signature.build(stuff=1)
-
-    def t_complexity(self) -> 'TComplexity':
-        return TComplexity(t=100)
-
-
-class TestSerialBloq(Bloq):
-    @cached_property
-    def signature(self) -> Signature:
-        return Signature.build(stuff=1)
-
-    def build_composite_bloq(self, bb: 'BloqBuilder', stuff: 'SoquetT') -> Dict[str, 'Soquet']:
-        for i in range(3):
-            stuff = bb.add(Atom(), stuff=stuff)
-        return {'stuff': stuff}
-
-
-@frozen
-class TestParallelBloq(Bloq):
-    @cached_property
-    def signature(self) -> Signature:
-        return Signature.build(stuff=3)
-
-    def build_composite_bloq(self, bb: 'BloqBuilder', stuff: 'SoquetT') -> Dict[str, 'Soquet']:
-        stuff = bb.split(stuff)
-        for i in range(len(stuff)):
-            stuff[i] = bb.add(Atom(), stuff=stuff[i])
-
-        return {'stuff': bb.join(stuff)}
-
-
-def test_test_serial_bloq_decomp():
-    sbloq = TestSerialBloq()
+def test_test_serial_combo_decomp():
+    sbloq = TestSerialCombo()
     qlt_testing.assert_valid_bloq_decomposition(sbloq)
 
 
-def test_test_parallel_bloq_decomp():
-    pbloq = TestParallelBloq()
+def test_test_parallel_combo_decomp():
+    pbloq = TestParallelCombo()
     qlt_testing.assert_valid_bloq_decomposition(pbloq)
 
 
-@pytest.mark.parametrize('cls', [TestSerialBloq, TestParallelBloq])
+@pytest.mark.parametrize('cls', [TestSerialCombo, TestParallelCombo])
 def test_copy(cls):
     assert cls().supports_decompose_bloq()
     cbloq = cls().decompose_bloq()
@@ -455,39 +412,39 @@ def test_copy(cls):
 def test_add_from(call_decompose):
     bb = BloqBuilder()
     stuff = bb.add_register('stuff', 3)
-    stuff = bb.add(TestParallelBloq(), stuff=stuff)
+    stuff = bb.add(TestParallelCombo(), reg=stuff)
     if call_decompose:
-        (stuff,) = bb.add_from(TestParallelBloq().decompose_bloq(), stuff=stuff)
+        (stuff,) = bb.add_from(TestParallelCombo().decompose_bloq(), reg=stuff)
     else:
-        (stuff,) = bb.add_from(TestParallelBloq(), stuff=stuff)
+        (stuff,) = bb.add_from(TestParallelCombo(), reg=stuff)
     bloq = bb.finalize(stuff=stuff)
     assert (
         bloq.debug_text()
         == """\
-TestParallelBloq()<0>
-  LeftDangle.stuff -> stuff
-  stuff -> Split(n=3)<1>.split
+TestParallelCombo()<0>
+  LeftDangle.stuff -> reg
+  reg -> Split(n=3)<1>.split
 --------------------
 Split(n=3)<1>
-  TestParallelBloq()<0>.stuff -> split
-  split[0] -> Atom()<2>.stuff
-  split[1] -> Atom()<3>.stuff
-  split[2] -> Atom()<4>.stuff
+  TestParallelCombo()<0>.reg -> split
+  split[0] -> TestAtom()<2>.q
+  split[1] -> TestAtom()<3>.q
+  split[2] -> TestAtom()<4>.q
 --------------------
-Atom()<2>
-  Split(n=3)<1>.split[0] -> stuff
-  stuff -> Join(n=3)<5>.join[0]
-Atom()<3>
-  Split(n=3)<1>.split[1] -> stuff
-  stuff -> Join(n=3)<5>.join[1]
-Atom()<4>
-  Split(n=3)<1>.split[2] -> stuff
-  stuff -> Join(n=3)<5>.join[2]
+TestAtom()<2>
+  Split(n=3)<1>.split[0] -> q
+  q -> Join(n=3)<5>.join[0]
+TestAtom()<3>
+  Split(n=3)<1>.split[1] -> q
+  q -> Join(n=3)<5>.join[1]
+TestAtom()<4>
+  Split(n=3)<1>.split[2] -> q
+  q -> Join(n=3)<5>.join[2]
 --------------------
 Join(n=3)<5>
-  Atom()<2>.stuff -> join[0]
-  Atom()<3>.stuff -> join[1]
-  Atom()<4>.stuff -> join[2]
+  TestAtom()<2>.q -> join[0]
+  TestAtom()<3>.q -> join[1]
+  TestAtom()<4>.q -> join[2]
   join -> RightDangle.stuff"""
     )
 
@@ -520,8 +477,8 @@ def test_add_duplicate_register():
 def test_flatten():
     bb = BloqBuilder()
     stuff = bb.add_register('stuff', 3)
-    stuff = bb.add(TestParallelBloq(), stuff=stuff)
-    stuff = bb.add(TestParallelBloq(), stuff=stuff)
+    stuff = bb.add(TestParallelCombo(), reg=stuff)
+    stuff = bb.add(TestParallelCombo(), reg=stuff)
     cbloq = bb.finalize(stuff=stuff)
     assert len(cbloq.bloq_instances) == 2
 
@@ -537,12 +494,12 @@ def test_flatten():
 
 
 def test_t_complexity():
-    assert Atom().t_complexity().t == 100
-    assert TestSerialBloq().decompose_bloq().t_complexity().t == 3 * 100
-    assert TestParallelBloq().decompose_bloq().t_complexity().t == 3 * 100
+    assert TestAtom().t_complexity().t == 100
+    assert TestSerialCombo().decompose_bloq().t_complexity().t == 3 * 100
+    assert TestParallelCombo().decompose_bloq().t_complexity().t == 3 * 100
 
-    assert TestSerialBloq().t_complexity().t == 3 * 100
-    assert TestParallelBloq().t_complexity().t == 3 * 100
+    assert TestSerialCombo().t_complexity().t == 3 * 100
+    assert TestParallelCombo().t_complexity().t == 3 * 100
 
 
 def test_notebook():

--- a/qualtran/_infra/quantum_graph_test.py
+++ b/qualtran/_infra/quantum_graph_test.py
@@ -15,7 +15,7 @@
 import pytest
 
 from qualtran import BloqInstance, DanglingT, LeftDangle, Register, RightDangle, Side, Soquet
-from qualtran._infra.bloq_test import TestCNOT
+from qualtran.bloqs.for_testing import TestAtom, TestTwoBitOp
 
 
 def test_dangling():
@@ -43,14 +43,14 @@ def test_dangling_hash():
 
 
 def test_soquet():
-    soq = Soquet(BloqInstance(TestCNOT(), i=0), Register('x', 10))
+    soq = Soquet(BloqInstance(TestTwoBitOp(), i=0), Register('x', 10))
     assert soq.reg.side is Side.THRU
     assert soq.idx == ()
     assert soq.pretty() == 'x'
 
 
 def test_soquet_idxed():
-    binst = BloqInstance(TestCNOT(), i=0)
+    binst = BloqInstance(TestTwoBitOp(), i=0)
     reg = Register('y', 10, shape=(10, 2))
 
     with pytest.raises(ValueError, match=r'Bad index.*'):
@@ -67,7 +67,7 @@ def test_soquet_idxed():
 
 
 def test_bloq_instance():
-    binst_a = BloqInstance(TestCNOT(), i=1)
-    binst_b = BloqInstance(TestCNOT(), i=1)
+    binst_a = BloqInstance(TestAtom(), i=1)
+    binst_b = BloqInstance(TestAtom(), i=1)
     assert binst_a == binst_b
-    assert str(binst_a) == 'TestCNOT()<1>'
+    assert str(binst_a) == 'TestAtom()<1>'

--- a/qualtran/bloqs/controlled_bloq_test.py
+++ b/qualtran/bloqs/controlled_bloq_test.py
@@ -14,80 +14,83 @@
 
 import pytest
 
-from qualtran._infra.composite_bloq_test import Atom, TestParallelBloq, TestSerialBloq
 from qualtran.bloqs.controlled_bloq import ControlledBloq
+from qualtran.bloqs.for_testing import TestAtom, TestParallelCombo, TestSerialCombo
 from qualtran.testing import assert_valid_bloq_decomposition
 
 
 def test_controlled_serial():
-    bloq = ControlledBloq(subbloq=TestSerialBloq())
+    bloq = ControlledBloq(subbloq=TestSerialCombo())
     cbloq = assert_valid_bloq_decomposition(bloq)
     assert (
         cbloq.debug_text()
         == """\
-C[Atom()]<0>
+C[TestAtom('atom0')]<0>
   LeftDangle.control -> control
-  LeftDangle.stuff -> stuff
-  control -> C[Atom()]<1>.control
-  stuff -> C[Atom()]<1>.stuff
+  LeftDangle.reg -> q
+  control -> C[TestAtom('atom1')]<1>.control
+  q -> C[TestAtom('atom1')]<1>.q
 --------------------
-C[Atom()]<1>
-  C[Atom()]<0>.control -> control
-  C[Atom()]<0>.stuff -> stuff
-  control -> C[Atom()]<2>.control
-  stuff -> C[Atom()]<2>.stuff
+C[TestAtom('atom1')]<1>
+  C[TestAtom('atom0')]<0>.control -> control
+  C[TestAtom('atom0')]<0>.q -> q
+  control -> C[TestAtom('atom2')]<2>.control
+  q -> C[TestAtom('atom2')]<2>.q
 --------------------
-C[Atom()]<2>
-  C[Atom()]<1>.control -> control
-  C[Atom()]<1>.stuff -> stuff
+C[TestAtom('atom2')]<2>
+  C[TestAtom('atom1')]<1>.control -> control
+  C[TestAtom('atom1')]<1>.q -> q
   control -> RightDangle.control
-  stuff -> RightDangle.stuff"""
+  q -> RightDangle.reg"""
     )
 
 
 def test_controlled_parallel():
-    bloq = ControlledBloq(subbloq=TestParallelBloq())
+    bloq = ControlledBloq(subbloq=TestParallelCombo())
     cbloq = assert_valid_bloq_decomposition(bloq)
+    print()
+    print(cbloq.debug_text())
+    print()
     assert (
         cbloq.debug_text()
         == """\
 C[Split(n=3)]<0>
   LeftDangle.control -> control
-  LeftDangle.stuff -> split
-  control -> C[Atom()]<1>.control
-  split[0] -> C[Atom()]<1>.stuff
-  split[1] -> C[Atom()]<2>.stuff
-  split[2] -> C[Atom()]<3>.stuff
+  LeftDangle.reg -> split
+  control -> C[TestAtom()]<1>.control
+  split[0] -> C[TestAtom()]<1>.q
+  split[1] -> C[TestAtom()]<2>.q
+  split[2] -> C[TestAtom()]<3>.q
 --------------------
-C[Atom()]<1>
+C[TestAtom()]<1>
   C[Split(n=3)]<0>.control -> control
-  C[Split(n=3)]<0>.split[0] -> stuff
-  control -> C[Atom()]<2>.control
-  stuff -> C[Join(n=3)]<4>.join[0]
+  C[Split(n=3)]<0>.split[0] -> q
+  control -> C[TestAtom()]<2>.control
+  q -> C[Join(n=3)]<4>.join[0]
 --------------------
-C[Atom()]<2>
-  C[Atom()]<1>.control -> control
-  C[Split(n=3)]<0>.split[1] -> stuff
-  control -> C[Atom()]<3>.control
-  stuff -> C[Join(n=3)]<4>.join[1]
+C[TestAtom()]<2>
+  C[TestAtom()]<1>.control -> control
+  C[Split(n=3)]<0>.split[1] -> q
+  control -> C[TestAtom()]<3>.control
+  q -> C[Join(n=3)]<4>.join[1]
 --------------------
-C[Atom()]<3>
-  C[Atom()]<2>.control -> control
-  C[Split(n=3)]<0>.split[2] -> stuff
+C[TestAtom()]<3>
+  C[TestAtom()]<2>.control -> control
+  C[Split(n=3)]<0>.split[2] -> q
   control -> C[Join(n=3)]<4>.control
-  stuff -> C[Join(n=3)]<4>.join[2]
+  q -> C[Join(n=3)]<4>.join[2]
 --------------------
 C[Join(n=3)]<4>
-  C[Atom()]<3>.control -> control
-  C[Atom()]<3>.stuff -> join[2]
-  C[Atom()]<1>.stuff -> join[0]
-  C[Atom()]<2>.stuff -> join[1]
+  C[TestAtom()]<3>.control -> control
+  C[TestAtom()]<3>.q -> join[2]
+  C[TestAtom()]<1>.q -> join[0]
+  C[TestAtom()]<2>.q -> join[1]
   control -> RightDangle.control
-  join -> RightDangle.stuff"""
+  join -> RightDangle.reg"""
     )
 
 
 def test_doubly_controlled():
     with pytest.raises(NotImplementedError):
         # TODO: https://github.com/quantumlib/Qualtran/issues/149
-        ControlledBloq(ControlledBloq(Atom()))
+        ControlledBloq(ControlledBloq(TestAtom()))

--- a/qualtran/bloqs/for_testing/__init__.py
+++ b/qualtran/bloqs/for_testing/__init__.py
@@ -12,26 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from qualtran import bloq_example, BloqExample
-from qualtran.bloqs.for_testing import TestAtom
-
-
-def _tester_bloq_func() -> TestAtom:
-    return TestAtom()
-
-
-@bloq_example
-def _tester_bloq() -> TestAtom:
-    return TestAtom()
-
-
-def test_bloq_example_explicit():
-    be = BloqExample(func=_tester_bloq_func, name='tester_bloq', bloq_cls=TestAtom)
-    assert be.name == 'tester_bloq'
-    assert be.bloq_cls == TestAtom
-
-
-def test_bloq_example_decorator():
-    be = _tester_bloq
-    assert be.name == 'tester_bloq'
-    assert be.bloq_cls == TestAtom
+from .atom import TestAtom, TestTwoBitOp
+from .many_registers import TestMultiRegister
+from .with_decomposition import TestParallelCombo, TestSerialCombo

--- a/qualtran/bloqs/for_testing/atom.py
+++ b/qualtran/bloqs/for_testing/atom.py
@@ -1,0 +1,113 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from functools import cached_property
+from typing import Any, Dict, Optional, TYPE_CHECKING
+
+import numpy as np
+from attrs import frozen
+
+from qualtran import Bloq, CompositeBloq, DecomposeTypeError, Signature, SoquetT
+from qualtran.cirq_interop.t_complexity_protocol import TComplexity
+
+if TYPE_CHECKING:
+    import quimb.tensor as qtn
+
+
+@frozen(repr=False)
+class TestAtom(Bloq):
+    """An atomic bloq useful for generic testing and demonstration.
+
+    Args:
+        tag: An optional string for differentiating `TestAtom`s.
+
+    Registers:
+        q: One bit
+    """
+
+    tag: Optional[str] = None
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature.build(q=1)
+
+    def decompose_bloq(self) -> 'CompositeBloq':
+        raise DecomposeTypeError(f"{self} is atomic")
+
+    def add_my_tensors(
+        self,
+        tn: 'qtn.TensorNetwork',
+        tag: Any,
+        *,
+        incoming: Dict[str, 'SoquetT'],
+        outgoing: Dict[str, 'SoquetT'],
+    ):
+        import quimb.tensor as qtn
+
+        tn.add(
+            qtn.Tensor(
+                data=np.array([[0, 1], [1, 0]]),
+                inds=(outgoing['q'], incoming['q']),
+                tags=[self.short_name(), tag],
+            )
+        )
+
+    def t_complexity(self) -> 'TComplexity':
+        return TComplexity(100)
+
+    def __repr__(self):
+        if self.tag:
+            return f'TestAtom({self.tag!r})'
+        else:
+            return 'TestAtom()'
+
+    def short_name(self) -> str:
+        if self.tag:
+            return self.tag
+        else:
+            return 'Atom'
+
+
+@frozen
+class TestTwoBitOp(Bloq):
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature.build(ctrl=1, target=1)
+
+    def decompose_bloq(self) -> 'CompositeBloq':
+        raise DecomposeTypeError(f"{self} is atomic")
+
+    def add_my_tensors(
+        self,
+        tn: 'qtn.TensorNetwork',
+        tag: Any,
+        *,
+        incoming: Dict[str, 'SoquetT'],
+        outgoing: Dict[str, 'SoquetT'],
+    ):
+        import quimb.tensor as qtn
+
+        _I = [[1, 0], [0, 1]]
+        _NULL = [[0, 0], [0, 0]]
+        _X = [[0, 1], [1, 0]]
+        tn.add(
+            qtn.Tensor(
+                data=np.array([[_I, _NULL], [_NULL, _X]]),
+                inds=(outgoing['ctrl'], incoming['ctrl'], outgoing['target'], incoming['target']),
+                tags=[self.short_name(), tag],
+            )
+        )
+
+    def short_name(self) -> str:
+        return 'op'

--- a/qualtran/bloqs/for_testing/atom_test.py
+++ b/qualtran/bloqs/for_testing/atom_test.py
@@ -11,27 +11,23 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import numpy as np
+import pytest
 
-from qualtran import bloq_example, BloqExample
-from qualtran.bloqs.for_testing import TestAtom
-
-
-def _tester_bloq_func() -> TestAtom:
-    return TestAtom()
+from qualtran import DecomposeTypeError
+from qualtran.bloqs.for_testing.atom import TestAtom, TestTwoBitOp
 
 
-@bloq_example
-def _tester_bloq() -> TestAtom:
-    return TestAtom()
+def test_test_atom():
+    ta = TestAtom()
+    assert ta.short_name() == 'Atom'
+    with pytest.raises(DecomposeTypeError):
+        ta.decompose_bloq()
 
 
-def test_bloq_example_explicit():
-    be = BloqExample(func=_tester_bloq_func, name='tester_bloq', bloq_cls=TestAtom)
-    assert be.name == 'tester_bloq'
-    assert be.bloq_cls == TestAtom
-
-
-def test_bloq_example_decorator():
-    be = _tester_bloq
-    assert be.name == 'tester_bloq'
-    assert be.bloq_cls == TestAtom
+def test_test_two_bit_op():
+    tba = TestTwoBitOp()
+    assert len(tba.signature) == 2
+    np.testing.assert_allclose(
+        tba.tensor_contract(), np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
+    )

--- a/qualtran/bloqs/for_testing/many_registers.py
+++ b/qualtran/bloqs/for_testing/many_registers.py
@@ -1,0 +1,54 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from functools import cached_property
+from typing import Dict
+
+import numpy as np
+from attrs import frozen
+
+from qualtran import Bloq, Register, Signature
+
+from .atom import TestAtom, TestTwoBitOp
+
+
+@frozen
+class TestMultiRegister(Bloq):
+    """A bloq with multiple, interesting registers.
+
+    Registers:
+        xx: A one-bit register that gets an operation applied to it.
+        yy: A matrix of 2-bit registers each of which gets a two bit operation applied to it.
+        zz: A three-bit register that is split and re-joined.
+    """
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature([Register('xx', 1), Register('yy', 2, shape=(2, 2)), Register('zz', 3)])
+
+    def build_composite_bloq(
+        self, bb: 'BloqBuilder', xx: 'SoquetT', yy: 'SoquetT', zz: 'SoquetT'
+    ) -> Dict[str, 'Soquet']:
+        xx = bb.add(TestAtom(), q=xx)
+        for i in range(2):
+            for j in range(2):
+                a, b = bb.split(yy[i, j])
+                a, b = bb.add(TestTwoBitOp(), ctrl=a, target=b)
+                yy[i, j] = bb.join(np.array([a, b]))
+        a, b, c = bb.split(zz)
+        zz = bb.join(np.array([a, b, c]))
+        return {'xx': xx, 'yy': yy, 'zz': zz}
+
+    def short_name(self) -> str:
+        return 'xyz'

--- a/qualtran/bloqs/for_testing/many_registers_test.py
+++ b/qualtran/bloqs/for_testing/many_registers_test.py
@@ -12,26 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from qualtran import bloq_example, BloqExample
-from qualtran.bloqs.for_testing import TestAtom
+import qualtran.testing as qlt_testing
+from qualtran.bloqs.for_testing.many_registers import TestMultiRegister
 
 
-def _tester_bloq_func() -> TestAtom:
-    return TestAtom()
+def test_test_multi_register():
+    bloq = TestMultiRegister()
+    assert [r.name for r in bloq.signature] == ['xx', 'yy', 'zz']
+    assert sum(r.total_bits() for r in bloq.signature) == 12
 
-
-@bloq_example
-def _tester_bloq() -> TestAtom:
-    return TestAtom()
-
-
-def test_bloq_example_explicit():
-    be = BloqExample(func=_tester_bloq_func, name='tester_bloq', bloq_cls=TestAtom)
-    assert be.name == 'tester_bloq'
-    assert be.bloq_cls == TestAtom
-
-
-def test_bloq_example_decorator():
-    be = _tester_bloq
-    assert be.name == 'tester_bloq'
-    assert be.bloq_cls == TestAtom
+    qlt_testing.assert_valid_bloq_decomposition(bloq)

--- a/qualtran/bloqs/for_testing/with_decomposition.py
+++ b/qualtran/bloqs/for_testing/with_decomposition.py
@@ -1,0 +1,51 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from functools import cached_property
+from typing import Dict
+
+from attrs import frozen
+
+from qualtran import Bloq, Signature, Soquet
+from qualtran.bloqs.for_testing.atom import TestAtom
+
+
+@frozen
+class TestSerialCombo(Bloq):
+    """Made up of three bloqs in serial order."""
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature.build(reg=1)
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', reg: 'SoquetT') -> Dict[str, 'Soquet']:
+        for i in range(3):
+            reg = bb.add(TestAtom(tag=f'atom{i}'), q=reg)
+        return {'reg': reg}
+
+
+@frozen
+class TestParallelCombo(Bloq):
+    """Made up of three bloqs that happen in parallel."""
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature.build(reg=3)
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', reg: 'SoquetT') -> Dict[str, 'Soquet']:
+        reg = bb.split(reg)
+        for i in range(len(reg)):
+            reg[i] = bb.add(TestAtom(), q=reg[i])
+
+        return {'reg': bb.join(reg)}

--- a/qualtran/bloqs/for_testing/with_decomposition_test.py
+++ b/qualtran/bloqs/for_testing/with_decomposition_test.py
@@ -12,26 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from qualtran import bloq_example, BloqExample
-from qualtran.bloqs.for_testing import TestAtom
+import qualtran.testing as qlt_testing
+from qualtran.bloqs.for_testing.with_decomposition import TestParallelCombo, TestSerialCombo
 
 
-def _tester_bloq_func() -> TestAtom:
-    return TestAtom()
+def test_test_serial_combo():
+    qlt_testing.assert_valid_bloq_decomposition(TestSerialCombo())
 
 
-@bloq_example
-def _tester_bloq() -> TestAtom:
-    return TestAtom()
-
-
-def test_bloq_example_explicit():
-    be = BloqExample(func=_tester_bloq_func, name='tester_bloq', bloq_cls=TestAtom)
-    assert be.name == 'tester_bloq'
-    assert be.bloq_cls == TestAtom
-
-
-def test_bloq_example_decorator():
-    be = _tester_bloq
-    assert be.name == 'tester_bloq'
-    assert be.bloq_cls == TestAtom
+def test_test_parallel_combo():
+    qlt_testing.assert_valid_bloq_decomposition(TestParallelCombo())

--- a/qualtran/bloqs/util_bloqs.ipynb
+++ b/qualtran/bloqs/util_bloqs.ipynb
@@ -17,14 +17,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qualtran.drawing import GraphDrawer, PrettyGraphDrawer\n",
+    "from qualtran.drawing import GraphDrawer, PrettyGraphDrawer, show_bloq\n",
     "from qualtran.bloqs.util_bloqs import Split, Join, Partition\n",
     "import numpy as np\n",
     "\n",
-    "from IPython.display import SVG\n",
-    "\n",
-    "def show_bloq(bloq, draw_cls=PrettyGraphDrawer):\n",
-    "    display(SVG(draw_cls(bloq).get_graph().create_svg()))"
+    "from IPython.display import SVG"
    ]
   },
   {
@@ -100,6 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1f3d37be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,6 +116,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "294bf286",
    "metadata": {},
    "source": [
     "## Partition\n",
@@ -128,6 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "95f378f2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,6 +139,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0985a408",
    "metadata": {},
    "source": [
     "An example of using a `Partition` as part of a decomposition is given below:"
@@ -147,76 +148,94 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b12cc1d1",
    "metadata": {},
    "outputs": [],
    "source": [
     "from qualtran import BloqBuilder, Soquet, SoquetT\n",
-    "from qualtran.bloqs.basic_gates import Hadamard, CNOT\n",
-    "\n",
-    "@frozen\n",
-    "class ComplicatedBloq(Bloq):\n",
-    "    @cached_property\n",
-    "    def signature(self) -> Signature:\n",
-    "        return Signature([Register('xx', 1), Register('yy', 2, shape=(2, 2)), Register('zz', 3)])\n",
-    "\n",
-    "    def build_composite_bloq(\n",
-    "        self, bb: 'BloqBuilder', xx: 'SoquetT', yy: 'SoquetT', zz: 'SoquetT'\n",
-    "    ) -> Dict[str, 'Soquet']:\n",
-    "        xx = bb.add(Hadamard(), q=xx)\n",
-    "        for i in range(2):\n",
-    "            for j in range(2):\n",
-    "                a, b = bb.split(yy[i, j])\n",
-    "                a, b = bb.add(CNOT(), ctrl=a, target=b)\n",
-    "                yy[i, j] = bb.join(np.array([a, b]))\n",
-    "        a, b, c = bb.split(zz)\n",
-    "        zz = bb.join(np.array([a, b, c]))\n",
-    "        return {'xx': xx, 'yy': yy, 'zz': zz}\n",
-    "\n",
-    "    def short_name(self) -> str:\n",
-    "        return 'CB'\n",
+    "from qualtran.bloqs.for_testing import TestMultiRegister\n",
     "\n",
     "@frozen\n",
     "class BlackBoxBloq(Bloq):\n",
-    "    test_bloq: Bloq\n",
+    "    subbloq: Bloq\n",
     "\n",
     "    @cached_property\n",
     "    def bitsize(self):\n",
-    "        return sum(reg.total_bits() for reg in self.test_bloq.signature)\n",
-    "\n",
-    "    def short_name(self) -> str:\n",
-    "        return \"BBBloq\" \n",
+    "        return sum(reg.total_bits() for reg in self.subbloq.signature)\n",
     "\n",
     "    @cached_property\n",
     "    def signature(self) -> Signature:\n",
-    "        return Signature.build(test_regs=self.bitsize)\n",
+    "        return Signature.build(system=self.bitsize)\n",
     "\n",
-    "    def build_composite_bloq(self, bb: 'BloqBuilder', test_regs: 'SoquetT') -> Dict[str, 'Soquet']:\n",
-    "        bloq_regs = self.test_bloq.signature\n",
+    "    def build_composite_bloq(self, bb: 'BloqBuilder', system: 'SoquetT') -> Dict[str, 'Soquet']:\n",
+    "        bloq_regs = self.subbloq.signature\n",
     "        partition = Partition(self.bitsize, bloq_regs)\n",
-    "        out_regs = bb.add(partition, x=test_regs)\n",
-    "        out_regs = bb.add(self.test_bloq, **{reg.name: sp for reg, sp in zip(bloq_regs, out_regs)})\n",
-    "        test_regs = bb.add(\n",
-    "            partition.dagger(), **{reg.name: sp for reg, sp in zip(bloq_regs, out_regs)}\n",
+    "        partitioned_vars = bb.add(partition, x=system)\n",
+    "        partitioned_vars = bb.add(\n",
+    "            self.subbloq, **{reg.name: sp for reg, sp in zip(bloq_regs, partitioned_vars)}\n",
     "        )\n",
-    "        return {'test_regs': test_regs}"
+    "        system = bb.add(\n",
+    "            partition.dagger(), **{reg.name: sp for reg, sp in zip(bloq_regs, partitioned_vars)}\n",
+    "        )\n",
+    "        return {'system': system}\n",
+    "    \n",
+    "    def short_name(self) -> str:\n",
+    "        return \"BBBloq\" "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d62031c1",
+   "metadata": {},
+   "source": [
+    "As an example, we'll use the generic `TestMultiRegister` bloq as our sub-bloq with many registers. It does different (contrived) things to the `xx`, `yy`, and `zz` registers:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c0bca171",
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_bloq(BlackBoxBloq(ComplicatedBloq()))"
+    "subbloq = TestMultiRegister()\n",
+    "show_bloq(subbloq.decompose_bloq())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dac7a234",
+   "metadata": {},
+   "source": [
+    "By wrapping it in `BlackBoxBloq`, the previously-complicated signature is now just one register named \"system\" with a larger bitsize."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f84e69ee",
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_bloq(BlackBoxBloq(ComplicatedBloq()).decompose_bloq())"
+    "show_bloq(BlackBoxBloq(subbloq))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a302d6e3",
+   "metadata": {},
+   "source": [
+    "`Partition` adapts between the two register sets. We can inspect this in the decomposition:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb6901a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_bloq(BlackBoxBloq(subbloq).decompose_bloq())"
    ]
   }
  ],
@@ -236,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/qualtran/bloqs/util_bloqs_test.py
+++ b/qualtran/bloqs/util_bloqs_test.py
@@ -21,9 +21,9 @@ import pytest
 from attrs import frozen
 
 from qualtran import Bloq, BloqBuilder, Register, Side, Signature, Soquet, SoquetT
-from qualtran._infra.bloq_test import TestCNOT
 from qualtran._infra.gate_with_registers import get_named_qubits
-from qualtran.bloqs.basic_gates import CNOT, Hadamard, XGate
+from qualtran.bloqs.basic_gates import CNOT, XGate
+from qualtran.bloqs.for_testing import TestMultiRegister
 from qualtran.bloqs.util_bloqs import Allocate, Free, Join, Partition, Split
 from qualtran.simulation.classical_sim import _cbloq_call_classically
 from qualtran.simulation.tensor import bloq_to_dense, cbloq_to_quimb
@@ -61,29 +61,6 @@ def test_util_bloqs():
 
 
 @frozen
-class ComplicatedBloq(Bloq):
-    @cached_property
-    def signature(self) -> Signature:
-        return Signature([Register('xx', 3), Register('yy', 2, shape=(2, 2))])
-
-    def build_composite_bloq(
-        self, bb: 'BloqBuilder', xx: 'SoquetT', yy: 'SoquetT'
-    ) -> Dict[str, 'Soquet']:
-        xs = bb.split(xx)
-        xs[0] = bb.add(Hadamard(), q=xs[0])
-        xx = bb.join(xs)
-        for i in range(2):
-            for j in range(2):
-                a, b = bb.split(yy[i, j])
-                a, b = bb.add(CNOT(), ctrl=a, target=b)
-                yy[i, j] = bb.join(np.array([a, b]))
-        return {'xx': xx, 'yy': yy}
-
-    def short_name(self) -> str:
-        return 'CB'
-
-
-@frozen
 class TestPartition(Bloq):
     test_bloq: Bloq
 
@@ -107,30 +84,39 @@ class TestPartition(Bloq):
 
 
 def test_partition():
-    bloq = TestPartition(test_bloq=TestCNOT())
+    bloq = TestPartition(test_bloq=CNOT())
     assert_valid_bloq_decomposition(bloq)
-    bloq = TestPartition(test_bloq=ComplicatedBloq())
+
+    bloq = TestPartition(test_bloq=TestMultiRegister())
     assert_valid_bloq_decomposition(bloq)
 
 
 def test_partition_tensor_contract():
-    bloq = TestPartition(test_bloq=ComplicatedBloq())
+    bloq = TestPartition(test_bloq=TestMultiRegister())
     tn, _ = cbloq_to_quimb(bloq.decompose_bloq())
     assert len(tn.tensors) == 3
-    assert bloq_to_dense(bloq).shape == (2048, 2048)
+    assert bloq_to_dense(bloq).shape == (4096, 4096)
 
 
 def test_partition_as_cirq_op():
-    bloq = TestPartition(test_bloq=TestCNOT())
+    bloq = TestPartition(test_bloq=CNOT())
     quregs = get_named_qubits(bloq.signature.lefts())
     op, quregs = bloq.as_cirq_op(cirq.ops.SimpleQubitManager(), **quregs)
     unitary = cirq.unitary(cirq.Circuit(op))
     assert np.allclose(unitary, bloq_to_dense(CNOT()))
-    bloq = TestPartition(test_bloq=ComplicatedBloq())
-    quregs = get_named_qubits(bloq.signature.lefts())
-    op, quregs = bloq.as_cirq_op(cirq.ops.SimpleQubitManager(), **quregs)
-    unitary = cirq.unitary(cirq.Circuit(op))
-    assert np.allclose(unitary, bloq_to_dense(bloq))
+
+    bloq = TestPartition(test_bloq=TestMultiRegister())
+    circuit, _ = bloq.decompose_bloq().to_cirq_circuit(
+        cirq.ops.SimpleQubitManager(), test_regs=cirq.NamedQubit.range(12, prefix='system')
+    )
+    assert (
+        circuit.to_text_diagram(transpose=True)
+        == """\
+system0           system1 system2 system3 system4 system5 system6 system7 system8 system9 system10 system11
+│                 │       │       │       │       │       │       │       │       │       │        │
+TestMultiRegister─yy──────yy──────yy──────yy──────yy──────yy──────yy──────yy──────zz──────zz───────zz
+│                 │       │       │       │       │       │       │       │       │       │        │"""
+    )
 
 
 def test_partition_call_classically():

--- a/qualtran/drawing/graphviz.ipynb
+++ b/qualtran/drawing/graphviz.ipynb
@@ -28,7 +28,7 @@
     "from qualtran.drawing import show_bloq\n",
     "\n",
     "# Use some test bloqs to show drawing features\n",
-    "from qualtran.drawing.graphviz_test import Atom, TestParallelBloq"
+    "from qualtran.bloqs.for_testing import TestAtom, TestParallelCombo"
    ]
   },
   {
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_bloq(Atom())"
+    "show_bloq(TestAtom())"
    ]
   },
   {
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_bloq(TestParallelBloq())"
+    "show_bloq(TestParallelCombo())"
    ]
   },
   {
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cbloq = TestParallelBloq().decompose_bloq()\n",
+    "cbloq = TestParallelCombo().decompose_bloq()\n",
     "show_bloq(cbloq)"
    ]
   },

--- a/qualtran/drawing/graphviz_test.py
+++ b/qualtran/drawing/graphviz_test.py
@@ -13,43 +13,17 @@
 #  limitations under the License.
 
 import re
-from functools import cached_property
-from typing import Dict
 
 import IPython.display
 import pytest
-from attrs import frozen
 
-from qualtran import Bloq, BloqBuilder, DecomposeTypeError, Signature, Soquet
+from qualtran.bloqs.for_testing import TestParallelCombo
 from qualtran.drawing.graphviz import _assign_ids_to_bloqs_and_soqs, GraphDrawer, PrettyGraphDrawer
 from qualtran.testing import execute_notebook
 
 
-@frozen
-class Atom(Bloq):
-    @cached_property
-    def signature(self) -> Signature:
-        return Signature.build(q=1)
-
-    def decompose_bloq(self) -> 'CompositeBloq':
-        raise DecomposeTypeError(f"{self} is atomic")
-
-
-class TestParallelBloq(Bloq):
-    @cached_property
-    def signature(self) -> Signature:
-        return Signature.build(stuff=3)
-
-    def build_composite_bloq(self, bb: 'BloqBuilder', stuff: 'SoquetT') -> Dict[str, 'Soquet']:
-
-        qs = bb.split(stuff)
-        for i in range(3):
-            qs[i] = bb.add(Atom(), q=qs[i])
-        return {'stuff': bb.join(qs)}
-
-
 def test_assign_ids():
-    cbloq = TestParallelBloq().decompose_bloq()
+    cbloq = TestParallelCombo().decompose_bloq()
     id_map = _assign_ids_to_bloqs_and_soqs(cbloq.bloq_instances, cbloq.all_soquets)
 
     ids = sorted(id_map.values())
@@ -68,12 +42,12 @@ def test_assign_ids():
             prefixes.add(v)
             continue
         prefixes.add(ma.group(1))
-    assert sorted(prefixes) == ['Atom', 'Join', 'Split', 'join', 'q', 'split', 'stuff']
+    assert sorted(prefixes) == ['Join', 'Split', 'TestAtom', 'join', 'q', 'reg', 'split']
 
 
 @pytest.mark.parametrize('draw_cls', [GraphDrawer, PrettyGraphDrawer])
 def test_graphviz(draw_cls):
-    bloq = TestParallelBloq().decompose_bloq()
+    bloq = TestParallelCombo().decompose_bloq()
     drawer = draw_cls(bloq)
     graph = drawer.get_graph()
     assert len(graph.get_nodes()) == 1 + 3 + 1  # split, atoms, join

--- a/qualtran/serialization/bloq.py
+++ b/qualtran/serialization/bloq.py
@@ -163,16 +163,18 @@ def bloqs_to_proto(
         _add_bloq_to_dict(bloq, bloq_to_idx)
         _populate_bloq_to_idx(bloq, bloq_to_idx, pred, max_depth)
 
+    # Decompose[..]Error is raised if `bloq` does not have a decomposition.
+    # KeyError is raised if `bloq` has a decomposition, but we do not wish to serialize it
+    # because of conditions checked by `pred` and `max_depth`.
+    stop_recursing_exceptions = (DecomposeNotImplementedError, DecomposeTypeError, KeyError)
+
     # `bloq_to_idx` would now contain a list of all bloqs that should be serialized.
     library = bloq_pb2.BloqLibrary(name=name)
     for bloq, bloq_id in bloq_to_idx.items():
         try:
             cbloq = bloq if isinstance(bloq, CompositeBloq) else bloq.decompose_bloq()
             decomposition = [_connection_to_proto(cxn, bloq_to_idx) for cxn in cbloq.connections]
-        except (NotImplementedError, KeyError):
-            # NotImplementedError is raised if `bloq` does not have a decomposition.
-            # KeyError is raises if `bloq` has a decomposition but we do not wish to serialize it
-            # because of conditions checked by `pred` and `max_depth`.
+        except stop_recursing_exceptions:
             decomposition = None
 
         try:
@@ -180,10 +182,7 @@ def bloqs_to_proto(
                 bloq_to_idx[b]: args.int_or_sympy_to_proto(c)
                 for b, c in sorted(bloq.bloq_counts().items(), key=lambda x: x[1])
             }
-        except (NotImplementedError, KeyError):
-            # NotImplementedError is raised if `bloq` does not implement bloq_counts.
-            # KeyError is raises if `bloq` has `bloq_counts` but we do not wish to serialize it
-            # because of conditions checked by `pred` and `max_depth`.
+        except stop_recursing_exceptions:
             bloq_counts = None
 
         library.table.add(

--- a/qualtran/serialization/bloq_test.py
+++ b/qualtran/serialization/bloq_test.py
@@ -20,7 +20,6 @@ import cirq
 import sympy
 
 from qualtran import Bloq, Signature
-from qualtran._infra.bloq_test import TestCNOT
 from qualtran._infra.composite_bloq_test import TestTwoCNOT
 from qualtran.bloqs.controlled_bloq import ControlledBloq
 from qualtran.bloqs.factoring.mod_exp import ModExp
@@ -53,7 +52,6 @@ def test_bloq_to_proto_cnot():
 
 
 def test_cbloq_to_proto_two_cnot():
-    bloq_serialization.RESOLVER_DICT.update({'TestCNOT': TestCNOT})
     bloq_serialization.RESOLVER_DICT.update({'TestTwoCNOT': TestTwoCNOT})
 
     cbloq = TestTwoCNOT().decompose_bloq()
@@ -61,7 +59,6 @@ def test_cbloq_to_proto_two_cnot():
     assert len(proto_lib.table) == 2  # TestTwoCNOT and TestCNOT
     # First one is always the CompositeBloq.
     assert len(proto_lib.table[0].decomposition) == 6
-    assert proto_lib.table[0].bloq.t_complexity.clifford == 2
     # Test round trip.
     assert cbloq in bloq_serialization.bloqs_from_proto(proto_lib)
 


### PR DESCRIPTION
There's been a bunch of ad hoc bloqs in various `*_test.py` files. This PR tries to consolodate some of that into `qualtran.bloqs.for_testing`. Whereas other bloqs in the standard library can and will evolve and have their features change -- theses should be used to test qualtran infra and protocols where a unit test wants to make sure things work on a minimal, generic, unchanging bloq.

This includes one- and two- bit atomic (leaf/non-decomposable) bloqs; two bloqs with decompositions in serial and parallel configuration; and the many-register ("complicatedbloq") from the block encoding tests. 

This PR changes the tests and notebooks to use these centralized generic bloqs.

When a specific bloq property is required for a unit test, we leave those bloqs as defined inside the `_test.py` file. Rule of thumb: if you want to use it in two different test modules consider factoring out. 

