### PR TITLE
`on_classical_vals` consistency

### DIFF
--- a/dev_tools/qualtran_dev_tools/pylint_bloq_checkers.py
+++ b/dev_tools/qualtran_dev_tools/pylint_bloq_checkers.py
@@ -1,0 +1,62 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import Optional
+
+from astroid.nodes import Arguments, ClassDef, FunctionDef
+from pylint.checkers import BaseChecker
+from pylint.lint import PyLinter
+
+
+class BloqClassicalSimChecker(BaseChecker):
+    name = "bloq-classical"
+    msgs = {
+        "W0001": (
+            "Method `on_classical_vals` in %s should have keyword-only arguments.",
+            'bloq-classical-args',
+            None,
+        ),
+        "W0002": (
+            "Override `on_classical_vals`, not `call_classically`.",
+            'bloq-classical-override',
+            None,
+        ),
+    }
+
+    def __init__(self, linter: Optional[PyLinter] = None):
+        super().__init__(linter)
+        self._bloq_classes = set()
+
+    def visit_classdef(self, node: ClassDef):
+        for ancestor in node.ancestors():
+            if ancestor.name == "Bloq":
+                self._bloq_classes.add(node)
+
+    def visit_functiondef(self, node: FunctionDef):
+        if node.name == "on_classical_vals" and node.parent in self._bloq_classes:
+            args: Arguments = node.args
+            argnames = [arg.name for arg in args.arguments]
+            if not argnames == ['self']:
+                self.add_message("bloq-classical-args", node=node, args=node.parent.name)
+            if args.vararg:
+                self.add_message("bloq-classical-args", node=node, args=node.parent.name)
+            if args.kwarg:
+                # this one is less serious
+                self.add_message("bloq-classical-args", node=node, args=node.parent.name)
+
+        if node.name == 'call_classically' and node.parent in self._bloq_classes:
+            self.add_message('bloq-classical-override', node=node)
+
+
+def register(linter):
+    linter.register_checker(BloqClassicalSimChecker(linter))

--- a/qualtran/bloqs/and_bloq.py
+++ b/qualtran/bloqs/and_bloq.py
@@ -239,7 +239,7 @@ class MultiAnd(GateWithRegisters):
         dag = '†' if self.adjoint else ''
         return f'And{dag}'
 
-    def on_classical_vals(self, ctrl: NDArray[np.uint8]) -> Dict[str, NDArray[np.uint8]]:
+    def on_classical_vals(self, *, ctrl: NDArray[np.uint8]) -> Dict[str, NDArray[np.uint8]]:
         if self.adjoint:
             raise NotImplementedError("Come back later.")
 

--- a/qualtran/bloqs/and_bloq.py
+++ b/qualtran/bloqs/and_bloq.py
@@ -24,7 +24,7 @@ to the and of its control registers. `And` will output the result into a fresh r
 
 import itertools
 from functools import cached_property
-from typing import Any, Dict, Set, Tuple
+from typing import Any, Dict, Optional, Set, Tuple
 
 import cirq
 import numpy as np
@@ -95,12 +95,16 @@ class And(GateWithRegisters):
         dag = '†' if self.adjoint else ''
         return f'And{dag}'
 
-    def on_classical_vals(self, ctrl: NDArray[np.uint8]) -> Dict[str, NDArray[np.uint8]]:
-        if self.adjoint:
-            raise NotImplementedError("Come back later.")
+    def on_classical_vals(
+        self, *, ctrl: NDArray[np.uint8], target: Optional[int] = None
+    ) -> Dict[str, NDArray[np.uint8]]:
+        out = 1 if tuple(ctrl) == (self.cv1, self.cv2) else 0
+        if not self.adjoint:
+            return {'ctrl': ctrl, 'target': out}
 
