### PR TITLE
More idiomatic adjoint changes

### DIFF
--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -163,6 +163,9 @@ class TwoBitCSwap(Bloq):
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         return {(TGate(), 7), (ArbitraryClifford(n=3), 10)}
 
+    def adjoint(self) -> 'Bloq':
+        return self
+
 
 @frozen
 class CSwap(GateWithRegisters):
@@ -240,6 +243,9 @@ class CSwap(GateWithRegisters):
 
     def _t_complexity_(self) -> TComplexity:
         return TComplexity(t=7 * self.bitsize, clifford=10 * self.bitsize)
+
+    def adjoint(self) -> 'Bloq':
+        return self
 
 
 @bloq_example

--- a/qualtran/bloqs/chemistry/df/double_factorization.ipynb
+++ b/qualtran/bloqs/chemistry/df/double_factorization.ipynb
@@ -66,8 +66,7 @@
     " - `num_eig`: The total number of eigenvalues.\n",
     " - `num_bits_state_prep`: The number of bits of precision for coherent alias sampling. Called $\\aleph$ in the reference.\n",
     " - `num_bits_rot_aa_outer`: Number of bits of precision for single qubit rotation for amplitude amplification. Called $b_r$ in the reference.\n",
-    " - `num_bits_rot`: Number of bits of precision for rotations for amplitude amplification in uniform state preparation. Called $\\beth$ in Ref[1].\n",
-    " - `adjoint`: Whether this bloq is daggered or not. This affects the QROM cost. \n",
+    " - `num_bits_rot`: Number of bits of precision for rotations for amplitude amplification in uniform state preparation. Called $\\beth$ in Ref[1]. \n",
     "\n",
     "#### Registers\n",
     " - `succ_l`: control for success for outer state preparation.\n",
@@ -131,7 +130,6 @@
     "    num_eig=num_eig,\n",
     "    num_bits_state_prep=num_bits_state_prep,\n",
     "    num_bits_rot=num_bits_rot,\n",
-    "    adjoint=False,\n",
     ")"
    ]
   },

--- a/qualtran/bloqs/chemistry/df/double_factorization.py
+++ b/qualtran/bloqs/chemistry/df/double_factorization.py
@@ -72,7 +72,6 @@ class DoubleFactorizationOneBody(Bloq):
             rotation for amplitude amplification. Called $b_r$ in the reference.
         num_bits_rot: Number of bits of precision for rotations for amplitude
             amplification in uniform state preparation. Called $\beth$ in Ref[1].
-        adjoint: Whether this bloq is daggered or not. This affects the QROM cost.
 
     Registers:
         succ_l: control for success for outer state preparation.
@@ -99,7 +98,6 @@ class DoubleFactorizationOneBody(Bloq):
     num_bits_state_prep: int
     num_bits_rot_aa: int = 8
     num_bits_rot: int = 24
-    adjoint: bool = False
 
     @property
     def control_registers(self) -> Iterable[Register]:
@@ -168,7 +166,6 @@ class DoubleFactorizationOneBody(Bloq):
             num_eig=self.num_eig,
             num_bits_rot_aa=self.num_bits_rot_aa,
             num_bits_state_prep=self.num_bits_state_prep,
-            adjoint=False,
         )
         xi, offset, rot, succ_p, p = bb.add(
             in_prep, xi=xi, offset=offset, rot=rot, succ_p=succ_p, p=p
@@ -180,7 +177,6 @@ class DoubleFactorizationOneBody(Bloq):
             num_eig=self.num_eig,
             num_spin_orb=self.num_spin_orb,
             num_bits_rot=self.num_bits_rot,
-            adjoint=False,
         )
         offset, p, rotations, spin, sys = bb.add(
             prot, offset=offset, p=p, rotations=rotations, spin=spin, sys=sys
@@ -195,8 +191,7 @@ class DoubleFactorizationOneBody(Bloq):
             num_eig=self.num_eig,
             num_spin_orb=self.num_spin_orb,
             num_bits_rot=self.num_bits_rot,
-            adjoint=True,
-        )
+        ).adjoint()
         offset, p, rotations, spin, sys = bb.add(
             prot, offset=offset, p=p, rotations=rotations, spin=spin, sys=sys
         )
@@ -207,8 +202,7 @@ class DoubleFactorizationOneBody(Bloq):
             num_eig=self.num_eig,
             num_bits_rot_aa=self.num_bits_rot_aa,
             num_bits_state_prep=self.num_bits_state_prep,
