### PR TITLE
Bump dependencies

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -16,10 +16,8 @@ ipython
 matplotlib
 ipywidgets
 
-# quimb and its tensor dependencies
+# quimb simulation
 quimb
-opt_einsum
-autoray
 
 # serialization
 protobuf

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=envs/dev.env.txt deps/dev-tools.txt deps/runtime.txt
 #
-absl-py==2.0.0
+absl-py==2.1.0
     # via tensorflow-docs
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-alabaster==0.7.13
+alabaster==0.7.16
     # via sphinx
-anyio==4.0.0
+anyio==4.2.0
     # via jupyter-server
 argon2-cffi==23.1.0
     # via jupyter-server
@@ -30,7 +30,7 @@ asttokens==2.4.1
     # via stack-data
 async-lru==2.0.4
     # via jupyterlab
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -r deps/runtime.txt
     #   jsonschema
@@ -39,13 +39,14 @@ attrs==23.1.0
 autoray==0.6.7
     # via
     #   -r deps/runtime.txt
+    #   cotengra
     #   quimb
-babel==2.13.1
+babel==2.14.0
     # via
     #   jupyterlab-server
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via
     #   nbconvert
     #   pydata-sphinx-theme
@@ -74,15 +75,17 @@ click==8.1.7
     #   black
     #   jupyter-cache
     #   pip-tools
-comm==0.2.0
+comm==0.2.1
     # via
     #   ipykernel
     #   ipywidgets
 contourpy==1.2.0
     # via matplotlib
-coverage[toml]==7.3.2
+cotengra==0.5.6
+    # via quimb
+coverage[toml]==7.4.0
     # via pytest-cov
-cryptography==41.0.6
+cryptography==41.0.7
     # via secretstorage
 cycler==0.12.1
     # via matplotlib
@@ -98,7 +101,7 @@ deprecation==2.1.0
     # via openfermion
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 docutils==0.20.1
     # via
@@ -117,34 +120,34 @@ execnet==2.0.2
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastjsonschema==2.19.0
+fastjsonschema==2.19.1
     # via nbformat
 filelock==3.13.1
     # via virtualenv
 flynt==0.78
     # via -r deps/format.txt
-fonttools==4.45.0
+fonttools==4.47.2
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
-greenlet==3.0.1
+greenlet==3.0.3
     # via sqlalchemy
-grpcio==1.59.3
+grpcio==1.60.0
     # via grpcio-tools
-grpcio-tools==1.59.3
+grpcio-tools==1.60.0
     # via -r deps/packaging.txt
 h5py==3.10.0
     # via
     #   openfermion
     #   pyscf
-idna==3.4
+idna==3.6
     # via
     #   anyio
     #   jsonschema
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via
     #   jupyter-cache
     #   keyring
@@ -152,12 +155,12 @@ importlib-metadata==6.8.0
     #   twine
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.27.0
+ipykernel==6.29.0
     # via
     #   -r deps/pytest.txt
     #   jupyterlab
     #   myst-nb
-ipython==8.17.2
+ipython==8.20.0
     # via
     #   -r deps/runtime.txt
     #   ipykernel
@@ -175,9 +178,9 @@ isort==5.10.1
     #   pylint
 jaraco-classes==3.3.0
     # via keyring
-jax==0.4.20
+jax==0.4.23
     # via openfermion
-jaxlib==0.4.20
+jaxlib==0.4.23
     # via openfermion
 jedi==0.19.1
     # via ipython
@@ -198,12 +201,12 @@ json5==0.9.14
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
-jsonschema[format-nongpl]==4.20.0
+jsonschema[format-nongpl]==4.21.1
     # via
     #   jupyter-events
     #   jupyterlab-server
     #   nbformat
-jsonschema-specifications==2023.11.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
 jupyter-cache==1.0.0
     # via myst-nb
@@ -212,7 +215,7 @@ jupyter-client==8.6.0
     #   ipykernel
     #   jupyter-server
     #   nbclient
-jupyter-core==5.5.0
+jupyter-core==5.7.1
     # via
     #   ipykernel
     #   jupyter-client
@@ -223,20 +226,20 @@ jupyter-core==5.5.0
     #   nbformat
 jupyter-events==0.9.0
     # via jupyter-server
-jupyter-lsp==2.2.0
+jupyter-lsp==2.2.2
     # via jupyterlab
-jupyter-server==2.11.2
+jupyter-server==2.12.5
     # via
     #   jupyter-lsp
     #   jupyterlab
     #   jupyterlab-server
     #   notebook
     #   notebook-shim
-jupyter-server-terminals==0.4.4
+jupyter-server-terminals==0.5.2
     # via jupyter-server
-jupyterlab==4.0.9
+jupyterlab==4.0.11
     # via notebook