-        target = 1 if tuple(ctrl) == (self.cv1, self.cv2) else 0
-        return {'ctrl': ctrl, 'target': target}
+        # Adjoint
+        assert target == out
+        return {'ctrl': ctrl}
 
     def add_my_tensors(
         self,

--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Iterable, Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import Dict, Iterable, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
 
 import cirq
 import sympy
@@ -66,8 +66,8 @@ class Add(GateWithRegisters, cirq.ArithmeticGate):
         a, b = register_values
         return a, a + b
 
-    def on_classical_vals(self, *args) -> Dict[str, 'ClassicalValT']:
-        return dict(zip([reg.name for reg in self.signature], self.apply(*args)))
+    def on_classical_vals(self, *, a: int, b: int) -> Dict[str, 'ClassicalValT']:
+        return {'a': a, 'b': a + b}
 
     def short_name(self) -> str:
         return "a+b"
@@ -196,9 +196,9 @@ class OutOfPlaceAdder(GateWithRegisters, cirq.ArithmeticGate):
         return a, b, c + a + b
 
     def on_classical_vals(
-        self, a: 'ClassicalValT', b: 'ClassicalValT'
+        self, *, a: 'ClassicalValT', b: 'ClassicalValT'
     ) -> Dict[str, 'ClassicalValT']:
-        return dict(zip('abc', (a, b, a + b)))
+        return {'a': a, 'b': b, 'c': a + b}
 
     def with_registers(self, *new_registers: Union[int, Sequence[int]]):
         raise NotImplementedError("no need to implement with_registers.")
@@ -310,19 +310,32 @@ class AddConstantMod(GateWithRegisters, cirq.ArithmeticGate):
     def with_registers(self, *new_registers: Union[int, Sequence[int]]) -> "AddMod":
         raise NotImplementedError()
 
+    def _classical_unctrled(self, target_val: int):
+        if target_val < self.mod:
+            return (target_val + self.add_val) % self.mod
+        return target_val
+
     def apply(self, *args) -> Union[int, Iterable[int]]:
         target_val = args[-1]
-        if target_val < self.mod:
-            new_target_val = (target_val + self.add_val) % self.mod
-        else:
-            new_target_val = target_val
+        new_target_val = self._classical_unctrled(target_val)
         if self.cvs and args[0] != int(''.join(str(x) for x in self.cvs), 2):
             new_target_val = target_val
         ret = (args[0], new_target_val) if self.cvs else (new_target_val,)
         return ret
 
-    def on_classical_vals(self, *args) -> Dict[str, 'ClassicalValT']:
-        return dict(zip([reg.name for reg in self.signature], self.apply(*args)))
+    def on_classical_vals(
+        self, *, x: int, ctrl: Optional[int] = None
+    ) -> Dict[str, 'ClassicalValT']:
+        out = self._classical_unctrled(x)
+        if self.cvs:
+            assert ctrl is not None
+            if ctrl == int(''.join(str(x) for x in self.cvs), 2):
+                return {'ctrl': ctrl, 'x': out}
+            else:
+                return {'ctrl': ctrl, 'x': x}
+
+        assert ctrl is None
+        return {'x': out}
 
     def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
         wire_symbols = ['@' if b else '@(0)' for b in self.cvs]

--- a/qualtran/bloqs/arithmetic/addition_test.py
+++ b/qualtran/bloqs/arithmetic/addition_test.py
@@ -155,6 +155,13 @@ def test_add():
     cbloq.t_complexity()
 
 
+def test_add_classical():
+    bloq = Add(bitsize=32)
+    ret1 = bloq.call_classically(a=10, b=3)
+    ret2 = bloq.decompose_bloq().call_classically(a=10, b=3)
+    assert ret1 == ret2
+
+
 @pytest.mark.parametrize('bitsize', [3])
 @pytest.mark.parametrize('mod', [5, 8])
 @pytest.mark.parametrize('add_val', [1, 2])

--- a/qualtran/bloqs/arithmetic/addition_test.py
+++ b/qualtran/bloqs/arithmetic/addition_test.py
@@ -38,6 +38,7 @@ def test_add_decomposition(a: int, b: int, num_bits: int):
     op = gate.on_registers(a=qubits[:num_bits], b=qubits[num_bits:])
     greedy_mm = cirq.GreedyQubitManager(prefix="_a", maximize_reuse=True)
     context = cirq.DecompositionContext(greedy_mm)
+    circuit0 = cirq.Circuit(op)
     circuit = cirq.Circuit(cirq.decompose_once(op, context=context))
     ancillas = sorted(circuit.all_qubits())[-num_anc:]
     initial_state = [0] * (2 * num_bits + num_anc)
@@ -47,6 +48,7 @@ def test_add_decomposition(a: int, b: int, num_bits: int):
     final_state[:num_bits] = list(iter_bits(a, num_bits))[::-1]
     final_state[num_bits : 2 * num_bits] = list(iter_bits(a + b, num_bits))[::-1]
     assert_circuit_inp_out_cirqsim(circuit, qubits + ancillas, initial_state, final_state)
+    assert_circuit_inp_out_cirqsim(circuit0, qubits + ancillas, initial_state, final_state)
     # Test diagrams
     expected_wire_symbols = ("In(x)",) * num_bits + ("In(y)/Out(x+y)",) * num_bits
     assert cirq.circuit_diagram_info(gate).wire_symbols == expected_wire_symbols

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -54,8 +54,8 @@ class LessThanConstant(GateWithRegisters, cirq.ArithmeticGate):
         input_val, less_than_val, target_register_val = register_vals
         return input_val, less_than_val, target_register_val ^ (input_val < less_than_val)
 
-    def on_classical_vals(self, x, target) -> Dict[str, 'ClassicalValT']:
-        return dict(zip(['x', 'target'], [x, target ^ (x < self.less_than_val)]))
+    def on_classical_vals(self, *, x: int, target: int) -> Dict[str, 'ClassicalValT']:
+        return {'x': x, 'target': target ^ (x < self.less_than_val)}
 
     def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
         wire_symbols = ["In(x)"] * self.bitsize
@@ -314,8 +314,8 @@ class LessThanEqual(GateWithRegisters, cirq.ArithmeticGate):
         x_val, y_val, target_val = register_vals
         return x_val, y_val, target_val ^ (x_val <= y_val)
 
-    def on_classical_vals(self, *args) -> Dict[str, 'ClassicalValT']:
-        return dict(zip([reg.name for reg in self.signature], self.apply(*args)))
+    def on_classical_vals(self, *, x: int, y: int, target: int) -> Dict[str, 'ClassicalValT']:
+        return {'x': x, 'y': y, 'target': target ^ (x <= y)}
 
     def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
         wire_symbols = ["In(x)"] * self.x_bitsize

--- a/qualtran/bloqs/arithmetic/conversions.py
+++ b/qualtran/bloqs/arithmetic/conversions.py
@@ -65,7 +65,7 @@ class ToContiguousIndex(Bloq):
         )
 
     def on_classical_vals(
-        self, mu: 'ClassicalValT', nu: 'ClassicalValT'
+        self, *, mu: 'ClassicalValT', nu: 'ClassicalValT'
     ) -> Dict[str, 'ClassicalValT']:
         return {'mu': mu, 'nu': nu, 's': nu * (nu + 1) // 2 + mu}
 

--- a/qualtran/bloqs/basic_gates/cnot.py
+++ b/qualtran/bloqs/basic_gates/cnot.py
@@ -29,6 +29,7 @@ from qualtran import (
     Soquet,
     SoquetT,
 )
+from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, ModPlus, WireSymbol
 
 if TYPE_CHECKING:
@@ -92,6 +93,9 @@ class CNOT(Bloq):
 
     def on_classical_vals(self, *, ctrl: int, target: int) -> Dict[str, 'ClassicalValT']:
         return {'ctrl': ctrl, 'target': (ctrl + target) % 2}
+
+    def t_complexity(self) -> 'TComplexity':
+        return TComplexity(clifford=1)
 
     def as_cirq_op(
         self, qubit_manager: 'cirq.QubitManager', ctrl: 'CirqQuregT', target: 'CirqQuregT'

--- a/qualtran/bloqs/basic_gates/cnot.py
+++ b/qualtran/bloqs/basic_gates/cnot.py
@@ -90,7 +90,7 @@ class CNOT(Bloq):
             )
         )
 