-            adjoint=True,
-        )
+        ).adjoint()
         xi, offset, rot, succ_p, p = bb.add(
             in_prep_dag, xi=xi, offset=offset, rot=rot, succ_p=succ_p, p=p
         )
@@ -235,30 +229,15 @@ class DoubleFactorizationOneBody(Bloq):
             num_eig=self.num_eig,
             num_bits_rot_aa=self.num_bits_rot_aa,
             num_bits_state_prep=self.num_bits_state_prep,
-            adjoint=False,
         )
         rot = ProgRotGateArray(
             num_aux=self.num_aux,
             num_eig=self.num_eig,
             num_spin_orb=self.num_spin_orb,
             num_bits_rot=self.num_bits_rot,
-            adjoint=False,
         )
-        in_prep_dag = InnerPrepareDoubleFactorization(
-            num_aux=self.num_aux,
-            num_spin_orb=self.num_spin_orb,
-            num_eig=self.num_eig,
-            num_bits_rot_aa=self.num_bits_rot_aa,
-            num_bits_state_prep=self.num_bits_state_prep,
-            adjoint=True,
-        )
-        rot_dag = ProgRotGateArray(
-            num_aux=self.num_aux,
-            num_eig=self.num_eig,
-            num_spin_orb=self.num_spin_orb,
-            num_bits_rot=self.num_bits_rot,
-            adjoint=True,
-        )
+        in_prep_dag = in_prep.adjoint()
+        rot_dag = rot.adjoint()
         # 2*In-prep_l, addition, Rotations, 2*H, 2*SWAPS, subtraction
         return {
             (in_prep, 1),  # in-prep_l listing 3 page 52/53
@@ -464,8 +443,7 @@ class DoubleFactorizationBlockEncoding(Bloq):
             num_spin_orb=self.num_spin_orb,
             num_eig=self.num_eig,
             num_bits_rot_aa=self.num_bits_rot_aa_inner,
-            adjoint=True,
-        )
+        ).adjoint()
         l, l_ne_zero, xi, rot, offset = bb.add(
             in_l_data_l, l=l, l_ne_zero=l_ne_zero, xi=xi, rot_data=rot, offset=offset
         )
@@ -474,8 +452,7 @@ class DoubleFactorizationBlockEncoding(Bloq):
             self.num_aux,
             num_bits_state_prep=self.num_bits_state_prep,
             num_bits_rot_aa=self.num_bits_rot_aa_outer,
-            adjoint=True,
-        )
+        ).adjoint()
         l, succ_l = bb.add(outer_prep, l=l, succ_l=succ_l)
         ctrl = succ_l, l_ne_zero, theta, succ_p
         return {
@@ -506,7 +483,6 @@ def _df_one_body() -> DoubleFactorizationOneBody:
         num_eig=num_eig,
         num_bits_state_prep=num_bits_state_prep,
         num_bits_rot=num_bits_rot,
-        adjoint=False,
     )
     return df_one_body
 

--- a/qualtran/bloqs/chemistry/df/prepare.py
+++ b/qualtran/bloqs/chemistry/df/prepare.py
@@ -41,7 +41,6 @@ class InnerPrepareDoubleFactorization(Bloq):
             rotation for amplitude amplification. Called $b_r$ in the reference.
         num_bits_state_prep: The number of bits of precision for coherent alias
             sampling. Called $\aleph$ in Ref[1].
-        adjoint: Whether this bloq is daggered or not. This affects the QROM cost.
 
     Registers:
         xi: data register for number storing $\Xi^{(l)}$.
@@ -59,11 +58,9 @@ class InnerPrepareDoubleFactorization(Bloq):
     num_eig: int
     num_bits_rot_aa: int
     num_bits_state_prep: int
-    adjoint: bool = False
 
     def pretty_name(self) -> str:
-        dag = '†' if self.adjoint else ''
-        return f"In-Prep{dag}"
+        return "In-Prep"
 
     @cached_property
     def signature(self) -> Signature:
@@ -82,7 +79,7 @@ class InnerPrepareDoubleFactorization(Bloq):
         cost_b = (Add(num_bits_lxi), 1)
         # QROAM for alt/keep values
         bp = num_bits_xi + self.num_bits_state_prep + 2  # C31
