### PR TITLE
Cirq interface opt-in

### DIFF
--- a/qualtran/bloqs/and_bloq.py
+++ b/qualtran/bloqs/and_bloq.py
@@ -35,8 +35,10 @@ from attrs import field, frozen
 from numpy.typing import NDArray
 
 from qualtran import (
+    Bloq,
     bloq_example,
     BloqDocSpec,
+    CompositeBloq,
     GateWithRegisters,
     Register,
     Side,
@@ -46,6 +48,7 @@ from qualtran import (
 )
 from qualtran.bloqs.basic_gates import TGate
 from qualtran.bloqs.util_bloqs import ArbitraryClifford
+from qualtran.cirq_interop import decompose_from_cirq_style_method
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, directional_text_box, WireSymbol
 from qualtran.resource_counting import big_O, BloqCountT, SympySymbolAllocator
@@ -212,7 +215,7 @@ _AND_DOC = BloqDocSpec(
 
 
 @frozen
-class MultiAnd(GateWithRegisters):
+class MultiAnd(Bloq):
     """A many-bit (multi-control) 'and' operation.
 
     Args:
@@ -290,6 +293,9 @@ class MultiAnd(GateWithRegisters):
             quregs['target'].flatten(),
         )
         yield self._decompose_via_tree(control, self.cvs, ancilla, *target)
+
+    def decompose_bloq(self) -> 'CompositeBloq':
+        return decompose_from_cirq_style_method(self)
 
     def _t_complexity_(self, adjoint: bool = False) -> TComplexity:
         pre_post_cliffords = len(self.cvs) - sum(self.cvs)  # number of zeros in self.cv

--- a/qualtran/cirq_interop/__init__.py
+++ b/qualtran/cirq_interop/__init__.py
@@ -17,6 +17,12 @@
 isort:skip_file
 """
 
-from ._cirq_to_bloq import CirqQuregT, CirqGateAsBloq, CirqGateAsBloqBase, cirq_optree_to_cbloq
+from ._cirq_to_bloq import (
+    CirqQuregT,
+    CirqGateAsBloq,
+    CirqGateAsBloqBase,
+    cirq_optree_to_cbloq,
+    decompose_from_cirq_style_method,
+)
 
 from ._bloq_to_cirq import BloqAsCirqGate

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -30,6 +30,7 @@ from qualtran import (
     BloqBuilder,
     CompositeBloq,
     DecomposeNotImplementedError,
+    DecomposeTypeError,
     GateWithRegisters,
     Register,
     Side,
@@ -37,7 +38,11 @@ from qualtran import (
     Soquet,
     SoquetT,
 )
-from qualtran._infra.gate_with_registers import get_named_qubits, split_qubits
+from qualtran._infra.gate_with_registers import (
+    _get_all_and_output_quregs_from_input,
+    get_named_qubits,
+    split_qubits,
+)
 from qualtran.cirq_interop._interop_qubit_manager import InteropQubitManager
 from qualtran.cirq_interop.t_complexity_protocol import t_complexity, TComplexity
 
@@ -280,6 +285,29 @@ def _gather_input_soqs(
     return qvars_in
 
 
+def _extract_bloq_from_op(op: 'cirq.Operation') -> Bloq:
+    """Get a `Bloq` out of a cirq Operation.
+
+    Unwrap BloqAsCirqGate, pass through any GateWithRegisters, and wrap
+    true cirq gates with `CirqGateAsBloq`.
+    """
+    from qualtran.cirq_interop._bloq_to_cirq import BloqAsCirqGate
+
+    if op.gate is None:
+        raise ValueError(f"Only gate operations are supported, not {op}.")
+
+    gate = op.gate
+    if isinstance(gate, BloqAsCirqGate):
+        # Perhaps this was operation was constructed from `Bloq.on()`.
+        return gate.bloq
+    if isinstance(gate, Bloq):
+        # I.e., `GateWithRegisters`.
+        return gate
+
+    # A base cirq gate.
+    return CirqGateAsBloq(gate)
+
+
 def cirq_optree_to_cbloq(
     optree: cirq.OP_TREE,
     *,
@@ -349,11 +377,8 @@ def cirq_optree_to_cbloq(
 
     # 2. Add each operation to the composite Bloq.
     for op in circuit.all_operations():
-        if op.gate is None:
-            raise ValueError(f"Only gate operations are supported, not {op}.")
-
-        bloq = op.gate if isinstance(op.gate, Bloq) else CirqGateAsBloq(op.gate)
-        if cirq.num_qubits(op.gate) == 0:
+        bloq = _extract_bloq_from_op(op)
+        if bloq.signature == Signature([]):
             bb.add(bloq)
             continue
 
@@ -395,3 +420,46 @@ def cirq_optree_to_cbloq(
         if qvar not in final_soqs_set:
             bb.free(qvar)
     return bb.finalize(**final_soqs_dict)
+
+
+def decompose_from_cirq_style_method(
+    bloq: Bloq, method_name='decompose_from_registers'
+) -> CompositeBloq:
+    """Return a `CompositeBloq` decomposition using a cirq-style decompose method.
+
+    For more details about defining cirq-style decompositions, see the documentation for
+    `GateWithRegisters`. Briefly, the bloq must have a method with the given name that
+    satisfies the following function signature:
+
+        def decompose_from_registers(
+            self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+        ) -> cirq.OP_TREE:
+
+    This must yield a list of `cirq.Operation`s using `cirq.Gate.on(...)`, `Bloq.on(...)`,
+    `GateWithRegisters.on_registers(...)`, or `Bloq.on_registers(...)`.
+
+    If `Bloq.on()` is used, the bloqs will be retained in their native form in the returned
+    composite bloq. If `cirq.Gate.on()` is used, the gates will be wrapped in `CirqGateAsBloq`.
+
+    Args:
+        bloq: The bloq to decompose.
+        method_name: The string name of the method that can be found on the bloq that
+            yields the cirq-style decomposition.
+    """
+    if any(
+        cirq.is_parameterized(reg.bitsize) or cirq.is_parameterized(reg.side)
+        for reg in bloq.signature
+    ):
+        # pylint: disable=raise-missing-from
+        raise DecomposeTypeError(f"Cannot decompose parameterized {bloq}.")
+
+    qm = InteropQubitManager()
+    in_quregs = get_named_qubits(bloq.signature.lefts())
+    qm.manage_qubits(itertools.chain.from_iterable(qreg.flatten() for qreg in in_quregs.values()))
+    all_quregs, out_quregs = _get_all_and_output_quregs_from_input(bloq.signature, qm, in_quregs)
+    context = cirq.DecompositionContext(qubit_manager=qm)
+    dfr_method = getattr(bloq, method_name)
+    decomposed_optree = dfr_method(context=context, **all_quregs)
+    return cirq_optree_to_cbloq(
+        decomposed_optree, signature=bloq.signature, in_quregs=in_quregs, out_quregs=out_quregs
+    )


### PR DESCRIPTION
The Cirq-interop code is high quality and highly refactorable. It’s currently configured as a [kitchen sink](https://www.merriam-webster.com/dictionary/everything%20but%20the%20kitchen%20sink). This change reconfigures some of the defaults.

This PR adds support for writing "cirq-style" decompositions with qubits and bloq.on(*qubits) for all bloqs. This is an informationally-complete way of defining decompositions that may be 1) more familiar to cirq people 2) more convenient if you’re wiring up a bunch of thru-registers and don’t want to redundantly write down inputs and outputs everywhere. `Bloq` learns `on` and `on_registers` method so that all bloqs can be wired up this way.

`BloqAsCirqGate` loses support for the bloq api. It’s just a Cirq gate and doesn’t implement the Bloq API. It’s confusing for it to be both. Note: `CirqGateAsBloq` is still both since it didn't confuse me when debugging this refactor but could be disentangled in a follow-on. 

GateWithRegisters that don’t implement any special cirq protocols can migrate to Bloq. They can still be wired up using Bloq.on(). As an example, this PR changes `MultiAnd` to a `Bloq` with no other modifications to the library required.

--------

Specific changes:
 - `Bloq.on` and `Bloq.on_registers` wrap in `BloqAsCirqGate` which now gets unwrapped by `cirq_optree_to_cbloq`. 
 - `GateWithRegisters` is unchanged apart from factoring out code into helper functions.
 - `BloqAsCirqGate` uses those helper functions