-    def on_classical_vals(self, ctrl: int, target: int) -> Dict[str, 'ClassicalValT']:
+    def on_classical_vals(self, *, ctrl: int, target: int) -> Dict[str, 'ClassicalValT']:
         return {'ctrl': ctrl, 'target': (ctrl + target) % 2}
 
     def as_cirq_op(

--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -92,7 +92,7 @@ class TwoBitSwap(Bloq):
         tn.add(qtn.Tensor(data=matrix, inds=out_inds + in_inds, tags=[self.short_name(), tag]))
 
     def on_classical_vals(
-        self, x: 'ClassicalValT', y: 'ClassicalValT'
+        self, *, x: 'ClassicalValT', y: 'ClassicalValT'
     ) -> Dict[str, 'ClassicalValT']:
         return {'x': y, 'y': x}
 
@@ -142,7 +142,7 @@ class TwoBitCSwap(Bloq):
         tn.add(qtn.Tensor(data=matrix, inds=out_inds + in_inds, tags=[self.short_name(), tag]))
 
     def on_classical_vals(
-        self, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'
+        self, *, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'
     ) -> Dict[str, 'ClassicalValT']:
         if ctrl == 0:
             return {'ctrl': 0, 'x': x, 'y': y}
@@ -205,7 +205,7 @@ class CSwap(GateWithRegisters):
         return {(TwoBitCSwap(), self.bitsize)}
 
     def on_classical_vals(
-        self, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'
+        self, *, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'
     ) -> Dict[str, 'ClassicalValT']:
         if ctrl == 0:
             return {'ctrl': 0, 'x': x, 'y': y}

--- a/qualtran/bloqs/basic_gates/toffoli.py
+++ b/qualtran/bloqs/basic_gates/toffoli.py
@@ -56,7 +56,7 @@ class Toffoli(Bloq):
         return TComplexity(t=4)
 
     def on_classical_vals(
-        self, ctrl: 'ClassicalValT', target: 'ClassicalValT'
+        self, *, ctrl: 'ClassicalValT', target: 'ClassicalValT'
     ) -> Dict[str, 'ClassicalValT']:
         assert target in [0, 1]
         if ctrl[0] == 1 and ctrl[1] == 1:

--- a/qualtran/bloqs/basic_gates/x_basis.py
+++ b/qualtran/bloqs/basic_gates/x_basis.py
@@ -166,7 +166,7 @@ class XGate(Bloq):
     def short_name(self) -> str:
         return 'X'
 
-    def on_classical_vals(self, q: int) -> Dict[str, 'ClassicalValT']:
+    def on_classical_vals(self, *, q: int) -> Dict[str, 'ClassicalValT']:
         return {'q': (q + 1) % 2}
 
     def as_cirq_op(

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Any, Dict, Set, Tuple, TYPE_CHECKING, Union
+from typing import Any, Dict, Optional, Set, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import numpy as np
@@ -94,7 +94,7 @@ class _ZVector(Bloq):
             )
         )
 