-jupyterlab-pygments==0.2.2
+jupyterlab-pygments==0.3.0
     # via nbconvert
 jupyterlab-server==2.25.2
     # via
@@ -248,7 +251,7 @@ keyring==24.3.0
     # via twine
 kiwisolver==1.4.5
     # via matplotlib
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.10.0
     # via astroid
 llvmlite==0.41.1
     # via numba
@@ -257,7 +260,7 @@ markdown-it-py==3.0.0
     #   mdit-py-plugins
     #   myst-parser
     #   rich
-markupsafe==2.1.3
+markupsafe==2.1.4
     # via
     #   jinja2
     #   nbconvert
@@ -278,11 +281,11 @@ mdurl==0.1.2
     # via markdown-it-py
 mistune==3.0.2
     # via nbconvert
-ml-dtypes==0.3.1
+ml-dtypes==0.3.2
     # via
     #   jax
     #   jaxlib
-more-itertools==10.1.0
+more-itertools==10.2.0
     # via jaraco-classes
 mpmath==1.3.0
     # via sympy
@@ -303,7 +306,7 @@ nbclient==0.9.0
     #   jupyter-cache
     #   myst-nb
     #   nbconvert
-nbconvert==7.11.0
+nbconvert==7.14.2
     # via
     #   -r deps/docs.txt
     #   -r deps/runtime.txt
@@ -318,16 +321,16 @@ nbformat==5.9.2
     #   nbclient
     #   nbconvert
     #   tensorflow-docs
-nest-asyncio==1.5.8
+nest-asyncio==1.6.0
     # via ipykernel
 networkx==3.2.1
     # via
     #   -r deps/runtime.txt
     #   cirq-core
     #   openfermion
-nh3==0.2.14
+nh3==0.2.15
     # via readme-renderer
-notebook==7.0.6
+notebook==7.0.7
     # via -r deps/dev-tools.txt
 notebook-shim==0.2.3
     # via
@@ -361,8 +364,7 @@ opt-einsum==3.3.0
     # via
     #   -r deps/runtime.txt
     #   jax
-    #   quimb
-overrides==7.4.0
+overrides==7.6.0
     # via jupyter-server
 packaging==23.2
     # via
@@ -377,23 +379,23 @@ packaging==23.2
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
-pandas==2.1.3
+pandas==2.2.0
     # via cirq-core
-pandocfilters==1.5.0
+pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.3
     # via jedi
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pexpect==4.8.0
+pexpect==4.9.0
     # via ipython
-pillow==10.1.0
+pillow==10.2.0
     # via matplotlib
 pip-tools==7.3.0
     # via -r deps/pip-tools.txt
 pkginfo==1.9.6
     # via twine
-platformdirs==4.0.0
+platformdirs==4.1.0
     # via
     #   black
     #   jupyter-core
@@ -403,15 +405,15 @@ pluggy==1.3.0
     # via pytest
 prometheus-client==0.19.0
     # via jupyter-server
-prompt-toolkit==3.0.41
+prompt-toolkit==3.0.43
     # via ipython
-protobuf==4.25.1
+protobuf==4.25.2
     # via
     #   -r deps/runtime.txt
     #   grpcio-tools
     #   mypy-protobuf
     #   tensorflow-docs
-psutil==5.9.6
+psutil==5.9.8
     # via
     #   ipykernel
     #   quimb
@@ -425,9 +427,9 @@ pure-eval==0.2.2
     # via stack-data
 pycparser==2.21
     # via cffi
-pydata-sphinx-theme==0.14.3
+pydata-sphinx-theme==0.15.2
     # via -r deps/docs.txt
-pydot==1.4.2
+pydot==2.0.0
     # via -r deps/runtime.txt
 pygments==2.17.2
     # via
@@ -448,14 +450,14 @@ pyproject-hooks==1.0.0
     # via build
 pyscf==2.4.0
     # via openfermion
-pytest==7.4.3
+pytest==7.4.4
     # via
     #   -r deps/pylint.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.3
     # via -r deps/pytest.txt
 pytest-cov==4.1.0
     # via -r deps/pytest.txt
@@ -478,16 +480,16 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   tensorflow-docs
-pyzmq==25.1.1
+pyzmq==25.1.2
     # via
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-quimb==1.6.0
+quimb==1.7.0
     # via -r deps/runtime.txt
 readme-renderer==42.0
     # via twine
-referencing==0.31.0
+referencing==0.32.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -513,7 +515,7 @@ rfc3986-validator==0.1.1
     #   jupyter-events
 rich==13.7.0
     # via twine
-rpds-py==0.13.1
+rpds-py==0.17.1
     # via
     #   jsonschema
     #   referencing
@@ -551,24 +553,19 @@ sphinx==7.2.6
     #   myst-nb
     #   myst-parser
     #   pydata-sphinx-theme