-        cost_c = (QROAM(self.num_eig + self.num_spin_orb // 2, bp, self.adjoint), 1)
+        cost_c = (QROAM(self.num_eig + self.num_spin_orb // 2, bp), 1)
         # inequality tests + CSWAP
         cost_d = (Toffoli(), self.num_bits_state_prep + num_bits_xi)
         return {cost_a, cost_b, cost_c, cost_d}
@@ -107,7 +104,6 @@ class OuterPrepareDoubleFactorization(Bloq):
         num_bits_rot_aa: Number of bits of precision for single qubit
             rotation for amplitude amplification in inner state preparation.
             Called $b_r$ in the reference.
-        adjoint: Whether to dagger the bloq or not.
 
     Registers:
         l: register to store L values for auxiliary index.
@@ -122,11 +118,9 @@ class OuterPrepareDoubleFactorization(Bloq):
     num_aux: int
     num_bits_state_prep: int
     num_bits_rot_aa: int = 8
-    adjoint: bool = False
 
     def pretty_name(self) -> str:
-        dag = '†' if self.adjoint else ''
-        return f"OuterPrep{dag}"
+        return "OuterPrep"
 
     @cached_property
     def signature(self) -> Signature:
@@ -138,7 +132,7 @@ class OuterPrepareDoubleFactorization(Bloq):
         cost_a = (PrepareUniformSuperposition(self.num_aux + 1, self.num_bits_rot_aa), 1)
         # QROAM for alt/keep
         output_size = num_bits_l + self.num_bits_state_prep
-        cost_b = (QROAM(self.num_aux + 1, output_size, adjoint=self.adjoint), 1)
+        cost_b = (QROAM(self.num_aux + 1, output_size), 1)
         # inequality test
         cost_c = (Toffoli(), self.num_bits_state_prep)
         # controlled swaps
@@ -161,7 +155,6 @@ class OutputIndexedData(Bloq):
         num_eig: Total number of eigenvalues.
         num_bits_rot_aa: Number of bits of precision for single qubit
             rotation for amplitude amplification.  Called $b_r$ in the reference.
-        ajoint: Whether to dagger the bloq or note. Affects bloq counts.
 
     Registers:
         l: register to store L values for auxiliary index.
@@ -180,11 +173,9 @@ class OutputIndexedData(Bloq):
     num_spin_orb: int
     num_eig: int
     num_bits_rot_aa: int = 8
-    adjoint: bool = False
 
     def pretty_name(self) -> str:
-        dag = '†' if self.adjoint else ''
-        return f"In_l-data_l{dag}"
+        return "In_l-data_l"
 
     @cached_property
     def signature(self) -> Signature:
@@ -203,7 +194,7 @@ class OutputIndexedData(Bloq):
         num_bits_lxi = (self.num_eig + self.num_spin_orb // 2 - 1).bit_length()
         num_bits_xi = (self.num_spin_orb // 2 - 1).bit_length()
         bo = num_bits_xi + num_bits_lxi + self.num_bits_rot_aa + 1
-        return {(QROAM(self.num_aux + 1, bo, adjoint=self.adjoint), 1)}
+        return {(QROAM(self.num_aux + 1, bo), 1)}
 
 
 @bloq_example
@@ -219,7 +210,6 @@ def _prep_inner() -> InnerPrepareDoubleFactorization:
         num_eig=num_eig,
         num_bits_rot_aa=num_bits_rot,
         num_bits_state_prep=num_bits_state_prep,
-        adjoint=False,
     )
     return prep_inner
 

--- a/qualtran/bloqs/chemistry/df/prepare_test.py
+++ b/qualtran/bloqs/chemistry/df/prepare_test.py
@@ -47,11 +47,8 @@ def test_outerprep_t_counts():
     _, counts = outer_prep.call_graph()
     toff = counts[TGate()] // 4
     outer_prep = OuterPrepareDoubleFactorization(
-        num_aux,
-        num_bits_state_prep=num_bits_state_prep,
-        num_bits_rot_aa=num_bits_rot_aa,
-        adjoint=True,
-    )
+        num_aux, num_bits_state_prep=num_bits_state_prep, num_bits_rot_aa=num_bits_rot_aa
+    ).adjoint()
     _, counts = outer_prep.call_graph()
     toff += counts[TGate()] // 4
     # The output size for the QROM for the first state preparation in Eq. (C27)
@@ -75,12 +72,8 @@ def test_indexed_data_t_counts():
     _, counts = in_l_data_l.call_graph()
     toff = counts[TGate()] // 4
     in_l_data_l = OutputIndexedData(
-        num_aux=num_aux,
-        num_spin_orb=num_spin_orb,
-        num_eig=num_eig,
-        num_bits_rot_aa=num_bits_rot_aa,
-        adjoint=True,
-    )
+        num_aux=num_aux, num_spin_orb=num_spin_orb, num_eig=num_eig, num_bits_rot_aa=num_bits_rot_aa
+    ).adjoint()
     _, counts = in_l_data_l.call_graph()
     toff += counts[TGate()] // 4
     # captured from cost2 in openfermion df.compute_cost
@@ -103,7 +96,6 @@ def test_inner_prepare_t_counts():
         num_eig=num_eig,
         num_bits_rot_aa=num_bits_rot_aa,
         num_bits_state_prep=num_bits_state_prep,
-        adjoint=False,
     )
     _, counts = in_prep.call_graph()
     toff = counts[TGate()] // 4
@@ -113,8 +105,7 @@ def test_inner_prepare_t_counts():
         num_eig=num_eig,
         num_bits_rot_aa=num_bits_rot_aa,
         num_bits_state_prep=num_bits_state_prep,
-        adjoint=True,
-    )
+    ).adjoint()
     _, counts = in_prep.call_graph()
     toff += counts[TGate()] // 4
     toff *= 2  # cost is for the two applications of the in-prep, in-prep^