-    def on_classical_vals(self, **vals: int) -> Dict[str, int]:
+    def on_classical_vals(self, *, q: Optional[int] = None) -> Dict[str, int]:
         """Return or consume 1 or 0 depending on `self.state` and `self.bit`.
 
         If `self.state`, we return a bit in the `q` register. Otherwise,
@@ -102,11 +102,9 @@ class _ZVector(Bloq):
         """
         bit_int = 1 if self.bit else 0  # guard against bad `self.bit` types.
         if self.state:
-            assert not vals, vals
+            assert q is None
             return {'q': bit_int}
 
-        q = vals.pop('q')
-        assert not vals, vals
         assert q == bit_int, q
         return {}
 
@@ -326,12 +324,12 @@ class _IntVector(Bloq):
 
         tn.add(qtn.Tensor(data=data, inds=inds, tags=[self.short_name(), tag]))
 
-    def on_classical_vals(self, **vals: 'ClassicalValT') -> Dict[str, int]:
+    def on_classical_vals(self, *, val: Optional[int] = None) -> Dict[str, int]:
         if self.state:
-            assert not vals
+            assert val is None
             return {'val': self.val}
 
-        assert vals['val'] == self.val, vals['val']
+        assert val == self.val, val
 
     def t_complexity(self) -> 'TComplexity':
         return TComplexity()