-    #   sphinxcontrib-applehelp
-    #   sphinxcontrib-devhelp
-    #   sphinxcontrib-htmlhelp
-    #   sphinxcontrib-qthelp
-    #   sphinxcontrib-serializinghtml
-sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-applehelp==1.0.8
     # via sphinx
-sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-devhelp==1.0.6
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.4
+sphinxcontrib-htmlhelp==2.0.5
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-qthelp==1.0.7
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.9
+sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
-sqlalchemy==2.0.23
+sqlalchemy==2.0.25
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -605,7 +602,7 @@ tomlkit==0.12.3
     # via pylint
 toolz==0.12.0
     # via cytoolz
-tornado==6.3.3
+tornado==6.4
     # via
     #   ipykernel
     #   jupyter-client
@@ -617,7 +614,7 @@ tqdm==4.66.1
     # via
     #   cirq-core
     #   quimb
-traitlets==5.13.0
+traitlets==5.14.1
     # via
     #   comm
     #   ipykernel
@@ -634,12 +631,13 @@ traitlets==5.13.0
     #   nbformat
 twine==4.0.2
     # via -r deps/packaging.txt
-types-protobuf==4.24.0.4
+types-protobuf==4.24.0.20240106
     # via mypy-protobuf
-types-python-dateutil==2.8.19.14
+types-python-dateutil==2.8.19.20240106
     # via arrow
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
+    #   anyio
     #   astroid
     #   async-lru
     #   cirq-core
@@ -647,7 +645,7 @@ typing-extensions==4.8.0
     #   myst-nb
     #   pydata-sphinx-theme
     #   sqlalchemy
-tzdata==2023.3
+tzdata==2023.4
     # via pandas
 uri-template==1.3.0
     # via jsonschema
@@ -655,9 +653,9 @@ urllib3==2.1.0
     # via
     #   requests
     #   twine
-virtualenv==20.24.7
+virtualenv==20.25.0
     # via -r deps/packaging.txt
-wcwidth==0.2.12
+wcwidth==0.2.13
     # via prompt-toolkit
 webcolors==1.13
     # via jsonschema
@@ -665,9 +663,9 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.6.4
+websocket-client==1.7.0
     # via jupyter-server
-wheel==0.41.3
+wheel==0.42.0
     # via
     #   -r deps/packaging.txt
     #   pip-tools

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -38,7 +38,6 @@ attrs==23.2.0
     #   referencing
 autoray==0.6.7
     # via
-    #   -r deps/runtime.txt
     #   cotengra
     #   quimb
 babel==2.14.0
@@ -361,9 +360,7 @@ openfermion[resources]==1.6.0
     #   -r deps/pylint.txt
     #   -r deps/pytest.txt
 opt-einsum==3.3.0
-    # via
-    #   -r deps/runtime.txt
-    #   jax
+    # via jax
 overrides==7.6.0
     # via jupyter-server
 packaging==23.2

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/docs.env.txt deps/docs.txt deps/runtime.txt
 #
-absl-py==2.0.0
+absl-py==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   tensorflow-docs
@@ -12,7 +12,7 @@ accessible-pygments==0.0.4
     # via
     #   -c envs/dev.env.txt
     #   pydata-sphinx-theme
-alabaster==0.7.13
+alabaster==0.7.16
     # via
     #   -c envs/dev.env.txt
     #   sphinx
@@ -24,7 +24,7 @@ asttokens==2.4.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -35,13 +35,14 @@ autoray==0.6.7
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   cotengra
     #   quimb
-babel==2.13.1
+babel==2.14.0
     # via
     #   -c envs/dev.env.txt
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -70,7 +71,7 @@ click==8.1.7
     # via
     #   -c envs/dev.env.txt
     #   jupyter-cache
-comm==0.2.0
+comm==0.2.1
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -79,6 +80,10 @@ contourpy==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
+cotengra==0.5.6
+    # via
+    #   -c envs/dev.env.txt
+    #   quimb
 cycler==0.12.1
     # via
     #   -c envs/dev.env.txt
@@ -117,19 +122,19 @@ executing==2.0.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-fastjsonschema==2.19.0
+fastjsonschema==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.45.0
+fonttools==4.47.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-greenlet==3.0.1
+greenlet==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   sqlalchemy
-idna==3.4
+idna==3.6
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -137,16 +142,16 @@ imagesize==1.4.1
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-importlib-metadata==6.8.0
+importlib-metadata==7.0.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-cache
     #   myst-nb
-ipykernel==6.27.0
+ipykernel==6.29.0
     # via
     #   -c envs/dev.env.txt
     #   myst-nb
-ipython==8.17.2
+ipython==8.20.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -169,11 +174,11 @@ jinja2==3.1.3
     #   nbconvert
     #   sphinx
     #   tensorflow-docs