--- a/qualtran/bloqs/chemistry/df/select_bloq.py
+++ b/qualtran/bloqs/chemistry/df/select_bloq.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 @frozen
 class ProgRotGateArray(Bloq):
-    r"""Rotate to to/from MO basis so-as-to apply number operators in DF basis.
+    r"""Rotate to/from MO basis so-as-to apply number operators in DF basis.
 
     An actual implementation of should derive from ProgrammableRotationGateArray.
 
@@ -55,11 +55,9 @@ class ProgRotGateArray(Bloq):
     num_spin_orb: int
     num_eig: int
     num_bits_rot: int
-    adjoint: bool = False
 
     def short_name(self) -> str:
-        dag = '†' if self.adjoint else ''
-        return f"Rotations{dag}"
+        return "Rotations"
 
     @cached_property
     def signature(self) -> Signature:
@@ -84,5 +82,5 @@ class ProgRotGateArray(Bloq):
         cost_c = self.num_spin_orb * (self.num_bits_rot - 2)  # apply rotations
         return {
             (Toffoli(), (cost_a + cost_c)),
-            (QROAM(data_size, self.num_spin_orb * self.num_bits_rot // 2, adjoint=self.adjoint), 1),
+            (QROAM(data_size, self.num_spin_orb * self.num_bits_rot // 2), 1),
         }

--- a/qualtran/bloqs/chemistry/df/select_bloq_test.py
+++ b/qualtran/bloqs/chemistry/df/select_bloq_test.py
@@ -24,21 +24,13 @@ def test_rotations():
     num_bits_rot = 10
     num_eig = 13031
     rot = ProgRotGateArray(
-        num_aux=num_aux,
-        num_eig=num_eig,
-        num_spin_orb=num_spin_orb,
-        num_bits_rot=num_bits_rot,
-        adjoint=False,
+        num_aux=num_aux, num_eig=num_eig, num_spin_orb=num_spin_orb, num_bits_rot=num_bits_rot
     )
     _, counts = rot.call_graph()
     toff = counts[TGate()] // 4
     rot = ProgRotGateArray(
-        num_aux=num_aux,
-        num_eig=num_eig,
-        num_spin_orb=num_spin_orb,
-        num_bits_rot=num_bits_rot,
-        adjoint=True,
-    )
+        num_aux=num_aux, num_eig=num_eig, num_spin_orb=num_spin_orb, num_bits_rot=num_bits_rot
+    ).adjoint()
     _, counts = rot.call_graph()
     toff += counts[TGate()] // 4
     toff *= 2  # cost is for the two applications of the (rot, rot^) pair

--- a/qualtran/bloqs/chemistry/resource_estimation.ipynb
+++ b/qualtran/bloqs/chemistry/resource_estimation.ipynb
@@ -42,6 +42,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b25c7684",
    "metadata": {},
    "source": [
     "## Second Quantized Hamiltonians \n",
@@ -73,6 +74,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3eedfe58",
    "metadata": {},
    "source": [
     "## Block Encoding Bloqs\n",
@@ -83,6 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2fb17f7f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,12 +104,13 @@
     "\n",
     "# Build Select and Prepare\n",
     "prep_thc = PrepareTHC.from_hamiltonian_coeffs(t_l, zeta, num_bits_state_prep=num_bits_state_prep)\n",
-    "sel_thc = SelectTHC(num_mu, num_spin_orb, num_bits_theta=num_bits_theta, kr1=16, kr2=16)\n"
+    "sel_thc = SelectTHC(num_mu, num_spin_orb, num_bits_theta=num_bits_theta, kr1=16, kr2=16)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5cd5d9e8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,6 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "55ce02c5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,6 +139,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "deb5c0fa",
    "metadata": {},
    "source": [
     "This looks like our math expression above. Now given our block encoding block we can determine the resources required as follows"
@@ -142,6 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "51d755a0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,6 +187,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dbd1615f",
    "metadata": {},
    "source": [
     "We see that our bloq is pretty close to the quoted result, with the difference being around 300 Toffolis. For some insight into the source of differences see the [THC notebook](thc/thc.ipynb). Typically we may expect some small differences with quoted literature results, with Qualtran hopefully providing the more accurate result!\n",
@@ -190,16 +198,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "16c0c1e6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "toffoli_counts = [get_toffoli_counts(b) for b in [sel_thc, prep_thc, attrs.evolve(prep_thc, adjoint=True)]]\n",
+    "toffoli_counts = [get_toffoli_counts(b) for b in [sel_thc, prep_thc, prep_thc.adjoint()]]\n",
     "print(toffoli_counts)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "693397f4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,6 +218,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "94fe7d78",
    "metadata": {},
    "source": [
     "We see SELECT is the dominant cost and the inverse state preparation is significantly more expensive than its inverse. Let's have a look at the circuits to see where the costs are coming from."
@@ -216,6 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f671f121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,6 +240,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cec920ff",
    "metadata": {},
    "source": [
     "This figure should resemble Fig. 4 in the [THC paper](https://arxiv.org/abs/2011.03494). This circuit takes a familiar form, uniform state preparation followed by coherent alias sampling (QROM + swaps). Let's see a breakdown of these costs."
@@ -236,6 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5efd66ae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,6 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "340a4dfe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,6 +301,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c443862a",
    "metadata": {},
    "source": [
     "Roughly 89% of the cost is from the QROM, the other costs being mostly negligible."
@@ -293,6 +309,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c1ef2155",
    "metadata": {},
    "source": [
     "Let's now look at SELECT"
@@ -301,6 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f68fb539",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,6 +331,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0f97fe06",
    "metadata": {},
    "source": [
     "Note that the swaps at the beginning and end of SELECT from Fig. 7 are included as part of Prepare. We see that SELECT only contains swaps and something called In-mu-R, which implements the rotations. Let's take a look at that bloq."
@@ -321,6 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2ae641a5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,6 +354,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2204490e",
    "metadata": {},
    "source": [
     "Unfortunately right now we don't get much insight into the cost breakdown from the diagram, but we know that the dominant cost arise from applying the rotations, which are more than 3 times as expensive as outputting the rotation angles. Check back soon for a more detailed decomposition."
@@ -341,6 +362,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0b9176a2",
    "metadata": {},
    "source": [
     "## Other Hamiltonians\n",
@@ -351,6 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "614bfb21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,6 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1cf0cd0d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,6 +400,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b9d2577a",
    "metadata": {},
    "source": [
     "This should resemble(!) Fig 16 in [the THC reference](https://arxiv.org/abs/2011.03494). Feel free to inspect the bloqs!"
@@ -384,6 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f7e7879b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,6 +420,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3d134102",
    "metadata": {},
    "source": [
     "## First Quantization\n",
@@ -404,6 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e34dcb1c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,6 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ee5806f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,6 +469,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "940a3538",
    "metadata": {},
    "source": [
     "Interesting! We see that as $\\eta$ grows the cost of SELECT dominates. Let's inspect the circuit to see what is the source of the dominant cost."
@@ -448,6 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "48ba76b0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,6 +491,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "09290c3b",
    "metadata": {},
    "source": [
     "We see that there are only 3 components, a multiplexed swap, a SELECT operation for the kinetic energy and a SELECT for the potential energy terms. Let's inspect the scaling of these costs with the system size again."
@@ -468,6 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a11b23c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,6 +530,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d3c32927",
    "metadata": {},
    "source": [
     "We see that for any interestingly sized system $(\\eta > 50)$ that the multiplexed swaps are the dominant cost. Going a little deeper we know that the cost of these swaps is $12 \\eta n_p + 4 \\eta - 8$ Toffolis while the other costs only depend on the bitsizes of different registers which is typically logarithmic in the system size (if there is any dependence). A more careful analysis would determine these parameters more precisely!"
@@ -505,7 +539,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -519,7 +553,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/qualtran/bloqs/chemistry/sf/prepare.py
+++ b/qualtran/bloqs/chemistry/sf/prepare.py
@@ -42,7 +42,6 @@ class InnerPrepareSingleFactorization(Bloq):
             sampling. Called aleph (fancy N) in Ref[1].
         num_bits_rot_aa: Number of bits of precision for rotations for amplitude
             amplification in uniform state preparation. Called b_r in Ref[1].
-        adjoint: Whether this bloq is daggered or not. This affects the QROM cost.
         kp1: qroam blocking factor for data indexed by the first register. ($l$ in this case)
         kp2: qroam blocking factor for data indexed by the second register. ($p,
             q$ in this case (these are made into a contiguous register.))
@@ -64,13 +63,11 @@ class InnerPrepareSingleFactorization(Bloq):
     num_spin_orb: int
     num_bits_state_prep: int
     num_bits_rot_aa: int = 8
-    adjoint: bool = False
     kp1: int = 1
     kp2: int = 1
 
     def pretty_name(self) -> str:
-        dag = '†' if self.adjoint else ''
-        return f"In-Prep{dag}"
+        return "In-Prep"
 
     @cached_property
     def signature(self) -> Signature:
@@ -94,7 +91,6 @@ class InnerPrepareSingleFactorization(Bloq):
                 self.kp1,
                 self.kp2,
                 2 * n + self.num_bits_state_prep + 2,
-                adjoint=self.adjoint,
             ),
             1,
         )
@@ -117,7 +113,6 @@ class OuterPrepareSingleFactorization(Bloq):
             sampling. Called $\aleph$ in the reference.
         num_bits_rot_aa: Number of bits of precision for rotations for amplitude
             amplification in uniform state preparation. Called $b_r$ in the reference.
-        adjoint: Whether to dagger the bloq or not.
 
     Registers:
         l: register to store L values for auxiliary index.
@@ -134,11 +129,9 @@ class OuterPrepareSingleFactorization(Bloq):
     num_aux: int
     num_bits_state_prep: int
     num_bits_rot_aa: int = 8
-    adjoint: bool = False
 
     def pretty_name(self) -> str:
-        dag = '†' if self.adjoint else ''
-        return f"OuterPrep{dag}"
+        return "OuterPrep"
 
     @cached_property
     def signature(self) -> Signature:
@@ -150,7 +143,7 @@ class OuterPrepareSingleFactorization(Bloq):
         num_bits_l = (self.num_aux + 1).bit_length()
         output_size = num_bits_l + self.num_bits_state_prep + 2
         # 1.b
-        cost_qroam = (QROAM(self.num_aux + 1, output_size, adjoint=self.adjoint), 1)
+        cost_qroam = (QROAM(self.num_aux + 1, output_size), 1)
         # 1.c inequality test for alias sampling
         cost_ineq = (LessThanEqual(self.num_bits_state_prep, self.num_bits_state_prep), 1)
         # 1.d swap alt/keep values

--- a/qualtran/bloqs/chemistry/sf/prepare_test.py
+++ b/qualtran/bloqs/chemistry/sf/prepare_test.py
@@ -46,11 +46,8 @@ def test_outerprep_t_counts():
     toff -= (7 - 4) * (nb_l + 1)
     toff -= 4 * num_bits_state_prep - 4
     outer_prep = OuterPrepareSingleFactorization(
-        num_aux,
-        num_bits_state_prep=num_bits_state_prep,
-        num_bits_rot_aa=num_bits_rot_aa,
-        adjoint=True,
-    )
+        num_aux, num_bits_state_prep=num_bits_state_prep, num_bits_rot_aa=num_bits_rot_aa
+    ).adjoint()
     eta = power_two(num_aux + 1)
     _, counts = outer_prep.call_graph()
     toff += counts[TGate()]
@@ -81,7 +78,6 @@ def test_inner_prepare_t_counts():
         num_spin_orb=num_spin_orb,
         num_bits_state_prep=num_bits_state_prep,
         num_bits_rot_aa=num_bits_rot_aa,
-        adjoint=False,
         kp1=2**2,
         kp2=2**5,
     )
@@ -96,10 +92,9 @@ def test_inner_prepare_t_counts():
         num_spin_orb=num_spin_orb,
         num_bits_rot_aa=num_bits_rot_aa,
         num_bits_state_prep=num_bits_state_prep,
-        adjoint=True,
         kp1=2**1,
         kp2=2**8,
-    )
+    ).adjoint()
     _, counts = in_prep.call_graph()
     # factor of two from squaring
     toff += counts[TGate()]

--- a/qualtran/bloqs/chemistry/sf/single_factorization.py
+++ b/qualtran/bloqs/chemistry/sf/single_factorization.py
@@ -170,7 +170,6 @@ class SingleFactorizationOneBody(Bloq):
             self.num_spin_orb,
             self.num_bits_state_prep,
             self.num_bits_rot_aa,
-            adjoint=False,
             kp1=self.kp1,
             kp2=self.kp2,
         )
@@ -195,10 +194,9 @@ class SingleFactorizationOneBody(Bloq):
             self.num_spin_orb,
             self.num_bits_state_prep,
             self.num_bits_rot_aa,
-            adjoint=True,
             kp1=self.kp1_inv,
             kp2=self.kp2_inv,
-        )
+        ).adjoint()
         l, p, q, succ_pq = bb.add(iprep_dag, l=l, p=p, q=q, succ_pq=succ_pq)
         return {
             'succ_l': succ_l,
@@ -219,7 +217,6 @@ class SingleFactorizationOneBody(Bloq):
             self.num_spin_orb,
             self.num_bits_state_prep,
             self.num_bits_rot_aa,
-            adjoint=False,
             kp1=self.kp1,
             kp2=self.kp2,
         )
@@ -228,10 +225,9 @@ class SingleFactorizationOneBody(Bloq):
             self.num_spin_orb,
             self.num_bits_state_prep,
             self.num_bits_rot_aa,
-            adjoint=True,
             kp1=self.kp1_inv,
             kp2=self.kp2_inv,
-        )
+        ).adjoint()
         n = (self.num_spin_orb // 2 - 1).bit_length()
         return {
             (iprep, 1),
@@ -398,8 +394,7 @@ class SingleFactorizationBlockEncoding(Bloq):
             self.num_aux,
             num_bits_state_prep=self.num_bits_state_prep,
             num_bits_rot_aa=self.num_bits_rot_aa_outer,
-            adjoint=True,
-        )
+        ).adjoint()
         l, succ_l, l_ne_zero, rot_aa[1] = bb.add(
             outer_prep, l=l, succ_l=succ_l, l_ne_zero=l_ne_zero, rot_aa=rot_aa[1]
         )

--- a/qualtran/bloqs/chemistry/thc/prepare.py
+++ b/qualtran/bloqs/chemistry/thc/prepare.py
@@ -89,7 +89,6 @@ class UniformSuperpositionTHC(Bloq):
 
     num_mu: int
     num_spin_orb: int
-    adjoint: bool = False
 
     @cached_property
     def signature(self) -> Signature:
@@ -253,7 +252,6 @@ class PrepareTHC(PrepareOracle):
     theta: Tuple[int, ...] = field(repr=False)
     keep: Tuple[int, ...] = field(repr=False)
     keep_bitsize: int
-    adjoint: bool = False
 
     @classmethod
     def from_hamiltonian_coeffs(
@@ -435,7 +433,7 @@ class PrepareTHC(PrepareOracle):
         nd = (data_size - 1).bit_length()
         cost_2 = (ToContiguousIndex(nmu, nd), 1)
         m = 2 * nmu + 2 + self.keep_bitsize
-        cost_3 = (QROAM(data_size, m, self.adjoint), 1)
+        cost_3 = (QROAM(data_size, m), 1)
         cost_4 = (OnEach(self.keep_bitsize, Hadamard()), 1)
         cost_5 = (LessThanEqual(self.keep_bitsize, self.keep_bitsize), 2)
         cost_6 = (CSwap(nmu), 3)


### PR DESCRIPTION
Following #566 

 - CSwap is self-adjoint
 - QROAM stub keeps its (renamed) flag for accurate costing / keeping this PR from being too complicated
 - All other `adjoint` boolean in the chemistry bloqs are superfluous 