### PR TITLE
Add `add_my_tensors` implementation to Allocate and enable tensor contraction for `PhaseGradientState` Bloq

### DIFF
--- a/qualtran/bloqs/rotations/phase_gradient_test.py
+++ b/qualtran/bloqs/rotations/phase_gradient_test.py
@@ -44,6 +44,15 @@ def test_phase_gradient_state(n: int):
 
 
 @pytest.mark.parametrize('n', [6, 7, 8])
+@pytest.mark.parametrize('t', [+0.124, -0.124, -1, +1])
+def test_phase_gradient_state_tensor_contract(n: int, t: float):
+    omega = np.exp(np.pi * 2 * t * 1j / (2**n))
+    state_coefs = 1 / np.sqrt(2**n) * np.array([omega**k for k in range(2**n)])
+    bloq = PhaseGradientState(n, t)
+    np.testing.assert_allclose(state_coefs, bloq.tensor_contract())
+
+
+@pytest.mark.parametrize('n', [6, 7, 8])
 @pytest.mark.parametrize('exponent', [-0.5, 1, 1 / 10])
 @pytest.mark.parametrize('controlled', [True, False])
 def test_phase_gradient_gate(n: int, exponent, controlled):

--- a/qualtran/bloqs/util_bloqs.py
+++ b/qualtran/bloqs/util_bloqs.py
@@ -280,6 +280,18 @@ class Allocate(Bloq):
     def t_complexity(self) -> 'TComplexity':
         return TComplexity()
 
+    def add_my_tensors(
+        self,
+        tn: 'qtn.TensorNetwork',
+        tag: Any,
+        *,
+        incoming: Dict[str, 'SoquetT'],
+        outgoing: Dict[str, 'SoquetT'],
+    ):
+        data = np.zeros(1 << self.n)
+        data[0] = 1
+        tn.add(qtn.Tensor(data=data, inds=(outgoing['reg'],), tags=['Allocate', tag]))
+
 
 @frozen
 class Free(Bloq):

--- a/qualtran/bloqs/util_bloqs_test.py
+++ b/qualtran/bloqs/util_bloqs_test.py
@@ -60,6 +60,17 @@ def test_util_bloqs():
     assert no_return is None
 
 
+def test_util_bloqs_tensor_contraction():
+    bb = BloqBuilder()
+    qs1 = bb.add(Allocate(10))
+    qs2 = bb.add(Split(10), reg=qs1)
+    qs3 = bb.add(Join(10), reg=qs2)
+    cbloq = bb.finalize(out=qs3)
+    expected = np.zeros(2**10)
+    expected[0] = 1
+    np.testing.assert_allclose(cbloq.tensor_contract(), expected)
+
+
 @frozen
 class TestPartition(Bloq):
     test_bloq: Bloq


### PR DESCRIPTION
An `Allocate` bloq should correspond to a new n-bit `|0^{n}>` state. 

Partially fixes https://github.com/quantumlib/Qualtran/issues/616 (adjoint uses `Free` which still doesn't have a tensor decomposition)
Obsoletes https://github.com/quantumlib/Qualtran/pull/615
Part of resolving https://github.com/quantumlib/Qualtran/issues/513