-jsonschema==4.20.0
+jsonschema==4.21.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-jsonschema-specifications==2023.11.1
+jsonschema-specifications==2023.12.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -186,7 +191,7 @@ jupyter-client==8.6.0
     #   -c envs/dev.env.txt
     #   ipykernel
     #   nbclient
-jupyter-core==5.5.0
+jupyter-core==5.7.1
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -194,7 +199,7 @@ jupyter-core==5.5.0
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyterlab-pygments==0.2.2
+jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -215,7 +220,7 @@ markdown-it-py==3.0.0
     #   -c envs/dev.env.txt
     #   mdit-py-plugins
     #   myst-parser
-markupsafe==2.1.3
+markupsafe==2.1.4
     # via
     #   -c envs/dev.env.txt
     #   jinja2
@@ -260,7 +265,7 @@ nbclient==0.9.0
     #   jupyter-cache
     #   myst-nb
     #   nbconvert
-nbconvert==7.11.0
+nbconvert==7.14.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
@@ -275,7 +280,7 @@ nbformat==5.9.2
     #   nbclient
     #   nbconvert
     #   tensorflow-docs
-nest-asyncio==1.5.8
+nest-asyncio==1.6.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -304,7 +309,6 @@ opt-einsum==3.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-    #   quimb
 packaging==23.2
     # via
     #   -c envs/dev.env.txt
@@ -313,11 +317,11 @@ packaging==23.2
     #   nbconvert
     #   pydata-sphinx-theme
     #   sphinx
-pandas==2.1.3
+pandas==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pandocfilters==1.5.0
+pandocfilters==1.5.1
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -325,28 +329,28 @@ parso==0.8.3
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pexpect==4.8.0
+pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.0.0
+platformdirs==4.1.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
-prompt-toolkit==3.0.41
+prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.1
+protobuf==4.25.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   tensorflow-docs
-psutil==5.9.6
+psutil==5.9.8
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -359,11 +363,11 @@ pure-eval==0.2.2
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-pydata-sphinx-theme==0.14.3
+pydata-sphinx-theme==0.15.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
-pydot==1.4.2
+pydot==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -397,16 +401,16 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   tensorflow-docs
-pyzmq==25.1.1
+pyzmq==25.1.2
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
-quimb==1.6.0
+quimb==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.31.0
+referencing==0.32.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -415,7 +419,7 @@ requests==2.31.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-rpds-py==0.13.1
+rpds-py==0.17.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -450,20 +454,15 @@ sphinx==7.2.6
     #   myst-nb
     #   myst-parser
     #   pydata-sphinx-theme
-    #   sphinxcontrib-applehelp
-    #   sphinxcontrib-devhelp
-    #   sphinxcontrib-htmlhelp
-    #   sphinxcontrib-qthelp
-    #   sphinxcontrib-serializinghtml
-sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-applehelp==1.0.8
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-devhelp==1.0.6
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-htmlhelp==2.0.4
+sphinxcontrib-htmlhelp==2.0.5
     # via
     #   -c envs/dev.env.txt
     #   sphinx
@@ -471,15 +470,15 @@ sphinxcontrib-jsmath==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-qthelp==1.0.7
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-serializinghtml==1.1.9
+sphinxcontrib-serializinghtml==1.1.10
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sqlalchemy==2.0.23
+sqlalchemy==2.0.25
     # via
     #   -c envs/dev.env.txt
     #   jupyter-cache
@@ -508,7 +507,7 @@ toolz==0.12.0
     # via
     #   -c envs/dev.env.txt
     #   cytoolz
-tornado==6.3.3
+tornado==6.4
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -518,7 +517,7 @@ tqdm==4.66.1
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
-traitlets==5.13.0
+traitlets==5.14.1
     # via
     #   -c envs/dev.env.txt
     #   comm
@@ -531,14 +530,14 @@ traitlets==5.13.0
     #   nbclient
     #   nbconvert
     #   nbformat
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
     #   myst-nb
     #   pydata-sphinx-theme
     #   sqlalchemy
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -546,7 +545,7 @@ urllib3==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   requests
-wcwidth==0.2.12
+wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -34,7 +34,6 @@ attrs==23.2.0
 autoray==0.6.7
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/runtime.txt
     #   cotengra
     #   quimb
 babel==2.14.0
@@ -301,14 +300,9 @@ numpy==1.25.2
     #   contourpy
     #   matplotlib
     #   numba
-    #   opt-einsum
     #   pandas
     #   quimb
     #   scipy
-opt-einsum==3.3.0
-    # via
-    #   -c envs/dev.env.txt
-    #   -r deps/runtime.txt
 packaging==23.2
     # via
     #   -c envs/dev.env.txt

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -21,7 +21,6 @@ attrs==23.2.0
 autoray==0.6.7
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/runtime.txt
     #   cotengra
     #   quimb
 beautifulsoup4==4.12.3
