### PR TITLE
Add build_call_graph for qrom.

### DIFF
--- a/qualtran/bloqs/qrom.py
+++ b/qualtran/bloqs/qrom.py
@@ -23,7 +23,7 @@ from numpy.typing import ArrayLike, NDArray
 from qualtran import Register, SelectionRegister, Soquet
 from qualtran._infra.gate_with_registers import merge_qubits, total_bits
 from qualtran.bloqs.and_bloq import And, MultiAnd
-from qualtran.bloqs.basic_gates import CNOT, XGate
+from qualtran.bloqs.basic_gates import CNOT
 from qualtran.bloqs.unary_iteration_bloq import UnaryIterationGate
 from qualtran.drawing import Circle, TextBox, WireSymbol
 from qualtran.resource_counting import BloqCountT, SympySymbolAllocator


### PR DESCRIPTION
Fixes half of #559 by adding a build_call_graph method. The QROM Circuit is unary iteration + a bunch of cnots to write the data. The call graph works out the cnot count through the bit pattern of the data and the Toffoli count through the usual unary iteration formula.

Currently this doesn't work for the variable space qrom which requires a specific pattern for the input data. There are two options: 1) add this checking to the method, or 2) Make a new VariableSpacedQROM bloq which does some checks on the input data and uses the correct cost. I prefer option 2) as it makes things more explicit and makes this pretty useful feature more visible. What do you think @tanujkhattar 