### PR TITLE
Add THC rotations.

### DIFF
--- a/dev_tools/autogenerate-bloqs-notebooks-v2.py
+++ b/dev_tools/autogenerate-bloqs-notebooks-v2.py
@@ -57,6 +57,8 @@ import qualtran.bloqs.chemistry.pbc.first_quantization.projectile.select_and_pre
 import qualtran.bloqs.chemistry.sf.single_factorization
 import qualtran.bloqs.chemistry.sparse.prepare
 import qualtran.bloqs.chemistry.sparse.select_bloq
+import qualtran.bloqs.chemistry.thc.prepare
+import qualtran.bloqs.chemistry.thc.select_bloq
 import qualtran.bloqs.factoring.mod_exp
 import qualtran.bloqs.multi_control_multi_target_pauli
 import qualtran.bloqs.prepare_uniform_superposition
@@ -152,6 +154,17 @@ NOTEBOOK_SPECS: List[NotebookSpecV2] = [
             qualtran.bloqs.chemistry.sf.single_factorization._SF_BLOCK_ENCODING,
         ],
         directory=f'{SOURCE_DIR}/bloqs/chemistry/sf',
+    ),
+    NotebookSpecV2(
+        title='Tensor Hypercontraction',
+        module=qualtran.bloqs.chemistry.thc,
+        bloq_specs=[
+            qualtran.bloqs.chemistry.thc.prepare._THC_UNI_PREP,
+            qualtran.bloqs.chemistry.thc.prepare._THC_PREPARE,
+            qualtran.bloqs.chemistry.thc.select_bloq._THC_ROTATIONS,
+            qualtran.bloqs.chemistry.thc.select_bloq._THC_SELECT,
+        ],
+        directory=f'{SOURCE_DIR}/bloqs/chemistry/thc',
     ),
     NotebookSpecV2(
         title='Block Encoding',

--- a/qualtran/bloqs/chemistry/thc/select_bloq.py
+++ b/qualtran/bloqs/chemistry/thc/select_bloq.py
@@ -15,8 +15,10 @@
 from functools import cached_property
 from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
 
+import cirq
 import numpy as np
 from attrs import frozen
+from numpy.typing import NDArray
 
 from qualtran import (
     Bloq,
@@ -28,35 +30,125 @@ from qualtran import (
     Signature,
     SoquetT,
 )
-from qualtran.bloqs.basic_gates import CSwap, Toffoli, XGate
+from qualtran.bloqs.basic_gates import CNOT, CSwap, Hadamard, Toffoli, XGate
 from qualtran.bloqs.chemistry.black_boxes import ApplyControlledZs
+from qualtran.bloqs.qrom import QROM
 from qualtran.bloqs.select_and_prepare import SelectOracle
+from qualtran.cirq_interop import CirqGateAsBloq
+from qualtran.cirq_interop.bit_tools import iter_bits_fixed_point
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+
+
+def find_givens_angles(chi: NDArray[np.float64], num_bits_prec: int = 20) -> Tuple[Tuple[int]]:
+    """Find rotation angles for givens rotations.
+
+    Args:
+        chi: THC leaf tensor of shape [num_spatial_orbs, num_mu]. Assumed that
+            each column is individually normalized.
+        num_bits_prec: The number of bits of precision with which to represent
+            the angles as fixed point floats.
+
+    Returns:
+        thetas: An [num_mu, num_spatial_orbitals, num_bits_prec] array of rotation angles.
+
+    References:
+        https://arxiv.org/pdf/2007.14460.pdf Eq. 57
+    """
+    thetas = np.zeros(chi.T.shape, dtype=int)
+    for mu, chi_mu in enumerate(chi.T):
+        div_fac = 1.0
+        for p, u_p in enumerate(chi_mu):
+            rhs = u_p / (2 * div_fac)
+            if abs(rhs) > 0.5:
+                rhs = 0.5 * np.sign(rhs)
+            theta_p = 0.5 * np.arccos(rhs)
+            div_fac *= np.sin(2 * theta_p)
+            theta_p_fp = ''.join(
+                str(b) for b in iter_bits_fixed_point(theta_p, width=num_bits_prec)
+            )
+            thetas[mu, p] = int(theta_p_fp, 2)
+    # for qrom we want to load num_spatial_orbs data sets for each mu
+    return tuple(tuple(int(tm) for tm in tp) for tp in thetas.T)
+
+
+@frozen
+class InterleavedCliffordA(Bloq):
+    r"""Clifford gates required to apply $e^{i \theta X_a Y_b}$ using just $R_z$ gates."""
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature.build(a=1, b=1)
+
+    def pretty_name(self) -> str:
+        return "CA"
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', a: SoquetT, b: SoquetT):
+        a = bb.add(Hadamard(), q=a)
+        b = bb.add(CirqGateAsBloq(cirq.S**-1), q=b)
+        b = bb.add(Hadamard(), q=b)
+        a, b = bb.add(CNOT(), ctrl=a, target=b)
+        return {'a': a, 'b': b}
+
+
+@frozen
+class InterleavedCliffordB(Bloq):
+    r"""Clifford gates required to apply $e^{i \theta Y_a X_b}$ using just $R_z$ gates."""
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature.build(a=1, b=1)
+
+    def pretty_name(self) -> str:
+        return "CB"
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', a: SoquetT, b: SoquetT):
+        a = bb.add(CirqGateAsBloq(cirq.S**-1), q=a)
+        a = bb.add(Hadamard(), q=a)
+        b = bb.add(Hadamard(), q=b)
+        a, b = bb.add(CNOT(), ctrl=a, target=b)
+        return {'a': a, 'b': b}
+
+
+@frozen
+class PhaseGradientRz(Bloq):
+    """Placeholder for Rz rotation using phase gradient register/gate.
+
+    Args:
+        bitsize: the number of bits of precision for the rotation angle.
+
+    Regerence
+        [Even more efficient quantum computations of chemistry through
+            tensor hypercontraction](https://arxiv.org/pdf/2011.03494.pdf) Listing. 3, page 17.
+    """
+
+    bitsize: int
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature.build(data=self.bitsize, target=1)
+
+    def short_name(self) -> str:
+        return r"$R_z(\theta)$"
+
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+        rot_cost = self.bitsize - 2
+        return {(Toffoli(), rot_cost)}
 
 
 @frozen
 class THCRotations(Bloq):
     r"""Bloq for rotating into THC basis through Givens rotation network.
 
-    This is accounting for In-data:rot and In-R in Fig. 7 of the THC paper (Ref.
-    1). In practice this bloq is made up of a QROM load of the angles followed
-    by controlled rotations. Equivalently it can be built from a modified
-    version of the ProgrammableRotationGateArray from implemented in qualtran
-    from Ref. 2. This is a placeholder waiting for an actual implementation.
-    See https://github.com/quantumlib/Qualtran/issues/386.
+    This is accounting for In-R in Fig. 7 of the THC paper (Ref.
+    1).
 
     Args:
         num_mu: THC auxiliary index dimension $M$
         num_spin_orb: number of spin orbitals $N$
         num_bits_theta: Number of bits of precision for the rotations. Called
             $\beth$ in the reference.
-        kr1: block sizes for QROM erasure for outputting rotation angles. See Eq 34.
-        kr2: block sizes for QROM erasure for outputting rotation angles. This
-            is for the second QROM (eq 35)
-        two_body_only: Whether to only apply the two body Hamiltonian. This reduces the QROM size.
-        adjoint: Whether to dagger this bloq or not.
 
     References:
         [Even more efficient quantum computations of chemistry through
@@ -68,48 +160,56 @@ class THCRotations(Bloq):
     num_mu: int
     num_spin_orb: int
     num_bits_theta: int
-    kr1: int = 1
-    kr2: int = 1
-    two_body_only: bool = False
-    adjoint: bool = False
 
     @cached_property
     def signature(self) -> Signature:
         return Signature(
             [
-                Register("nu_eq_mp1", bitsize=1),
-                Register("data", bitsize=self.num_bits_theta),
-                Register("sel", bitsize=self.num_mu.bit_length()),
-                Register("trg", bitsize=self.num_spin_orb // 2),
+                Register("data", bitsize=self.num_bits_theta, shape=(self.num_spin_orb // 2,)),
+                Register("target", bitsize=self.num_spin_orb // 2),
             ]
         )
 
     def pretty_name(self) -> str:
-        dag = '†' if self.adjoint else ''
-        return f"In_mu-R{dag}"
+        return "In-Rot"
+
+    def build_composite_bloq(
+        self, bb: 'BloqBuilder', data: SoquetT, target: SoquetT
+    ) -> Dict[str, 'SoquetT']:
+        trg_bits = bb.split(target)
+        for qi in range(self.num_spin_orb // 2 - 1):
+            # X_i Y_{i+1} rotation
+            trg_bits[qi], trg_bits[qi + 1] = bb.add(
+                InterleavedCliffordA(), a=trg_bits[qi], b=trg_bits[qi + 1]
+            )
+            data[qi], trg_bits[qi + 1] = bb.add(
+                PhaseGradientRz(self.num_bits_theta), data=data[qi], target=trg_bits[qi + 1]
+            )
+            # TODO: should be adjointed!
+            trg_bits[qi], trg_bits[qi + 1] = bb.add(
+                InterleavedCliffordA(), a=trg_bits[qi], b=trg_bits[qi + 1]
+            )
+            # Y_i X_{i+1} rotation
+            trg_bits[qi], trg_bits[qi + 1] = bb.add(
+                InterleavedCliffordB(), a=trg_bits[qi], b=trg_bits[qi + 1]
+            )
+            data[qi], trg_bits[qi + 1] = bb.add(
+                PhaseGradientRz(self.num_bits_theta), data=data[qi], target=trg_bits[qi + 1]
+            )
+            # TODO: should be adjointed!
+            trg_bits[qi], trg_bits[qi + 1] = bb.add(
+                InterleavedCliffordB(), a=trg_bits[qi], b=trg_bits[qi + 1]
+            )
+
+        target = bb.join(trg_bits)
+        return {'data': data, 'target': target}
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        # from listings on page 17 of Ref. [1]
-        num_data_sets = self.num_mu + self.num_spin_orb // 2
-        if self.adjoint:
-            if self.two_body_only:
-                toff_cost_qrom = (
-                    int(np.ceil(self.num_mu / self.kr1))
-                    + int(np.ceil(self.num_spin_orb / (2 * self.kr1)))
-                    + self.kr1
-                )
-            else:
-                toff_cost_qrom = int(np.ceil(self.num_mu / self.kr2)) + self.kr2
-        else:
-            toff_cost_qrom = num_data_sets - 2
-            if self.two_body_only:
-                # we don't need the only body bit for the second application of the
-                # rotations for the nu register.
-                toff_cost_qrom -= self.num_spin_orb // 2
         # xref https://github.com/quantumlib/Qualtran/issues/370, the cost below
         # assume a phase gradient.
+        # In Burg et al there are N//2-1 rotations not N//2.
         rot_cost = self.num_spin_orb * (self.num_bits_theta - 2)
-        return {(Toffoli(), (rot_cost + toff_cost_qrom))}
+        return {(Toffoli(), rot_cost)}
 
 
 @frozen
@@ -121,6 +221,10 @@ class SelectTHC(SelectOracle):
         num_spin_orb: number of spin orbitals $N$
         num_bits_theta: Number of bits of precision for the rotations. Called
             $\beth$ in the reference.
+        rotation_angles: Sequence of num_bits_theta-bit fixed-point
+            representation of the basis rotation angles. For each mu thera
+            num_spin_orb // 2 angles, which can be determined from
+            find_givens_angles.
         kr1: block sizes for QROM erasure for outputting rotation angles. See Eq 34.
         kr2: block sizes for QROM erasure for outputting rotation angles. This
             is for the second QROM (eq 35)
@@ -146,6 +250,7 @@ class SelectTHC(SelectOracle):
     num_mu: int
     num_spin_orb: int
     num_bits_theta: int
+    rotation_angles: Tuple[Tuple[int]]
     kr1: int = 1
     kr2: int = 1
     control_val: Optional[int] = None
@@ -177,6 +282,31 @@ class SelectTHC(SelectOracle):
             Register("sys_b", bitsize=self.num_spin_orb // 2),
         )
 
+    def add_qrom_bloq(
+        self,
+        bb: 'BloqBuilder',
+        mu: SoquetT,
+        data: SoquetT,
+        nu_eq_mp1: SoquetT,
+        two_body_only: bool = False,
+    ):
+        """Helper to hide some boilerplate when adding a qrom with many target registers."""
+        qrom = QROM(
+            np.array(self.rotation_angles),
+            selection_bitsizes=(self.num_mu.bit_length(),),
+            target_bitsizes=(self.num_bits_theta,) * (self.num_spin_orb // 2),
+            num_controls=0 if two_body_only else 1,
+        )
+        regs = {} if two_body_only else {'control': nu_eq_mp1}
+        regs |= {'selection': mu}
+        regs |= {f'target{i}': data[i] for i in range(self.num_spin_orb // 2)}
+        regs = bb.add_d(qrom, **regs)
+        mu = regs['selection']
+        data = [regs[f'target{i}'] for i in range(self.num_spin_orb // 2)]
+        if not two_body_only:
+            nu_eq_mp1 = regs['control']
+        return mu, data, nu_eq_mp1
+
     def build_composite_bloq(
         self,
         bb: 'BloqBuilder',
@@ -192,40 +322,36 @@ class SelectTHC(SelectOracle):
     ) -> Dict[str, 'SoquetT']:
         plus_b, sys_a, sys_b = bb.add(CSwap(self.num_spin_orb // 2), ctrl=plus_b, x=sys_a, y=sys_b)
 
-        # Rotations
-        data = bb.allocate(self.num_bits_theta)
-        nu_eq_mp1, data, mu, sys_a = bb.add(
+        # Allocate ancilla for qrom here due to https://github.com/quantumlib/Qualtran/issues/549
+        data = np.array([bb.allocate(self.num_bits_theta) for _ in range(self.num_spin_orb // 2)])
+        # 1. QROM the rotation angles.
+        mu, data, nu_eq_mp1 = self.add_qrom_bloq(bb, mu, data, nu_eq_mp1)
+        data, sys_a = bb.add(
             THCRotations(
                 num_mu=self.num_mu,
                 num_spin_orb=self.num_spin_orb,
                 num_bits_theta=self.num_bits_theta,
-                kr1=self.kr1,
-                kr2=self.kr2,
             ),
-            nu_eq_mp1=nu_eq_mp1,
             data=data,
-            sel=mu,
-            trg=sys_a,
+            target=sys_a,
         )
         # Controlled Z_0
         (succ,), sys_b = bb.add(
             ApplyControlledZs(cvs=(1,), bitsize=self.num_spin_orb // 2), ctrls=(succ,), system=sys_b
         )
-        # Undo rotations
-        nu_eq_mp1, data, mu, sys_a = bb.add(
+        # invert the rotations
+        data, sys_a = bb.add(
             THCRotations(
                 num_mu=self.num_mu,
                 num_spin_orb=self.num_spin_orb,
                 num_bits_theta=self.num_bits_theta,
-                kr1=self.kr1,
-                kr2=self.kr2,
-                adjoint=True,
             ),
-            nu_eq_mp1=nu_eq_mp1,
             data=data,
-            sel=mu,
-            trg=sys_a,
+            target=sys_a,
         )
+        # erase qrom
+        mu, data, nu_eq_mp1 = self.add_qrom_bloq(bb, mu, data, nu_eq_mp1)
+        # undo spin swaps
         plus_b, sys_a, sys_b = bb.add(CSwap(self.num_spin_orb // 2), ctrl=plus_b, x=sys_a, y=sys_b)
 
         plus_mn = bb.add(XGate(), q=plus_mn)
@@ -240,19 +366,15 @@ class SelectTHC(SelectOracle):
         plus_b, sys_a, sys_b = bb.add(CSwap(self.num_spin_orb // 2), ctrl=plus_b, x=sys_a, y=sys_b)
 
         # Rotations
-        nu_eq_mp1, data, mu, sys_a = bb.add(
+        mu, data, nu_eq_mp1 = self.add_qrom_bloq(bb, mu, data, nu_eq_mp1)
+        data, sys_a = bb.add(
             THCRotations(
                 num_mu=self.num_mu,
                 num_spin_orb=self.num_spin_orb,
                 num_bits_theta=self.num_bits_theta,
-                kr1=self.kr1,
-                kr2=self.kr2,
-                two_body_only=True,
             ),
-            nu_eq_mp1=nu_eq_mp1,
             data=data,
-            sel=mu,
-            trg=sys_a,
+            target=sys_a,
         )
         # Controlled Z_0
         (succ, nu_eq_mp1), sys_b = bb.add(
@@ -260,28 +382,24 @@ class SelectTHC(SelectOracle):
             ctrls=(succ, nu_eq_mp1),
             system=sys_b,
         )
-        # Undo rotations
-        nu_eq_mp1, data, mu, sys_a = bb.add(
+        # invert the rotations
+        data, sys_a = bb.add(
             THCRotations(
                 num_mu=self.num_mu,
                 num_spin_orb=self.num_spin_orb,
                 num_bits_theta=self.num_bits_theta,
-                kr1=self.kr1,
-                kr2=self.kr2,
-                two_body_only=True,
-                adjoint=True,
             ),
-            nu_eq_mp1=nu_eq_mp1,
             data=data,
-            sel=mu,
-            trg=sys_a,
+            target=sys_a,
         )
+        mu, data, nu_eq_mp1 = self.add_qrom_bloq(bb, mu, data, nu_eq_mp1)
 
         # Clean up
         plus_b, sys_a, sys_b = bb.add(CSwap(self.num_spin_orb // 2), ctrl=plus_b, x=sys_a, y=sys_b)
 
         # Undo the mu-nu swaps
-        bb.free(data)
+        for d in data:
+            bb.free(d)
         return {
             'succ': succ,
             'nu_eq_mp1': nu_eq_mp1,
@@ -293,19 +411,65 @@ class SelectTHC(SelectOracle):
             'sys_a': sys_a,
             'sys_b': sys_b,
         }
+        # Need build_call_graph here.
+        # # from listings on page 17 of Ref. [1]
+        # num_data_sets = self.num_mu + self.num_spin_orb // 2
+        # if self.adjoint:
+        #     if self.two_body_only:
+        #         toff_cost_qrom = (
+        #             int(np.ceil(self.num_mu / self.kr1))
+        #             + int(np.ceil(self.num_spin_orb / (2 * self.kr1)))
+        #             + self.kr1
+        #         )
+        #     else:
+        #         toff_cost_qrom = int(np.ceil(self.num_mu / self.kr2)) + self.kr2
+        # else:
+        #     toff_cost_qrom = num_data_sets - 2
+        #     if self.two_body_only:
+        #         # we don't need the only body bit for the second application of the
+        #         # rotations for the nu register.
+        #         toff_cost_qrom -= self.num_spin_orb // 2
 
 
 @bloq_example
 def _thc_sel() -> SelectTHC:
-    num_mu = 8
     num_mu = 10
     num_spin_orb = 2 * 4
-    thc_sel = SelectTHC(num_mu=num_mu, num_spin_orb=num_spin_orb, num_bits_theta=12)
+    num_bits_theta = 18
+    chi = np.random.random(size=(num_spin_orb // 2, num_mu))
+    # should be individually normalized
+    norms = np.sqrt(np.einsum("pm,pm->m", chi, chi))
+    chi = np.einsum("pm,m->pm", chi, norms)
+    rotation_angles = find_givens_angles(chi, num_bits_prec=num_bits_theta)
+    thc_sel = SelectTHC(
+        num_mu=num_mu,
+        num_spin_orb=num_spin_orb,
+        num_bits_theta=num_bits_theta,
+        rotation_angles=rotation_angles,
+    )
     return thc_sel
 
 
 _THC_SELECT = BloqDocSpec(
     bloq_cls=SelectTHC,
-    import_line='from qualtran.bloqs.chemistry.thc.select_bloq import SelectTHC',
+    import_line='from qualtran.bloqs.chemistry.thc.select_bloq import find_givens_angles, SelectTHC',
     examples=(_thc_sel,),
+)
+
+
+@bloq_example
+def _thc_rotations() -> THCRotations:
+    num_mu = 10
+    num_spin_orb = 2 * 4
+    num_bits_theta = 20
+    thc_rotations = THCRotations(
+        num_mu=num_mu, num_spin_orb=num_spin_orb, num_bits_theta=num_bits_theta
+    )
+    return thc_rotations
+
+
+_THC_ROTATIONS = BloqDocSpec(
+    bloq_cls=THCRotations,
+    import_line='from qualtran.bloqs.chemistry.thc.select_bloq import THCRotations',
+    examples=(_thc_rotations,),
 )

--- a/qualtran/bloqs/chemistry/thc/select_bloq_test.py
+++ b/qualtran/bloqs/chemistry/thc/select_bloq_test.py
@@ -12,8 +12,102 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from qualtran.bloqs.chemistry.thc.select_bloq import _thc_sel
+import cirq
+import numpy as np
+import pytest
+import scipy.linalg
+
+from qualtran.bloqs.chemistry.thc.select_bloq import _thc_rotations, _thc_sel, find_givens_angles
 
 
-def test_thc_uniform_prep(bloq_autotester):
+def test_thc_rotations(bloq_autotester):
+    bloq_autotester(_thc_rotations)
+
+
+def test_thc_select(bloq_autotester):
     bloq_autotester(_thc_sel)
+
+
+@pytest.mark.parametrize("theta", 2 * np.pi * np.random.random(10))
+def test_interleaved_cliffords(theta):
+    a, b = cirq.LineQubit.range(2)
+    XY = cirq.Circuit([cirq.X(a), cirq.Y(b)])
+    UXY = cirq.unitary(XY)
+    RXY_ref = scipy.linalg.expm(-1j * theta * UXY / 2)
+    C0 = [cirq.H(a), cirq.S(b) ** -1, cirq.H(b), cirq.CNOT(a, b)]
+    C1 = [cirq.S(a) ** -1, cirq.H(a), cirq.H(b), cirq.CNOT(a, b)]
+    RXY = cirq.unitary(cirq.Circuit([C0, cirq.Rz(rads=theta)(b), cirq.inverse(C0)]))
+    assert np.allclose(RXY, RXY_ref)
+    YX = cirq.Circuit([cirq.Y(a), cirq.X(b)])
+    UYX = cirq.unitary(YX)
+    RYX_ref = scipy.linalg.expm(1j * theta * UYX / 2)
+    RYX = cirq.unitary(cirq.Circuit([C1, cirq.Rz(rads=-theta)(b), cirq.inverse(C1)]))
+    assert np.allclose(RYX, RYX_ref)
+
+
+def test_givens_angles_original():
+    def givens_matrix(theta, p, q, phi, norb):
+        mat = np.eye(norb, dtype=np.complex128)
+        mat[p, p] = np.cos(theta)
+        mat[p, q] = -np.exp(1j * phi) * np.sin(theta)
+        mat[q, p] = np.sin(theta)
+        mat[q, q] = np.exp(1j * phi) * np.cos(theta)
+        return mat
+
+    norb = 6
+    u = np.random.random((norb, norb))
+    u = u + u.T
+    u, _ = np.linalg.qr(u)
+    from openfermion.linalg.givens_rotations import givens_decomposition_square
+
+    decomp, diagonal = givens_decomposition_square(u)
+    D = np.diag(diagonal)
+    U = np.eye(norb)
+    for x in decomp:
+        prod_g = np.eye(norb)
+        for parallel_ops in reversed(x):
+            p, q, theta, phi = parallel_ops
+            g = givens_matrix(theta, p, q, phi, norb)
+            prod_g = prod_g @ g
+        U = prod_g @ U
+    U = D.dot(U)
+
+
+# def test_givens_unitary():
+#     num_orb = 4
+#     mat = np.random.random((num_orb, num_orb))
+#     mat = 0.5 * (mat + mat.T)
+#     unitary, _ = np.linalg.qr(mat)
+#     assert np.allclose(unitary.T @ unitary, np.eye(num_orb))
+#     thetas = find_givens_angles(unitary)
+#     qubits = cirq.LineQubit.range(num_orb)
+#     from openfermion.ops import FermionOperator
+#     from openfermion.transforms import jordan_wigner, qubit_operator_to_pauli_sum
+
+#     def majoranas_as_paulis(p, qubits=None):
+#         a_p = FermionOperator(f'{p}')
+#         a_p_dag = FermionOperator(f'{p}^')
+#         maj_0 = a_p + a_p_dag
+#         maj_1 = -1j * (a_p - a_p_dag)
+#         return (
+#             qubit_operator_to_pauli_sum(jordan_wigner(maj_0), qubits=qubits),
+#             qubit_operator_to_pauli_sum(jordan_wigner(maj_1), qubits=qubits),
+#         )
+
+#     g0, g1 = majoranas_as_paulis(2, qubits=qubits)
+#     # assert g0.matrix().shape == (2**num_orb, 2**num_orb)
+
+#     # def build_vop(u, p, theta, qubits):
+#     #     id_before = cirq.IdentityGate(qubits[p])
+#     #     id_after = cirq.IdentityGate(qubits[p + 1])
+#     #     RXY = scipy.linalg.expm(1j * theta * UXY.matrix())
+#     #     return RXY
+
+#     # U = np.eye(2**num_orb)
+#     # for p in range(num_orb - 1):
+#     #     Vp = build_vop(0, p, thetas[0, p], qubits)
+#     #     U = np.dot(U, Vp)
+
+#     # Z = cirq.unitary(cirq.Circuit(cirq.Z(qubits[0])  + [cirq.IdentityGate(q) for q in qubits[1:]]))
+#     # maj_0, maj_1 = zip(*[build_majoranas(p, qubits) for p in range(num_orb)])
+#     # trans = U.conj().T @ Z @ U

--- a/qualtran/bloqs/chemistry/thc/thc.ipynb
+++ b/qualtran/bloqs/chemistry/thc/thc.ipynb
@@ -25,6 +25,7 @@
     "from qualtran.drawing import show_bloq, show_call_graph, show_counts_sigma\n",
     "from typing import *\n",
     "import numpy as np\n",
+    "import sympy\n",
     "import cirq"
    ]
   },
@@ -404,8 +405,10 @@
     " - `num_mu`: THC auxiliary index dimension $M$\n",
     " - `num_spin_orb`: number of spin orbitals $N$\n",
     " - `num_bits_theta`: Number of bits of precision for the rotations. Called $\\beth$ in the reference.\n",
+    " - `rotation_angles`: Sequence of num_bits_theta-bit fixed-point representation of the basis rotation angles. For each mu thera num_spin_orb // 2 angles, which can be determined from find_givens_angles.\n",
     " - `kr1`: block sizes for QROM erasure for outputting rotation angles. See Eq 34.\n",
-    " - `kr2`: block sizes for QROM erasure for outputting rotation angles. This is for the second QROM (eq 35) \n",
+    " - `kr2`: block sizes for QROM erasure for outputting rotation angles. This is for the second QROM (eq 35)\n",
+    " - `control_val`: A control bit for the entire gate. \n",
     "\n",
     "#### Registers\n",
     " - `succ`: success flag qubit from uniform state preparation\n",
@@ -431,7 +434,7 @@
    },
    "outputs": [],
    "source": [
-    "from qualtran.bloqs.chemistry.thc.select_bloq import SelectTHC"
+    "from qualtran.bloqs.chemistry.thc.select_bloq import find_givens_angles, SelectTHC"
    ]
   },
   {
@@ -453,10 +456,20 @@
    },
    "outputs": [],
    "source": [
-    "num_mu = 8\n",
     "num_mu = 10\n",
     "num_spin_orb = 2 * 4\n",
-    "thc_sel = SelectTHC(num_mu=num_mu, num_spin_orb=num_spin_orb, num_bits_theta=12)"
+    "num_bits_theta = 18\n",
+    "chi = np.random.random(size=(num_spin_orb // 2, num_mu))\n",
+    "# should be individually normalized\n",
+    "norms = np.sqrt(np.einsum(\"pm,pm->m\", chi, chi))\n",
+    "chi = np.einsum(\"pm,m->pm\", chi, norms)\n",
+    "rotation_angles = find_givens_angles(chi, num_bits_prec=num_bits_theta)\n",
+    "thc_sel = SelectTHC(\n",
+    "    num_mu=num_mu,\n",
+    "    num_spin_orb=num_spin_orb,\n",
+    "    num_bits_theta=num_bits_theta,\n",
+    "    rotation_angles=rotation_angles,\n",
+    ")"
    ]
   },
   {
@@ -506,6 +519,118 @@
     "show_call_graph(thc_sel_g)\n",
     "show_counts_sigma(thc_sel_sigma)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c806274e",
+   "metadata": {
+    "cq.autogen": "THCRotations.bloq_doc.md"
+   },
+   "source": [
+    "## `THCRotations`\n",
+    "Bloq for rotating into THC basis through Givens rotation network.\n",
+    "\n",
+    "This is accounting for In-R in Fig. 7 of the THC paper (Ref.\n",
+    "1).\n",
+    "\n",
+    "#### Parameters\n",
+    " - `num_mu`: THC auxiliary index dimension $M$\n",
+    " - `num_spin_orb`: number of spin orbitals $N$\n",
+    " - `num_bits_theta`: Number of bits of precision for the rotations. Called $\\beth$ in the reference. \n",
+    "\n",
+    "#### References\n",
+    "[Even more efficient quantum computations of chemistry through\n",
+    "    tensor hypercontraction](https://arxiv.org/pdf/2011.03494.pdf) Fig. 7.\n",
+    "[Quantum computing enhanced computational catalysis](https://arxiv.org/abs/2007.14460).\n",
+    "    Burg, Low et. al. 2021. Eq. 73\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b47e682e",
+   "metadata": {
+    "cq.autogen": "THCRotations.bloq_doc.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.chemistry.thc.select_bloq import THCRotations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45231662",
+   "metadata": {
+    "cq.autogen": "THCRotations.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a28c2ea",
+   "metadata": {
+    "cq.autogen": "THCRotations.thc_rotations"
+   },
+   "outputs": [],
+   "source": [
+    "num_mu = 10\n",
+    "num_spin_orb = 2 * 4\n",
+    "num_bits_theta = 20\n",
+    "thc_rotations = THCRotations(\n",
+    "    num_mu=num_mu, num_spin_orb=num_spin_orb, num_bits_theta=num_bits_theta\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb0dccea",
+   "metadata": {
+    "cq.autogen": "THCRotations.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "376246e6",
+   "metadata": {
+    "cq.autogen": "THCRotations.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([thc_rotations],\n",
+    "           ['`thc_rotations`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fc07b01",
+   "metadata": {
+    "cq.autogen": "THCRotations.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9e32ce8",
+   "metadata": {
+    "cq.autogen": "THCRotations.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "thc_rotations_g, thc_rotations_sigma = thc_rotations.call_graph()\n",
+    "show_call_graph(thc_rotations_g)\n",
+    "show_counts_sigma(thc_rotations_sigma)"
+   ]
   }
  ],
  "metadata": {
@@ -515,7 +640,15 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
    "version": "3.11.5"
   }
  },


### PR DESCRIPTION
Adds the rotation network necessary for applying [THC select](https://journals.aps.org/prxquantum/pdf/10.1103/PRXQuantum.2.030305) (Fig 5):

![Screenshot 2023-12-17 at 5 44 35 PM](https://github.com/quantumlib/Qualtran/assets/12097876/152df820-098c-431b-8f29-31049eef0c79)

The first part involves qrom-ming the rotations angle to beta-bits of precision, I've refactored this out of the THCRotations bloq into the main select decomposition.

The second part involves applying the [Givens network](https://arxiv.org/pdf/2007.14460.pdf) (page 72, eq 62/63) using the angles from qrom (which is In-R above):

![Screenshot 2023-12-17 at 5 43 49 PM](https://github.com/quantumlib/Qualtran/assets/12097876/c7b76c91-07c0-4e17-9e1a-5a7ff364c495)

Current limitations:

1. Requires a phase gradient rotation bloq (I added a placeholder for the moment)
2. Should we add an S-gate bloq to qualtran?
3. Unit tests for angle determination / circuit correctness.

Only 3 is really blocking me at the moment.th