@@ -213,14 +212,9 @@ numpy==1.25.2
     #   contourpy
     #   matplotlib
     #   numba
-    #   opt-einsum
     #   pandas
     #   quimb
     #   scipy
-opt-einsum==3.3.0
-    # via
-    #   -c envs/dev.env.txt
-    #   -r deps/runtime.txt
 packaging==23.2
     # via
     #   -c envs/dev.env.txt

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -12,7 +12,7 @@ asttokens==2.4.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -22,8 +22,9 @@ autoray==0.6.7
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   cotengra
     #   quimb
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -47,7 +48,7 @@ click==8.1.7
     # via
     #   -c envs/dev.env.txt
     #   black
-comm==0.2.0
+comm==0.2.1
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -55,6 +56,10 @@ contourpy==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
+cotengra==0.5.6
+    # via
+    #   -c envs/dev.env.txt
+    #   quimb
 cycler==0.12.1
     # via
     #   -c envs/dev.env.txt
@@ -83,7 +88,7 @@ executing==2.0.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-fastjsonschema==2.19.0
+fastjsonschema==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
@@ -91,11 +96,11 @@ flynt==0.78
     # via
     #   -c envs/dev.env.txt
     #   -r deps/format.txt
-fonttools==4.45.0
+fonttools==4.47.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-ipython==8.17.2
+ipython==8.20.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -116,11 +121,11 @@ jinja2==3.1.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-jsonschema==4.20.0
+jsonschema==4.21.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-jsonschema-specifications==2023.11.1
+jsonschema-specifications==2023.12.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -128,14 +133,14 @@ jupyter-client==8.6.0
     # via
     #   -c envs/dev.env.txt
     #   nbclient
-jupyter-core==5.5.0
+jupyter-core==5.7.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyterlab-pygments==0.2.2
+jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -151,7 +156,7 @@ llvmlite==0.41.1
     # via
     #   -c envs/dev.env.txt
     #   numba
-markupsafe==2.1.3
+markupsafe==2.1.4
     # via
     #   -c envs/dev.env.txt
     #   jinja2
@@ -181,7 +186,7 @@ nbclient==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-nbconvert==7.11.0
+nbconvert==7.14.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -216,17 +221,16 @@ opt-einsum==3.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-    #   quimb
 packaging==23.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
     #   nbconvert
-pandas==2.1.3
+pandas==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pandocfilters==1.5.0
+pandocfilters==1.5.1
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -234,32 +238,32 @@ parso==0.8.3
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pathspec==0.11.2
+pathspec==0.12.1
     # via
     #   -c envs/dev.env.txt
     #   black
-pexpect==4.8.0
+pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.0.0
+platformdirs==4.1.0
     # via
     #   -c envs/dev.env.txt
     #   black
     #   jupyter-core
-prompt-toolkit==3.0.41
+prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.1
+protobuf==4.25.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-psutil==5.9.6
+psutil==5.9.8
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -271,7 +275,7 @@ pure-eval==0.2.2
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-pydot==1.4.2
+pydot==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -295,20 +299,20 @@ pytz==2023.3.post1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-pyzmq==25.1.1
+pyzmq==25.1.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
-quimb==1.6.0
+quimb==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.31.0
+referencing==0.32.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==0.13.1
+rpds-py==0.17.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -354,7 +358,7 @@ toolz==0.12.0
     # via
     #   -c envs/dev.env.txt
     #   cytoolz
-tornado==6.3.3
+tornado==6.4
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
@@ -363,7 +367,7 @@ tqdm==4.66.1
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
-traitlets==5.13.0
+traitlets==5.14.1
     # via
     #   -c envs/dev.env.txt
     #   comm
@@ -375,15 +379,15 @@ traitlets==5.13.0
     #   nbclient
     #   nbconvert
     #   nbformat
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -c envs/dev.env.txt
     #   pandas
-wcwidth==0.2.12
+wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit

--- a/dev_tools/requirements/envs/pip-tools.env.txt
+++ b/dev_tools/requirements/envs/pip-tools.env.txt
@@ -30,7 +30,7 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.3
+wheel==0.42.0
     # via
     #   -c envs/dev.env.txt
     #   pip-tools

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -37,7 +37,6 @@ attrs==23.2.0
 autoray==0.6.7
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/runtime.txt
     #   cotengra
     #   quimb
 babel==2.14.0
@@ -300,7 +299,6 @@ openfermion[resources]==1.6.0
 opt-einsum==3.3.0
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/runtime.txt
     #   jax
 packaging==23.2
     # via

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/pylint.env.txt deps/pylint.txt deps/runtime.txt
 #
-absl-py==2.0.0
+absl-py==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   tensorflow-docs
-alabaster==0.7.13
+alabaster==0.7.16
     # via
     #   -c envs/dev.env.txt
     #   sphinx
