### PR TITLE
Fixes bug with addition endianness.

### DIFF
--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -66,8 +66,10 @@ class Add(GateWithRegisters, cirq.ArithmeticGate):
         a, b = register_values
         return a, a + b
 
-    def on_classical_vals(self, *args) -> Dict[str, 'ClassicalValT']:
-        return dict(zip([reg.name for reg in self.signature], self.apply(*args)))
+    def on_classical_vals(
+        self, a: 'ClassicalValT', b: 'ClassicalValT'
+    ) -> Dict[str, 'ClassicalValT']:
+        return {'a': a, 'b': a + b}
 
     def short_name(self) -> str:
         return "a+b"
@@ -103,9 +105,10 @@ class Add(GateWithRegisters, cirq.ArithmeticGate):
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
     ) -> cirq.OP_TREE:
-        input_bits = quregs['a']
-        output_bits = quregs['b']
-        ancillas = context.qubit_manager.qalloc(self.bitsize - 1)
+        # reverse the order of qubits for big endian-ness.
+        input_bits = quregs['a'][::-1]
+        output_bits = quregs['b'][::-1]
+        ancillas = context.qubit_manager.qalloc(self.bitsize - 1)[::-1]
         # Start off the addition by anding into the ancilla
         yield And().on(input_bits[0], output_bits[0], ancillas[0])
         # Left part of Fig.2

--- a/qualtran/bloqs/arithmetic/addition_test.py
+++ b/qualtran/bloqs/arithmetic/addition_test.py
@@ -39,6 +39,7 @@ def test_add_decomposition(a: int, b: int, num_bits: int):
     greedy_mm = cirq.GreedyQubitManager(prefix="_a", maximize_reuse=True)
     context = cirq.DecompositionContext(greedy_mm)
     circuit = cirq.Circuit(cirq.decompose_once(op, context=context))
+    circuit0 = cirq.Circuit(op)
     ancillas = sorted(circuit.all_qubits())[-num_anc:]
     initial_state = [0] * (2 * num_bits + num_anc)
     initial_state[:num_bits] = list(iter_bits(a, num_bits))
@@ -47,11 +48,15 @@ def test_add_decomposition(a: int, b: int, num_bits: int):
     final_state[:num_bits] = list(iter_bits(a, num_bits))
     final_state[num_bits : 2 * num_bits] = list(iter_bits(a + b, num_bits))
     assert_circuit_inp_out_cirqsim(circuit, qubits + ancillas, initial_state, final_state)
+    assert_circuit_inp_out_cirqsim(
+        circuit0, qubits, initial_state[:-num_anc], final_state[:-num_anc]
+    )
     # Test diagrams
     expected_wire_symbols = ("In(x)",) * num_bits + ("In(y)/Out(x+y)",) * num_bits
     assert cirq.circuit_diagram_info(gate).wire_symbols == expected_wire_symbols
     # Test with_registers
     assert gate.with_registers([2] * 6, [2] * 6) == Add(6)
+    # test no decompose with same inputs
 
 
 def test_add_truncated():


### PR DESCRIPTION
I needed to reverse the qubit order in the cirq decomposition to ensure big-endianness was preserved (the giveaway was the original unit test was reversing the iter_bits list of bits).