--- a/qualtran/bloqs/factoring/mod_add.py
+++ b/qualtran/bloqs/factoring/mod_add.py
@@ -63,7 +63,7 @@ class CtrlScaleModAdd(Bloq):
         return n * bloq.t_complexity()
 
     def on_classical_vals(
-        self, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'
+        self, *, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'
     ) -> Dict[str, 'ClassicalValT']:
         if ctrl == 0:
             return {'ctrl': 0, 'x': x, 'y': y}

--- a/qualtran/bloqs/factoring/mod_exp.py
+++ b/qualtran/bloqs/factoring/mod_exp.py
@@ -116,7 +116,7 @@ class ModExp(Bloq):
             (self._CtrlModMul(k=k), self.exp_bitsize),
         }
 
-    def on_classical_vals(self, exponent: int):
+    def on_classical_vals(self, *, exponent: int):
         return {'exponent': exponent, 'x': (self.base**exponent) % self.mod}
 
     def short_name(self) -> str:

--- a/qualtran/bloqs/factoring/mod_mul.py
+++ b/qualtran/bloqs/factoring/mod_mul.py
@@ -87,7 +87,7 @@ class CtrlModMul(Bloq):
         k = ssa.new_symbol('k')
         return {(self._Add(k=k), 2), (CSwap(self.bitsize), 1)}
 
-    def on_classical_vals(self, ctrl, x) -> Dict[str, ClassicalValT]:
+    def on_classical_vals(self, *, ctrl, x) -> Dict[str, ClassicalValT]:
         if ctrl == 0:
             return {'ctrl': ctrl, 'x': x}
 

--- a/qualtran/bloqs/swap_network.py
+++ b/qualtran/bloqs/swap_network.py
@@ -94,7 +94,7 @@ class CSwapApprox(GateWithRegisters):
         yield [g_on_y, cnot_x_to_y, g_on_y, cnot_y_to_x]
 
     def on_classical_vals(
-        self, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'
+        self, *, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'
     ) -> Dict[str, 'ClassicalValT']:
         if ctrl == 0:
             return {'ctrl': 0, 'x': x, 'y': y}

--- a/qualtran/bloqs/util_bloqs.py
+++ b/qualtran/bloqs/util_bloqs.py
@@ -216,35 +216,41 @@ class Partition(Bloq):
             )
         )
 
-    def on_classical_vals(self, **vals: 'ClassicalValT') -> Dict[str, int]:
+    def _classical_partition(self, x: int) -> Dict[str, 'ClassicalValT']:
+        out_vals = {}
+        xbits = ints_to_bits(x, self.n)[0]
+        start = 0
+        for reg in self.regs:
+            size = np.prod(reg.shape + (reg.bitsize,))
+            bits_reg = xbits[start : start + size]
+            if reg.shape == ():
+                out_vals[reg.name] = bits_to_ints(bits_reg)[0]
+            else:
+                ints_reg = bits_to_ints(
+                    [
+                        bits_reg[i * reg.bitsize : (i + 1) * reg.bitsize]
+                        for i in range(np.prod(reg.shape))
+                    ]
+                )
+                out_vals[reg.name] = np.array(ints_reg).reshape(reg.shape)
+            start += size
+        return out_vals
+
+    def _classical_unpartition(self, **vals: 'ClassicalValT'):
+        out_vals = []
+        for reg in self.regs:
+            if isinstance(vals[reg.name], np.ndarray):
+                out_vals.append(ints_to_bits(vals[reg.name].ravel(), reg.bitsize).ravel())
+            else:
+                out_vals.append(ints_to_bits(vals[reg.name], reg.bitsize)[0])
+        big_int = np.concatenate(out_vals)
+        return {'x': bits_to_ints(big_int)[0]}
+
+    def on_classical_vals(self, **vals: 'ClassicalValT') -> Dict[str, 'ClassicalValT']:
         if self.partition:
-            out_vals = {}
-            xbits = ints_to_bits(vals['x'], self.n)[0]
-            start = 0
-            for reg in self.regs:
-                size = np.prod(reg.shape + (reg.bitsize,))
-                bits_reg = xbits[start : start + size]
-                if reg.shape == ():
-                    out_vals[reg.name] = bits_to_ints(bits_reg)[0]
-                else:
-                    ints_reg = bits_to_ints(
-                        [
-                            bits_reg[i * reg.bitsize : (i + 1) * reg.bitsize]
-                            for i in range(np.prod(reg.shape))
-                        ]
-                    )
-                    out_vals[reg.name] = np.array(ints_reg).reshape(reg.shape)
-                start += size
-            return out_vals
+            return self._classical_partition(vals['x'])
         else:
-            out_vals = []
-            for reg in self.regs:
-                if isinstance(vals[reg.name], np.ndarray):
-                    out_vals.append(ints_to_bits(vals[reg.name].ravel(), reg.bitsize).ravel())
-                else:
-                    out_vals.append(ints_to_bits(vals[reg.name], reg.bitsize)[0])
-            big_int = np.concatenate(out_vals)
-            return {'x': bits_to_ints(big_int)[0]}
+            return self._classical_unpartition(**vals)
 
     def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
         if soq.reg.shape:

--- a/qualtran/bloqs/util_bloqs.py
+++ b/qualtran/bloqs/util_bloqs.py
@@ -62,7 +62,7 @@ class Split(Bloq):
     def t_complexity(self) -> 'TComplexity':
         return TComplexity()
 
-    def on_classical_vals(self, split: int) -> Dict[str, 'ClassicalValT']:
+    def on_classical_vals(self, *, split: int) -> Dict[str, 'ClassicalValT']:
         return {'split': ints_to_bits(np.array([split]), self.n)[0]}
 
     def add_my_tensors(
@@ -129,7 +129,7 @@ class Join(Bloq):
             )
         )
 
-    def on_classical_vals(self, join: 'NDArray[np.uint8]') -> Dict[str, int]:
+    def on_classical_vals(self, *, join: 'NDArray[np.uint8]') -> Dict[str, int]:
         return {'join': bits_to_ints(join)[0]}
 
     def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
@@ -288,7 +288,7 @@ class Free(Bloq):
     def signature(self) -> Signature:
         return Signature([Register('free', bitsize=self.n, side=Side.LEFT)])
 
-    def on_classical_vals(self, free: int) -> Dict[str, 'ClassicalValT']:
+    def on_classical_vals(self, *, free: int) -> Dict[str, 'ClassicalValT']:
         if free != 0:
             raise ValueError(f"Tried to free a non-zero register: {free}.")
         return {}

--- a/qualtran/cirq_interop/_cirq_to_bloq_test.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq_test.py
@@ -31,7 +31,7 @@ from qualtran import (
 )
 from qualtran._infra.gate_with_registers import get_named_qubits
 from qualtran.bloqs.and_bloq import And
-from qualtran.bloqs.basic_gates import OneState
+from qualtran.bloqs.basic_gates import CNOT, OneState
 from qualtran.bloqs.util_bloqs import Allocate, Free, Join, Split
 from qualtran.cirq_interop import cirq_optree_to_cbloq, CirqGateAsBloq, CirqQuregT
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
@@ -216,7 +216,7 @@ def test_cirq_gate_as_bloq_for_left_only_gates():
     bloqs_list = [binst.bloq for binst in cbloq.bloq_instances]
     assert bloqs_list.count(Split(2)) == 1
     assert bloqs_list.count(Free(1)) == 2
-    assert bloqs_list.count(CirqGateAsBloq(cirq.CNOT)) == 1
+    assert bloqs_list.count(CNOT()) == 1
     assert bloqs_list.count(CirqGateAsBloq(cirq.ResetChannel())) == 2
 
 


### PR DESCRIPTION
 - add a pylint checker (manual use only, for now)
 - use keyword arguments everywhere
 - some style commits
 - Fix the `on_classical_vals` methods in arithmetic bloqs

Then there's a more controversial commit that lets us use the classical sim protocol on cirq-ft-style bloqs. 

Take a look; The commits should be pretty atomic and I can pull out the less controversial ones; let me know