@@ -28,7 +28,7 @@ asttokens==2.4.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -38,12 +38,13 @@ autoray==0.6.7
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   cotengra
     #   quimb
-babel==2.13.1
+babel==2.14.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -68,7 +69,7 @@ cirq-core==1.3.0.dev20231018023458
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   openfermion
-comm==0.2.0
+comm==0.2.1
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -76,6 +77,10 @@ contourpy==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
+cotengra==0.5.6
+    # via
+    #   -c envs/dev.env.txt
+    #   quimb
 cycler==0.12.1
     # via
     #   -c envs/dev.env.txt
@@ -117,11 +122,11 @@ executing==2.0.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-fastjsonschema==2.19.0
+fastjsonschema==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.45.0
+fonttools==4.47.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -130,7 +135,7 @@ h5py==3.10.0
     #   -c envs/dev.env.txt
     #   openfermion
     #   pyscf
-idna==3.4
+idna==3.6
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -142,7 +147,7 @@ iniconfig==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
-ipython==8.17.2
+ipython==8.20.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -155,11 +160,11 @@ isort==5.10.1
     # via
     #   -c envs/dev.env.txt
     #   pylint
-jax==0.4.20
+jax==0.4.23
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-jaxlib==0.4.20
+jaxlib==0.4.23
     # via
     #   -c envs/dev.env.txt
     #   openfermion
@@ -173,11 +178,11 @@ jinja2==3.1.3
     #   nbconvert
     #   sphinx
     #   tensorflow-docs
-jsonschema==4.20.0
+jsonschema==4.21.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-jsonschema-specifications==2023.11.1
+jsonschema-specifications==2023.12.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -185,14 +190,14 @@ jupyter-client==8.6.0
     # via
     #   -c envs/dev.env.txt
     #   nbclient
-jupyter-core==5.5.0
+jupyter-core==5.7.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyterlab-pygments==0.2.2
+jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -204,7 +209,7 @@ kiwisolver==1.4.5
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.10.0
     # via
     #   -c envs/dev.env.txt
     #   astroid
@@ -212,7 +217,7 @@ llvmlite==0.41.1
     # via
     #   -c envs/dev.env.txt
     #   numba
-markupsafe==2.1.3
+markupsafe==2.1.4
     # via
     #   -c envs/dev.env.txt
     #   jinja2
@@ -235,7 +240,7 @@ mistune==3.0.2
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-ml-dtypes==0.3.1
+ml-dtypes==0.3.2
     # via
     #   -c envs/dev.env.txt
     #   jax
@@ -248,7 +253,7 @@ nbclient==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-nbconvert==7.11.0
+nbconvert==7.14.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -297,7 +302,6 @@ opt-einsum==3.3.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   jax
-    #   quimb
 packaging==23.2
     # via
     #   -c envs/dev.env.txt
@@ -306,11 +310,11 @@ packaging==23.2
     #   nbconvert
     #   pytest
     #   sphinx
-pandas==2.1.3
+pandas==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pandocfilters==1.5.0
+pandocfilters==1.5.1
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -318,15 +322,15 @@ parso==0.8.3
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pexpect==4.8.0
+pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.0.0
+platformdirs==4.1.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -335,16 +339,16 @@ pluggy==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
-prompt-toolkit==3.0.41
+prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.1
+protobuf==4.25.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   tensorflow-docs
-psutil==5.9.6
+psutil==5.9.8
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -360,7 +364,7 @@ pure-eval==0.2.2
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-pydot==1.4.2
+pydot==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -383,7 +387,7 @@ pyscf==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-pytest==7.4.3
+pytest==7.4.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
@@ -401,15 +405,15 @@ pyyaml==6.0.1
     # via
     #   -c envs/dev.env.txt
     #   tensorflow-docs
-pyzmq==25.1.1
+pyzmq==25.1.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
-quimb==1.6.0
+quimb==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.31.0
+referencing==0.32.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -419,7 +423,7 @@ requests==2.31.0
     #   -c envs/dev.env.txt
     #   openfermion
     #   sphinx
-rpds-py==0.13.1
+rpds-py==0.17.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -456,20 +460,15 @@ sphinx==7.2.6
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
-    #   sphinxcontrib-applehelp
-    #   sphinxcontrib-devhelp
-    #   sphinxcontrib-htmlhelp
-    #   sphinxcontrib-qthelp
-    #   sphinxcontrib-serializinghtml
-sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-applehelp==1.0.8
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-devhelp==1.0.6
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-htmlhelp==2.0.4
+sphinxcontrib-htmlhelp==2.0.5
     # via
     #   -c envs/dev.env.txt
     #   sphinx
@@ -477,11 +476,11 @@ sphinxcontrib-jsmath==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-qthelp==1.0.7
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-serializinghtml==1.1.9
+sphinxcontrib-serializinghtml==1.1.10
     # via
     #   -c envs/dev.env.txt
     #   sphinx
