### PR TITLE
General costs

### DIFF
--- a/qualtran/Protocols.ipynb
+++ b/qualtran/Protocols.ipynb
@@ -24,26 +24,66 @@
    "id": "1e356672",
    "metadata": {},
    "source": [
-    "## Summary of Qualtran protocols\n",
+    "## Decomposition\n",
     "\n",
-    "### Decomposition\n",
+    "### Interface\n",
+    "You can get a decomposition of a bloq in terms of its component bloqs by calling `bloq.decompose_bloq()`. Additional functionality is provided by the `qualtran.BloqBuilder` class. \n",
     "\n",
-    "You can get a decomposition of a bloq in terms of its component bloqs by calling `bloq.decompose_bloq()`. Additional functionality is provided by the `qualtran.BloqBuilder` class. To implement this protocol, bloq authors can override `Bloq.build_composite_bloq(...)`. A fallback to use a Cirq decomposition is provided. There is no default fallback -- `qualtran.DecomposeNotImplementedError` will be raised.\n",
+    "### Implementation\n",
+    "\n",
+    "To implement this protocol, bloq authors can override `Bloq.build_composite_bloq(...)`.\n",
+    "\n",
+    "### Fallbacks\n",
+    "\n",
+    "There is no default implementation; `qualtran.DecomposeNotImplementedError` will be raised.\n",
+    "`qualtran.cirq_interop.decompose_from_cirq_style_method` can be used as a fallback."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26313128",
+   "metadata": {},
+   "source": [
+    "## Call Graph\n",
+    "\n",
+    "### Interface\n",
+    "\n",
+    "You can get a directed-acyclic graph representing the hierarchical decomposition of bloqs by calling `bloq.call_graph()` or direct callees with `bloq.bloq_counts()`. Additional functionality is contained in the `qualtran.resource_counting` module. \n",
+    "\n",
+    "### Implementation\n",
+    "To implement this protocol, bloq authors can override `Bloq.build_call_graph(...)`.\n",
     "\n",
     "\n",
-    "### Call Graph\n",
+    "### Fallbacks\n",
+    "The default fallback uses the decomposition protocol and `build_cbloq_call_graph(...)`. See the full [call graph protocol documentation](./resource_counting/bloq_counts.ipynb) for details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc9e374c",
+   "metadata": {},
+   "source": [
+    "## Tensor\n",
     "\n",
-    "You can get a directed-acyclic graph representing the hierarchical decomposition of bloqs by calling `bloq.call_graph()` or direct callees with `bloq.bloq_counts()`. Additional functionality is contained in the `qualtran.resource_counting` module. To implement this protocol, bloq authors can override `Bloq.build_call_graph(...)`. The default fallback uses the decomposition protocol and `build_cbloq_call_graph(...)`. See the full [call graph protocol documentation](./resource_counting/bloq_counts.ipynb) for details.\n",
+    "You can get a tensor (i.e. vector or matrix representation) of a bloq or composite bloq by calling `bloq.tensor_contract()`. Additional functionality is contained in the `qualtran.simulation.tensor` module. To implement this protocol, bloq authors can override `Bloq.add_my_tensors(...)`. The default fallback uses the decomposition protocol and `cbloq_as_contracted_tensor(...)`. See the full [tensor protocol documentation](./simulation/tensor.ipynb) for details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f13bbd6",
+   "metadata": {},
+   "source": [
+    "## Classical\n",
     "\n",
-    "### Tensor\n",
-    "\n",
-    "You can get a tensor (i.e. vector or matrix representation) of a bloq or composite bloq by calling `bloq.tensor_contract()`. Additional functionality is contained in the `qualtran.simulation.tensor` module. To implement this protocol, bloq authors can override `Bloq.add_my_tensors(...)`. The default fallback uses the decomposition protocol and `cbloq_as_contracted_tensor(...)`. See the full [tensor protocol documentation](./simulation/tensor.ipynb) for details.\n",
-    "\n",
-    "### Classical\n",
-    "\n",
-    "You can get a bloq's classical action on a basis state by calling `bloq.call_classically(**vals)`. Additional functionality is contained in the `qualtran.simulation.classical_sim` module. To implement this protocol, bloq authors can override `Bloq.on_classical_vals(...)`. The default fallback uses the decomposition protocol and `cbloq_call_classically`. An exception should be raised if a bloq acts non-classically on its data.\n",
-    "\n",
-    "### Other methods\n",
+    "You can get a bloq's classical action on a basis state by calling `bloq.call_classically(**vals)`. Additional functionality is contained in the `qualtran.simulation.classical_sim` module. To implement this protocol, bloq authors can override `Bloq.on_classical_vals(...)`. The default fallback uses the decomposition protocol and `cbloq_call_classically`. An exception should be raised if a bloq acts non-classically on its data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e356672",
+   "metadata": {},
+   "source": [
+    "## Other methods\n",
     "\n",
     "Other methods on `Bloq` can be called or overridden to support drawing or interoperability with Cirq."
    ]

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from qualtran.cirq_interop import CirqQuregT
     from qualtran.cirq_interop.t_complexity_protocol import TComplexity
     from qualtran.drawing import WireSymbol
-    from qualtran.resource_counting import BloqCountT, GeneralizerT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountT, CostKV, GeneralizerT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -278,6 +278,14 @@ class Bloq(metaclass=abc.ABCMeta):
         the provided `SympySymbolAllocator`.
         """
         return self.decompose_bloq().build_call_graph(ssa)
+
+    def my_static_costs(self) -> Sequence['CostKV']:
+        return []
+
+    def my_leaf_costs(self) -> Sequence['CostKV']:
+        from qualtran.resource_counting import AddCostVal, BloqCount
+
+        return [(BloqCount(self), AddCostVal(1))]
 
     def call_graph(
         self,

--- a/qualtran/bloqs/for_testing/costing.py
+++ b/qualtran/bloqs/for_testing/costing.py
@@ -1,0 +1,76 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import List, Sequence, Set
+
+from attrs import field, frozen
+
+from qualtran import Bloq, Signature
+from qualtran.resource_counting import (
+    AddCostVal,
+    BloqCount,
+    BloqCountT,
+    CLIFFORD_COST,
+    CostKV,
+    MaxCostVal,
+    MaxQubits,
+    MulCostVal,
+    SuccessProb,
+    SympySymbolAllocator,
+)
+
+
+@frozen
+class CostingBloq(Bloq):
+    """A bloq that lets you set the costs via attributes."""
+
+    name: str
+    num_qubits: int
+    callees: Sequence[BloqCountT] = field(converter=tuple, factory=tuple)
+    static_costs: Sequence[CostKV] = field(converter=tuple, factory=tuple)
+    leaf_costs: Sequence[CostKV] | None = field(
+        converter=lambda x: tuple(x) if x is not None else x, default=None
+    )
+
+    def signature(self) -> 'Signature':
+        return Signature.build(register=self.num_qubits)
+
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+        return set(self.callees)
+
+    def my_static_costs(self) -> List[CostKV]:
+        return [(MaxQubits(), MaxCostVal(self.num_qubits))] + list(self.static_costs)
+
+    def my_leaf_costs(self) -> List[CostKV]:
+        if self.leaf_costs is None:
+            return [(BloqCount(self), AddCostVal(1)), (MaxQubits(), MaxCostVal(self.num_qubits))]
+        return list(self.leaf_costs)
+
+    def pretty_name(self):
+        return self.name
+
+    def __str__(self):
+        return self.name
+
+
+def make_example_1() -> Bloq:
+    tgate = CostingBloq('TGate', num_qubits=1)
+    tof = CostingBloq(
+        'Tof', num_qubits=3, callees=[(tgate, 4)], static_costs=[(CLIFFORD_COST, AddCostVal(7))]
+    )
+    add = CostingBloq('Add', num_qubits=8, callees=[(tof, 8)])
+    comp = CostingBloq(
+        'Compare', num_qubits=9, callees=[(tof, 8)], static_costs=[(SuccessProb(), MulCostVal(0.9))]
+    )
+    modadd = CostingBloq('ModAdd', num_qubits=8, callees=[(add, 1), (comp, 2)])
+    return modadd

--- a/qualtran/resource_counting/__init__.py
+++ b/qualtran/resource_counting/__init__.py
@@ -17,9 +17,13 @@
 isort:skip_file
 """
 
+from ._cost_key import CostKey, BloqCount, AnyCount, CLIFFORD_COST, MaxQubits, SuccessProb
+from ._cost_val import CostVal, AddCostVal, MulCostVal, MaxCostVal
+
 from .bloq_counts import (
     BloqCountT,
     GeneralizerT,
+    CostKV,
     big_O,
     SympySymbolAllocator,
     get_bloq_call_graph,

--- a/qualtran/resource_counting/_cost_key.py
+++ b/qualtran/resource_counting/_cost_key.py
@@ -1,0 +1,74 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import abc
+from typing import Generic, TYPE_CHECKING
+
+from attrs import frozen
+
+from ._cost_val import AddCostVal, CostValT, MaxCostVal, MulCostVal
+
+if TYPE_CHECKING:
+    from qualtran import Bloq
+
+
+class CostKey(Generic[CostValT], metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def identity_val(self) -> CostValT:
+        ...
+
+
+@frozen
+class BloqCount(CostKey[AddCostVal]):
+    bloq: 'Bloq'
+
+    def identity_val(self) -> AddCostVal:
+        return AddCostVal(0)
+
+    def __str__(self):
+        return f'{self.bloq} count'
+
+
+@frozen
+class AnyCount(CostKey[AddCostVal]):
+    cost_name: str
+
+    def identity_val(self) -> AddCostVal:
+        return AddCostVal(0)
+
+    def __str__(self):
+        return f'{self.cost_name} count'
+
+
+CLIFFORD_COST = AnyCount("clifford")
+
+
+@frozen
+class MaxQubits(CostKey[MaxCostVal]):
+    """A cost representing the maximum qubits required."""
+
+    def identity_val(self) -> MaxCostVal:
+        return MaxCostVal.minval()
+
+    def __str__(self):
+        return 'max qubits'
+
+
+@frozen
+class SuccessProb(CostKey[MulCostVal]):
+    def identity_val(self) -> MulCostVal:
+        return MulCostVal(1.0)
+
+    def __str__(self):
+        return 'success prob'

--- a/qualtran/resource_counting/_cost_val.py
+++ b/qualtran/resource_counting/_cost_val.py
@@ -1,0 +1,89 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import abc
+import math
+from typing import TypeVar
+
+from attrs import frozen
+
+
+class CostVal(metaclass=abc.ABCMeta):
+    """Values that can do val += y * n
+
+    "+=" should combine two costs; "*n" should do the combination n times;
+    For additive costs, these are normal addition and multiplication.
+    For multiplicitive costs, these would be multiplying and power.
+    For "max" costs, this is max() and identity.
+    """
+
+    @abc.abstractmethod
+    def __mul__(self, other):
+        ...
+
+    @abc.abstractmethod
+    def __iadd__(self, other):
+        ...
+
+
+CostValT = TypeVar('CostValT', bound=CostVal)
+
+
+@frozen
+class AddCostVal(CostVal):
+    qty: int
+
+    def __mul__(self, other: int):
+        return AddCostVal(self.qty * other)
+
+    def __iadd__(self, other: 'AddCostVal'):
+        return AddCostVal(self.qty + other.qty)
+
+    def __str__(self):
+        return f'{self.qty}'
+
+
+@frozen
+class MulCostVal(CostVal):
+    val: float
+
+    def __mul__(self, other: int):
+        return MulCostVal(self.val**other)
+
+    def __iadd__(self, other: 'MulCostVal'):
+        assert isinstance(other, MulCostVal)
+        return MulCostVal(self.val * other.val)
+
+    def __str__(self):
+        return f'{self.val}'
+
+
+@frozen
+class MaxCostVal(CostVal):
+    val: float
+
+    @classmethod
+    def minval(cls) -> 'MaxCostVal':
+        return MaxCostVal(-math.inf)
+
+    def __mul__(self, other: int):
+        # doing repeated "max" is the same as doing one max.
+        return MaxCostVal(self.val)
+
+    def __iadd__(self, other: 'MaxCostVal'):
+        assert isinstance(other, MaxCostVal)
+        return MaxCostVal(max(self.val, other.val))
+
+    def __str__(self):
+        return f'{self.val}'

--- a/qualtran/resource_counting/generic_costs_scratch.ipynb
+++ b/qualtran/resource_counting/generic_costs_scratch.ipynb
@@ -1,0 +1,173 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a650c1ad",
+   "metadata": {},
+   "source": [
+    "Each leaf bloq reports its \"leaf costs\". The costs are percolated up the DAG with simple recursion:\n",
+    "\n",
+    "```python\n",
+    "def cost(caller):\n",
+    "    # Base case: leaf bloq\n",
+    "    if is_leaf(caller):\n",
+    "        return caller.my_leaf_costs()\n",
+    "    \n",
+    "    # Recursive step: callees\n",
+    "    return sum(n * cost(callee) for n, callee in caller.callees())\n",
+    "```\n",
+    "\n",
+    "Note that we *only* query `bloq.leaf_costs()` when the bloq is an actual leaf. What if there is other information we want to annotate on bloqs that are not leaf bloqs? Like succeess probability or some sort of overhead? We add a method for including costs that should be added to the ones gleaned from recursion.\n",
+    "\n",
+    "```python\n",
+    "    cost = sum(n * cost(callee) for n, callee in caller.callees())\n",
+    "    cost += caller.my_static_costs()\n",
+    "    return cost\n",
+    "```\n",
+    "\n",
+    "I've been using addition and multiplication for convenience, but these operations depend on the cost value type. `+` should be considered a generic reduction step and `* n` should mean \"do that reduction `n` times\". For something like success probability, you'd use multiplication and power. For something like max qubit width, you'd use max and identity. Each type of cost also has to report its \"identity\" aka 0 value to make the reduction work.\n",
+    "\n",
+    "I've been using one cost value; but the `.my_leaf_costs()` and `.my_static_costs()` methods will return a list of `(costkey, costval)` tuples and all the operations should be done be joining on the `costkey` column. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3258aaa1",
+   "metadata": {},
+   "source": [
+    "-----"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38b53f2a",
+   "metadata": {},
+   "source": [
+    "We want the source code to define a canonical call graph but we may want to muck with it for resource estimation purposes. For example: we already support stopping early by marking certain bloqs as leaf bloqs; and we support merging bloqs through the `generalizer`. \n",
+    "\n",
+    "Consider if we wanted to query either Total T Count or T+Tof count. With one \"costs\" method; you'd either never get the total T count or always get the total T count. If you did something really naive, you'd double-count the Ts from the toffoli decomposition. We need to be able to say that it costs *either* the sum of its callees *or* this fixed value of 1 toffoli.\n",
+    "\n",
+    "So in our design, we first build the call graph in the usual way and generalize and leaf-ify to our hearts content. We then use that online call graph to do the cost recursion which will intelligently dispatch to either the recursive costs or the leaf costs.\n",
+    "\n",
+    "A potential drawback is if you leafify something that doesn't explicitly specify its leaf costs, you may quietly miss some important costs. But it would be redundant to manually put in all the recursive costs in case that bloq is ever used as a leaf. The compromise solution is for the default leaf costs method to report that it takes 1 bloq-count of `self`. This prevents accidently ignoring a whole subtree of the call graph. But any of the non-bloq-count recursively-derived costs would be lost."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffc45ce3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloq, show_call_graph\n",
+    "\n",
+    "%matplotlib inline\n",
+    "from matplotlib import pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06af1e63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.for_testing.costing import CostingBloq, make_example_1\n",
+    "cost_bloq = make_example_1()\n",
+    "g, _ = cost_bloq.call_graph(keep=lambda b:b.name in ['TGate'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11086383",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_call_graph(g)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9eb3bdcc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for bloq, data in g.nodes.data():\n",
+    "    print(bloq,'\\t', data['costs'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25a54673",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.bloq_counts import _sum_up_costs\n",
+    "totals = _sum_up_costs(g)\n",
+    "print('----------------\\n\\n')\n",
+    "\n",
+    "for bloq, costs in totals.items():\n",
+    "    print(bloq)\n",
+    "    for costkey, costval in costs.items():\n",
+    "        print('  ', costkey, '\\t', costval)\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b044717",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing.bloq_counts_graph import GraphvizCounts\n",
+    "\n",
+    "class CostGraphviz(GraphvizCounts):\n",
+    "    def __init__(self, g, totals):\n",
+    "        super().__init__(g)\n",
+    "        self.totals = totals\n",
+    "    \n",
+    "    \n",
+    "    def get_node_properties(self, b):\n",
+    "        label = ['<']\n",
+    "        label += ['<font point-size=\"10\">']\n",
+    "        label += ['<table border=\"0\" cellborder=\"1\" cellspacing=\"0\" cellpadding=\"5\">\\n']\n",
+    "        label += [f'<tr><td colspan=\"2\"><font point-size=\"12\">{b.name}(nq={b.num_qubits})</font></td></tr>\\n']\n",
+    "        \n",
+    "        for cost, costval in self.totals[b].items():\n",
+    "            label += [f'<tr><td>{cost}</td><td>{costval}</td></tr>']\n",
+    "        \n",
+    "        label += ['</table></font>']\n",
+    "        label += ['>']\n",
+    "        return {'label': ''.join(label), 'shape': 'plaintext'}\n",
+    "    \n",
+    "    \n",
+    "CostGraphviz(g, totals).get_svg()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
One of qualtran's main objective is to aid in the accounting of resource requirements ("costs") for quantum algorithms. The call graph protocol will happily count up bloqs for you, but we want to account for other costs (qubit 'width', precision, ...).

**This is a draft PR that sketches out my current prototype, described a bit below.**

This PR builds on the call graph. Recall that nodes in the call graph are bloqs and edges indicate that the predecessor bloq "calls" the successor bloq as a subroutine. The edges are annotated with a quantity `'n'`, which is how many times the callee is invoked. 

Now, nodes in the call graph (i.e. bloqs) will be annotated with a `"costs"` field. This is a table of costs (namely a list of `(CostKey, CostVal)` tuples). `CostKey` can be things like `BloqCount(bloq=TGate())` or `MaxQubits()` and `CostVal` can be an additive, multiplicative, or extrememizing general 'value'. The costs are derived from the call graph.

   cost(caller, is_leaf=False) = caller.static_costs + sum(n * cost(callee) for n, callee in caller.callees)
   cost(bloq, is_leaf=True) = bloq.static_costs + bloq.leaf_costs

That is: we use _either_ the sum of callee costs _or_ specifically annotated 'leaf' costs depending on whether the bloq is a leaf (or not) in the call graph. You can use the existing call graph machinery to treat bloqs as leafs (or not) with `generalizer`, `keep`, and `max_depth` arguments. 

Consider if we wanted to query either Total T Count or T+Tof count. With one "costs" method; you'd either never get the total T count or always get the total T count. If you did something really naive, you'd double-count the Ts from the toffoli decomposition. We need to be able to say that it costs *either* the sum of its callees *or* this fixed value of 1 toffoli.


The pseudocode above uses addition and multiplication for convenience, but these operations depend on the `CostVal` type. `+` should be considered a generic reduction step and `* n` should mean "do that reduction `n` times". For something like success probability, you'd use multiplication and power. For something like max qubit width, you'd use max and identity. Each type of cost also has to report its "identity" aka 0 value to make the reduction work.

The pseudocode above implies one cost per bloq; but all methods handle a list of `(CostKey, CostVal)`. Reductions are done by joining on the `CostKey` column. 