### PR TITLE
Add quantum data types

### DIFF
--- a/qualtran/_infra/data_types.py
+++ b/qualtran/_infra/data_types.py
@@ -73,12 +73,12 @@ class QAny(QDType):
 
     bitsize: Union[int, sympy.Expr]
 
+    def __attrs_post_init__(self):
+        assert self.bitsize > 1, "bitsize must be > 1."
+
     @property
     def num_qubits(self):
         return self.bitsize
-
-    def __eq__(self, other) -> bool:
-        return other.num_qubits == self.num_qubits
 
 
 @attrs.frozen
@@ -92,6 +92,9 @@ class QInt(QDType):
     """
 
     bitsize: Union[int, sympy.Expr]
+
+    def __attrs_post_init__(self):
+        assert self.bitsize > 1, "bitsize must be > 1."
 
     @property
     def num_qubits(self):
@@ -109,6 +112,9 @@ class QIntOnesComp(QDType):
     """
 
     bitsize: Union[int, sympy.Expr]
+
+    def __attrs_post_init__(self):
+        assert self.bitsize > 1, "bitsize must be > 1."
 
     @property
     def num_qubits(self):
@@ -128,6 +134,9 @@ class QUnsignedInt(QDType):
 
     bitsize: int
 
+    def __attrs_post_init__(self):
+        assert self.bitsize > 1, "bitsize must be > 1."
+
     @property
     def num_qubits(self):
         return self.bitsize
@@ -146,12 +155,10 @@ class BoundedQInt(QDType):
     iteration_length: int
 
     def __attrs_post_init__(self):
-        if self.iteration_range.start > self.iteration_range.stop:
-            raise ValueError("iteration_range limits should be increasing in value.")
-
-        if len(self.iteration_range) > 2**self.bitsize:
+        assert self.bitsize > 1, "bitsize must be > 1."
+        if self.iteration_length > 2**self.bitsize:
             raise ValueError(
-                f"BoundedQInt iteration length is too large for given bitsize. {len(self.iteration_range)} vs {2**self.bitsize}"
+                f"BoundedQInt iteration length is too large for given bitsize. {self.iteration_length} vs {2**self.bitsize}"
             )
 
     @property
@@ -177,3 +184,6 @@ class QFixedPoint(QDType):
     @property
     def num_qubits(self):
         return self.int_bitsize + self.frac_bitsize + 1
+
+    def __attrs_post_init__(self):
+        assert self.num_qubits > 1, "Number of qubits must be > 1."