@@ -516,7 +515,7 @@ toolz==0.12.0
     # via
     #   -c envs/dev.env.txt
     #   cytoolz
-tornado==6.3.3
+tornado==6.4
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
@@ -525,7 +524,7 @@ tqdm==4.66.1
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
-traitlets==5.13.0
+traitlets==5.14.1
     # via
     #   -c envs/dev.env.txt
     #   comm
@@ -537,12 +536,12 @@ traitlets==5.13.0
     #   nbclient
     #   nbconvert
     #   nbformat
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   astroid
     #   cirq-core
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -550,7 +549,7 @@ urllib3==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   requests
-wcwidth==0.2.12
+wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -12,7 +12,7 @@ asttokens==2.4.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -22,8 +22,9 @@ autoray==0.6.7
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   cotengra
     #   quimb
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -48,7 +49,7 @@ cirq-core==1.3.0.dev20231018023458
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   openfermion
-comm==0.2.0
+comm==0.2.1
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -57,7 +58,11 @@ contourpy==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-coverage[toml]==7.3.2
+cotengra==0.5.6
+    # via
+    #   -c envs/dev.env.txt
+    #   quimb
+coverage[toml]==7.4.0
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -102,11 +107,11 @@ executing==2.0.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-fastjsonschema==2.19.0
+fastjsonschema==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.45.0
+fonttools==4.47.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -115,7 +120,7 @@ h5py==3.10.0
     #   -c envs/dev.env.txt
     #   openfermion
     #   pyscf
-idna==3.4
+idna==3.6
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -123,11 +128,11 @@ iniconfig==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
-ipykernel==6.27.0
+ipykernel==6.29.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-ipython==8.17.2
+ipython==8.20.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -137,11 +142,11 @@ ipywidgets==8.1.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-jax==0.4.20
+jax==0.4.23
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-jaxlib==0.4.20
+jaxlib==0.4.23
     # via
     #   -c envs/dev.env.txt
     #   openfermion
@@ -153,11 +158,11 @@ jinja2==3.1.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-jsonschema==4.20.0
+jsonschema==4.21.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-jsonschema-specifications==2023.11.1
+jsonschema-specifications==2023.12.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -166,7 +171,7 @@ jupyter-client==8.6.0
     #   -c envs/dev.env.txt
     #   ipykernel
     #   nbclient
-jupyter-core==5.5.0
+jupyter-core==5.7.1
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -174,7 +179,7 @@ jupyter-core==5.5.0
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyterlab-pygments==0.2.2
+jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -190,7 +195,7 @@ llvmlite==0.41.1
     # via
     #   -c envs/dev.env.txt
     #   numba
-markupsafe==2.1.3
+markupsafe==2.1.4
     # via
     #   -c envs/dev.env.txt
     #   jinja2
@@ -210,7 +215,7 @@ mistune==3.0.2
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-ml-dtypes==0.3.1
+ml-dtypes==0.3.2
     # via
     #   -c envs/dev.env.txt
     #   jax
@@ -223,7 +228,7 @@ nbclient==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-nbconvert==7.11.0
+nbconvert==7.14.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -233,7 +238,7 @@ nbformat==5.9.2
     #   -r deps/runtime.txt
     #   nbclient
     #   nbconvert
-nest-asyncio==1.5.8
+nest-asyncio==1.6.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -275,7 +280,6 @@ opt-einsum==3.3.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   jax
-    #   quimb
 packaging==23.2
     # via
     #   -c envs/dev.env.txt
@@ -284,11 +288,11 @@ packaging==23.2
     #   matplotlib
     #   nbconvert
     #   pytest
-pandas==2.1.3
+pandas==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pandocfilters==1.5.0
+pandocfilters==1.5.1
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -296,15 +300,15 @@ parso==0.8.3
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pexpect==4.8.0
+pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.0.0
+platformdirs==4.1.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -312,15 +316,15 @@ pluggy==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
-prompt-toolkit==3.0.41
+prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.1
+protobuf==4.25.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-psutil==5.9.6
+psutil==5.9.8
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -337,7 +341,7 @@ pure-eval==0.2.2
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-pydot==1.4.2
+pydot==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -355,14 +359,14 @@ pyscf==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-pytest==7.4.3
+pytest==7.4.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -384,16 +388,16 @@ pytz==2023.3.post1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-pyzmq==25.1.1
+pyzmq==25.1.2
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
-quimb==1.6.0
+quimb==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.31.0
+referencing==0.32.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -402,7 +406,7 @@ requests==2.31.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-rpds-py==0.13.1
+rpds-py==0.17.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -454,7 +458,7 @@ toolz==0.12.0
     # via
     #   -c envs/dev.env.txt
     #   cytoolz
-tornado==6.3.3
+tornado==6.4
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -464,7 +468,7 @@ tqdm==4.66.1
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
-traitlets==5.13.0
+traitlets==5.14.1
     # via
     #   -c envs/dev.env.txt
     #   comm
@@ -477,11 +481,11 @@ traitlets==5.13.0
     #   nbclient
     #   nbconvert
     #   nbformat
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -489,7 +493,7 @@ urllib3==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   requests
-wcwidth==0.2.12
+wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -21,7 +21,6 @@ attrs==23.2.0
 autoray==0.6.7
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/runtime.txt
     #   cotengra
     #   quimb
 beautifulsoup4==4.12.3
@@ -278,7 +277,6 @@ openfermion[resources]==1.6.0
 opt-einsum==3.3.0
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/runtime.txt
     #   jax
 packaging==23.2
     # via

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -8,7 +8,7 @@ asttokens==2.4.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -18,8 +18,9 @@ autoray==0.6.7
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   cotengra
     #   quimb
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -35,7 +36,7 @@ cirq-core==1.3.0.dev20231018023458
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-comm==0.2.0
+comm==0.2.1
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -43,6 +44,10 @@ contourpy==1.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
+cotengra==0.5.6
+    # via
+    #   -c envs/dev.env.txt
+    #   quimb
 cycler==0.12.1
     # via
     #   -c envs/dev.env.txt
@@ -71,15 +76,15 @@ executing==2.0.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-fastjsonschema==2.19.0
+fastjsonschema==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.45.0
+fonttools==4.47.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-ipython==8.17.2
+ipython==8.20.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -96,11 +101,11 @@ jinja2==3.1.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-jsonschema==4.20.0
+jsonschema==4.21.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-jsonschema-specifications==2023.11.1
+jsonschema-specifications==2023.12.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -108,14 +113,14 @@ jupyter-client==8.6.0
     # via
     #   -c envs/dev.env.txt
     #   nbclient
-jupyter-core==5.5.0
+jupyter-core==5.7.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyterlab-pygments==0.2.2
+jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -131,7 +136,7 @@ llvmlite==0.41.1
     # via
     #   -c envs/dev.env.txt
     #   numba
-markupsafe==2.1.3
+markupsafe==2.1.4
     # via
     #   -c envs/dev.env.txt
     #   jinja2
@@ -157,7 +162,7 @@ nbclient==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-nbconvert==7.11.0
+nbconvert==7.14.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -192,17 +197,16 @@ opt-einsum==3.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-    #   quimb
 packaging==23.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
     #   nbconvert
-pandas==2.1.3
+pandas==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-pandocfilters==1.5.0
+pandocfilters==1.5.1
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -210,27 +214,27 @@ parso==0.8.3
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pexpect==4.8.0
+pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==10.1.0
+pillow==10.2.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.0.0
+platformdirs==4.1.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
-prompt-toolkit==3.0.41
+prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.1
+protobuf==4.25.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-psutil==5.9.6
+psutil==5.9.8
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -242,7 +246,7 @@ pure-eval==0.2.2
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-pydot==1.4.2
+pydot==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -266,20 +270,20 @@ pytz==2023.3.post1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-pyzmq==25.1.1
+pyzmq==25.1.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
-quimb==1.6.0
+quimb==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.31.0
+referencing==0.32.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==0.13.1
+rpds-py==0.17.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -320,7 +324,7 @@ toolz==0.12.0
     # via
     #   -c envs/dev.env.txt
     #   cytoolz
-tornado==6.3.3
+tornado==6.4
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
@@ -329,7 +333,7 @@ tqdm==4.66.1
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
-traitlets==5.13.0
+traitlets==5.14.1
     # via
     #   -c envs/dev.env.txt
     #   comm
@@ -341,15 +345,15 @@ traitlets==5.13.0
     #   nbclient
     #   nbconvert
     #   nbformat
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -c envs/dev.env.txt
     #   pandas
-wcwidth==0.2.12
+wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -17,7 +17,6 @@ attrs==23.2.0
 autoray==0.6.7
     # via
     #   -c envs/dev.env.txt
-    #   -r deps/runtime.txt
     #   cotengra
     #   quimb
 beautifulsoup4==4.12.3
@@ -189,14 +188,9 @@ numpy==1.25.2
     #   contourpy
     #   matplotlib
     #   numba
-    #   opt-einsum
     #   pandas
     #   quimb
     #   scipy
-opt-einsum==3.3.0
-    # via
-    #   -c envs/dev.env.txt
-    #   -r deps/runtime.txt
 packaging==23.2
     # via
     #   -c envs/dev.env.txt


### PR DESCRIPTION
 - pydot has a major version bump, but the changelog looks fine
 - quimb looks like it changed its preferred backend which is now declared in its dependencies rather than us listing a bunch of things ourselves. 