--- a/qualtran/_infra/data_types.py
+++ b/qualtran/_infra/data_types.py
@@ -1,0 +1,179 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Quantum data type definitions.
+
+We often wish to write algorithms which operate on quantum data. One can think
+of quantum data types, similar to classical data types, where a collection of
+qubits can be used to represent a specific quantum data type (eg: a quantum
+integer of width 32 would comprise of 32 qubits, similar to a classical uint32
+type). More generally, many current primitives and algorithms in qualtran
+implicitly expect registers which represent signed or unsigned integers,
+fixed-point (fp) numbers , or “classical registers” which store some classical
+value. Enforcing typing helps developers and users reason about algorithms, and
+will also allow better type checking.
+
+The basic principles we follow are:
+
+1. Typing should not be too invasive for the developer / user: We got pretty far
+without explicitly typing registers.
+2. For algorithms or bloqs which expect registers which are meant to encode
+numeric types (integers, reals, etc.) then typing should be strictly enforced.
+For example, a bloq multiplying two fixed point reals should be built with an
+explicit QFixedPoint dtype.
+3. The smallest addressable unit is a QBit. Other types are interpretations of
+collections of QBits. A QUnsigedInt(32) is intended to represent a register
+encoding positive integers.
+4. To avoid too much overhead we have a QAny type, which is meant to represent
+an opaque bag of bits with no particular significance associated with them. A
+bloq defined with a QAny register (e.g. a n-bit CSwap) will accept any other type assuming the
+bitsizes match. QInt(32) == QAny(32), QInt(32) != QFixedPoint(16, 16). QInt(32) != QUnsignedInt(32).
+5. We assume a big endian convention for addressing QBits in registers throughout qualtran.
+6. Ones' complement integers are used extensively in quantum algorithms. We have
+two types QInt and QIntOnesComp for integers using two's and ones' complement
+respectively.
+"""
+
+import abc
+from typing import Union
+
+import attrs
+import sympy
+
+
+class QDType:
+    @property
+    @abc.abstractmethod
+    def num_qubits(self):
+        """Number of qubits required to represent a single instance of this data type."""
+
+
+@attrs.frozen
+class QBit(QDType):
+    """A single qubit. The smallest addressable unit of quantum data."""
+
+    @property
+    def num_qubits(self):
+        return 1
+
+
+@attrs.frozen
+class QAny(QDType):
+    """Opaque bag-of-qbits type. Should be used sparingly"""
+
+    bitsize: Union[int, sympy.Expr]
+
+    @property
+    def num_qubits(self):
+        return self.bitsize
+
+    def __eq__(self, other) -> bool:
+        return other.num_qubits == self.num_qubits
+
+
+@attrs.frozen
+class QInt(QDType):
+    """Integer of a given width bitsize.
+
+    A two's complement representation is assumed for negative integers.
+
+    Attributes:
+        bitsize: The number of qubits used to represent the integer.
+    """
+
+    bitsize: Union[int, sympy.Expr]
+
+    @property
+    def num_qubits(self):
+        return self.bitsize
+
+
+@attrs.frozen
+class QIntOnesComp(QDType):
+    """Integer of a given width bitsize.
+
+    A ones' complement representation is assumed for negative integers.
+
+    Attributes:
+        bitsize: The number of qubits used to represent the integer.
+    """
+
+    bitsize: Union[int, sympy.Expr]
+
+    @property
+    def num_qubits(self):
+        return self.bitsize
+
+
+@attrs.frozen
+class QUnsignedInt(QDType):
+    """Integer of a given width bitsize which wraps around upon overflow.
+
+    Similar to unsigned integer types in C. Any intended wrap around effect is
+    expected to be handled by the developer.
+
+    Attributes:
+        bitsize: The number of qubits used to represent the integer.
+    """
+
+    bitsize: int
+
+    @property
+    def num_qubits(self):
+        return self.bitsize
+
+
+@attrs.frozen
+class BoundedQInt(QDType):
+    """Integer whose values are bounded within a range.
+
+    Attributes:
+        bitsize: The number of qubits used to represent the integer.
+        iteration_length: The length of the iteration range.
+    """
+
+    bitsize: Union[int, sympy.Expr]
+    iteration_length: int
+
+    def __attrs_post_init__(self):
+        if self.iteration_range.start > self.iteration_range.stop:
+            raise ValueError("iteration_range limits should be increasing in value.")
+
+        if len(self.iteration_range) > 2**self.bitsize:
+            raise ValueError(
+                f"BoundedQInt iteration length is too large for given bitsize. {len(self.iteration_range)} vs {2**self.bitsize}"
+            )
+
+    @property
+    def num_qubits(self):
+        return self.bitsize
+
+
+@attrs.frozen
+class QFixedPoint(QDType):
+    """Fixed point type to represent real numbers.
+
+    The integer part of the float and the fractional part (the part after the
+    decimal plase) can be chosen to have different bitsizes. An additional sign bit is assumed.
+
+    Attributes:
+        int_bitsize: The number of qubits used to represent the integer part of the float.
+        frac_bitsize: The number of qubits used to represent the fractional part of the float.
+    """
+
+    int_bitsize: Union[int, sympy.Expr]
+    frac_bitsize: Union[int, sympy.Expr]
+
+    @property
+    def num_qubits(self):
+        return self.int_bitsize + self.frac_bitsize + 1

--- a/qualtran/_infra/data_types.py
+++ b/qualtran/_infra/data_types.py
@@ -69,7 +69,7 @@ class QBit(QDType):
 
 @attrs.frozen
 class QAny(QDType):
-    """Opaque bag-of-qbits type. Should be used sparingly"""
+    """Opaque bag-of-qbits type."""
 
     bitsize: Union[int, sympy.Expr]
 
@@ -83,7 +83,7 @@ class QAny(QDType):
 
 @attrs.frozen
 class QInt(QDType):
-    """Integer of a given width bitsize.
+    """Signed Integer of a given width bitsize.
 
     A two's complement representation is assumed for negative integers.
 
@@ -103,7 +103,7 @@ class QInt(QDType):
 
 @attrs.frozen
 class QIntOnesComp(QDType):
-    """Integer of a given width bitsize.
+    """Signed Integer of a given width bitsize.
 
     A ones' complement representation is assumed for negative integers.
 
@@ -123,7 +123,7 @@ class QIntOnesComp(QDType):
 
 @attrs.frozen
 class QUnsignedInt(QDType):
-    """Integer of a given width bitsize which wraps around upon overflow.
+    """Unsigned integer of a given width bitsize which wraps around upon overflow.
 
     Similar to unsigned integer types in C. Any intended wrap around effect is
     expected to be handled by the developer.

--- a/qualtran/_infra/data_types_test.py
+++ b/qualtran/_infra/data_types_test.py
@@ -1,0 +1,43 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from qualtran._infra.data_types import BoundedQInt, QFixedPoint, QInt, QUnsignedInt
+
+
+def test_qint():
+    qint_8 = QInt(8)
+    assert qint_8.num_qubits == 8
+
+
+def test_qintmod():
+    qint_8 = QUnsignedInt(8)
+    assert qint_8.num_qubits == 8
+
+
+def test_bounded_qint():
+    qint_3 = BoundedQInt(2, range(0, 3))
+    assert qint_3.bitsize == 2
+    assert len(qint_3.iteration_range) == 3
+    qint_4 = BoundedQInt(3, range(-2, 2))
+    with pytest.raises(ValueError):
+        BoundedQInt(3, range(0, 9))
+    with pytest.raises(ValueError):
+        BoundedQInt(3, range(2, -2))
+
+
+def test_qfixedpoint():
+    qfp_16 = QFixedPoint(1, 15)
+    assert qfp_16.num_qubits == 16

--- a/qualtran/_infra/data_types_test.py
+++ b/qualtran/_infra/data_types_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from qualtran._infra.data_types import BoundedQInt, QFixedPoint, QInt, QUnsignedInt
+from qualtran._infra.data_types import BoundedQInt, QFixedPoint, QInt, QIntOnesComp, QUnsignedInt
 
 
 def test_qint():
@@ -22,22 +22,24 @@ def test_qint():
     assert qint_8.num_qubits == 8
 
 
-def test_qintmod():
+def test_qint_ones():
+    qint_8 = QIntOnesComp(8)
+    assert qint_8.num_qubits == 8
+
+
+def test_quint():
     qint_8 = QUnsignedInt(8)
     assert qint_8.num_qubits == 8
 
 
 def test_bounded_qint():
-    qint_3 = BoundedQInt(2, range(0, 3))
+    qint_3 = BoundedQInt(2, 3)
     assert qint_3.bitsize == 2
-    assert len(qint_3.iteration_range) == 3
-    qint_4 = BoundedQInt(3, range(-2, 2))
+    assert qint_3.iteration_length == 3
     with pytest.raises(ValueError):
-        BoundedQInt(3, range(0, 9))
-    with pytest.raises(ValueError):
-        BoundedQInt(3, range(2, -2))
+        BoundedQInt(4, 76)
 
 
 def test_qfixedpoint():
     qfp_16 = QFixedPoint(1, 15)
-    assert qfp_16.num_qubits == 16
+    assert qfp_16.num_qubits == 17

--- a/qualtran/_infra/registers.py
+++ b/qualtran/_infra/registers.py
@@ -16,11 +16,14 @@
 import enum
 import itertools
 from collections import defaultdict
+from functools import cached_property
 from typing import Dict, Iterable, Iterator, List, overload, Tuple
 
 import attrs
 import numpy as np
 from attrs import field, frozen
+
+from .data_types import QAny, QBit
 
 
 class Side(enum.Flag):
@@ -62,6 +65,12 @@ class Register:
         default=tuple(), converter=lambda v: (v,) if isinstance(v, int) else tuple(v)
     )
     side: Side = Side.THRU
+
+    @cached_property
+    def dtype(self):
+        if self.bitsize == 1:
+            return QBit()
+        return QAny(self.n)
 
     def all_idxs(self) -> Iterable[Tuple[int, ...]]:
         """Iterate over all possible indices of a multidimensional register."""


### PR DESCRIPTION
Factored out from #597.

* Adds the basic data types under _infra/data_types, with some documentation.
* Adds a dtype property to registers. I couldn't find a non-invasive way of shimming in the register to use the dtype: adding a converter for bitsize is problematic because then reg.bitsize would return a QDType. changing the name to reg.dtype would require a huge diff (replacing Register(.., bitsize=n) everywhere).
* No type checking or any other features of data types are used. Essentially nothing has changed.

Part 2: deprecate bitsize in register for dtype and add bitsize as a parameter. Add some interception code for Signature.build as discussed in #597. This will be a big PR. passing an int will work but will raise a warning potentially (although this is probably too annoying in practice). This will lead to some temporary weirdness like reg = Register(dtype=1) which is unfortunate but I don't see a way around it.

Part3: deprecate SelectionRegister in favour of Register(dtype=BoundedQInt(...))

Part 4: A handful of PRs for the registers which actually use numeric types (arithmetic / chemistry, ...). Splits / Joins. Type checking won't be enforced yet.

Part 5:  Totally deprecate integer values for Register.

Part 6: Enforce type checking of registers during _process_soquets. Splits/Joins expect dtypes rather than register sizes.