### PR TITLE
[GQSP] fix bug in phase angle calculation

### DIFF
--- a/qualtran/bloqs/generalized_qsp.py
+++ b/qualtran/bloqs/generalized_qsp.py
@@ -224,7 +224,7 @@ def qsp_phase_factors(
         a, b = S[:, d]
         theta[d] = np.arctan2(np.abs(b), np.abs(a))
         # \phi_d = arg(a / b)
-        phi[d] = 0 if np.isclose(np.abs(b), 0) else safe_angle(a) - safe_angle(b)
+        phi[d] = 0 if np.isclose(np.abs(b), 0) else safe_angle(a * np.conj(b))
 
         if d == 0:
             lambd = safe_angle(b)

--- a/qualtran/bloqs/generalized_qsp.py
+++ b/qualtran/bloqs/generalized_qsp.py
@@ -282,7 +282,7 @@ class GeneralizedQSP(GateWithRegisters):
 
     @cached_property
     def _lambda(self) -> float:
-        return 0  # self._qsp_phases[2]
+        return self._qsp_phases[2]
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, signal, **quregs: NDArray[cirq.Qid]

--- a/qualtran/bloqs/generalized_qsp.py
+++ b/qualtran/bloqs/generalized_qsp.py
@@ -245,7 +245,7 @@ def qsp_phase_factors(
         if d == 0:
             lambd = safe_angle(b)
         else:
-            S = SU2RotationGate(theta[d], phi[d], 0).rotation_matrix @ S
+            S = SU2RotationGate(theta[d], phi[d], 0).rotation_matrix.conj().T @ S
 
             # check if the gate was actually correct
             aa, bb = S[0][0], S[1][d]

--- a/qualtran/bloqs/generalized_qsp.py
+++ b/qualtran/bloqs/generalized_qsp.py
@@ -68,15 +68,10 @@ class SU2RotationGate(GateWithRegisters):
     ) -> cirq.OP_TREE:
         qubit = q[0]
 
-        gates = cirq.single_qubit_matrix_to_gates(self.rotation_matrix)
-        matrix = np.eye(2)
-        for gate in gates:
-            yield gate.on(qubit)
-            matrix = cirq.unitary(gate) @ matrix
-
-        # `cirq.single_qubit_matrix_to_gates` does not preserve global phase
-        matrix = matrix @ self.rotation_matrix.conj().T
-        yield cirq.GlobalPhaseGate(matrix[0, 0].conj()).on()
+        yield cirq.Rz(rads=np.pi - self.lambd).on(qubit)
+        yield cirq.Ry(rads=2 * self.theta).on(qubit)
+        yield cirq.Rz(rads=-self.phi).on(qubit)
+        yield cirq.GlobalPhaseGate(np.exp(1j * (np.pi + self.lambd + self.phi) / 2)).on()
 
 
 def qsp_complementary_polynomial(

--- a/qualtran/bloqs/generalized_qsp.py
+++ b/qualtran/bloqs/generalized_qsp.py
@@ -242,7 +242,7 @@ def qsp_phase_factors(
             #      even though we want it to be 0.
             #      There should be a more numerically stable way to compute the relevant phis
             #      so that the final QSP sequence is valid.
-            phi[d] = np.angle(a) - np.angle(b)
+            phi[d] = 0 if np.isclose(np.abs(b), 0) else np.angle(a) - np.angle(b)
 
         if d == 0:
             lambd = np.angle(b)

--- a/qualtran/bloqs/generalized_qsp_test.py
+++ b/qualtran/bloqs/generalized_qsp_test.py
@@ -155,13 +155,14 @@ def verify_generalized_qsp(
 
 @pytest.mark.parametrize("bitsize", [1, 2, 3])
 @pytest.mark.parametrize("degree", [2, 3, 4, 5, 50, 100, 150])
-def test_generalized_real_qsp_on_random_unitaries(bitsize: int, degree: int):
+@pytest.mark.parametrize("assume_real", [True, False])
+def test_generalized_real_qsp_on_random_unitaries(bitsize: int, degree: int, assume_real: bool):
     random_state = np.random.RandomState(42)
 
     for _ in range(10):
         U = RandomGate.create(bitsize, random_state=random_state)
         P = random_qsp_polynomial(degree, random_state=random_state, only_real_coeffs=True)
-        verify_generalized_qsp(U, P, only_real_coeffs=True)
+        verify_generalized_qsp(U, P, only_real_coeffs=assume_real)
 
 
 @define(slots=False)

--- a/qualtran/bloqs/generalized_qsp_test.py
+++ b/qualtran/bloqs/generalized_qsp_test.py
@@ -152,7 +152,7 @@ def verify_generalized_qsp(U: GateWithRegisters, P: Sequence[complex]):
 
 @pytest.mark.parametrize("bitsize", [1, 2, 3])
 @pytest.mark.parametrize("degree", [2, 3, 4, 5, 50, 100, 150, 180])
-def test_generalized_real_qsp_on_random_unitaries(bitsize: int, degree: int):
+def test_generalized_qsp_with_real_poly_on_random_unitaries(bitsize: int, degree: int):
     random_state = np.random.RandomState(42)
 
     for _ in range(10):
@@ -163,7 +163,7 @@ def test_generalized_real_qsp_on_random_unitaries(bitsize: int, degree: int):
 
 @pytest.mark.parametrize("bitsize", [1, 2, 3])
 @pytest.mark.parametrize("degree", [2, 3, 4, 5, 50, 100, 120])
-def test_generalized_qsp_on_random_unitaries(bitsize: int, degree: int):
+def test_generalized_qsp_with_complex_poly_on_random_unitaries(bitsize: int, degree: int):
     random_state = np.random.RandomState(42)
 
     for _ in range(10):

--- a/qualtran/bloqs/generalized_qsp_test.py
+++ b/qualtran/bloqs/generalized_qsp_test.py
@@ -130,10 +130,9 @@ def evaluate_polynomial_of_matrix(P: Sequence[complex], U: NDArray) -> NDArray:
     return result
 
 
-def assert_matrices_same_upto_global_phase(A: NDArray, B: NDArray):
+def assert_matrices_almost_equal(A: NDArray, B: NDArray):
     assert A.shape == B.shape
-    assert np.linalg.norm(A @ A.conj().T - B @ B.conj().T) <= 1e-5
-    assert np.linalg.norm(A.conj().T @ A - B.conj().T @ B) <= 1e-5
+    assert np.linalg.norm(A - B) <= 1e-5
 
 
 def verify_generalized_qsp(U: GateWithRegisters, P: Sequence[complex]):
@@ -144,11 +143,11 @@ def verify_generalized_qsp(U: GateWithRegisters, P: Sequence[complex]):
 
     expected_top_left = evaluate_polynomial_of_matrix(P, input_unitary)
     actual_top_left = result_unitary[:N, :N]
-    assert_matrices_same_upto_global_phase(expected_top_left, actual_top_left)
+    assert_matrices_almost_equal(expected_top_left, actual_top_left)
 
     expected_bottom_left = evaluate_polynomial_of_matrix(gqsp_U.Q, input_unitary)
     actual_bottom_left = result_unitary[N:, :N]
-    assert_matrices_same_upto_global_phase(expected_bottom_left, actual_bottom_left)
+    assert_matrices_almost_equal(expected_bottom_left, actual_bottom_left)
 
 
 @pytest.mark.parametrize("bitsize", [1, 2, 3])

--- a/qualtran/bloqs/generalized_qsp_test.py
+++ b/qualtran/bloqs/generalized_qsp_test.py
@@ -136,10 +136,12 @@ def assert_matrices_same_upto_global_phase(A: NDArray, B: NDArray):
     assert np.linalg.norm(A.conj().T @ A - B.conj().T @ B) <= 1e-5
 
 
-def verify_generalized_qsp(U: GateWithRegisters, P: Sequence[complex]):
+def verify_generalized_qsp(
+    U: GateWithRegisters, P: Sequence[complex], *, only_real_coeffs: bool = False
+):
     input_unitary = cirq.unitary(U)
     N = input_unitary.shape[0]
-    gqsp_U = GeneralizedQSP(U, P)
+    gqsp_U = GeneralizedQSP(U, P, only_real_coeffs=only_real_coeffs)
     result_unitary = cirq.unitary(gqsp_U)
 
     expected_top_left = evaluate_polynomial_of_matrix(P, input_unitary)
@@ -152,14 +154,14 @@ def verify_generalized_qsp(U: GateWithRegisters, P: Sequence[complex]):
 
 
 @pytest.mark.parametrize("bitsize", [1, 2, 3])
-@pytest.mark.parametrize("degree", [2, 3, 4])
+@pytest.mark.parametrize("degree", [2, 3, 4, 5, 50, 100, 150])
 def test_generalized_real_qsp_on_random_unitaries(bitsize: int, degree: int):
     random_state = np.random.RandomState(42)
 
-    for _ in range(20):
+    for _ in range(10):
         U = RandomGate.create(bitsize, random_state=random_state)
         P = random_qsp_polynomial(degree, random_state=random_state, only_real_coeffs=True)
-        verify_generalized_qsp(U, P)
+        verify_generalized_qsp(U, P, only_real_coeffs=True)
 
 
 @define(slots=False)

--- a/qualtran/bloqs/generalized_qsp_test.py
+++ b/qualtran/bloqs/generalized_qsp_test.py
@@ -136,12 +136,10 @@ def assert_matrices_same_upto_global_phase(A: NDArray, B: NDArray):
     assert np.linalg.norm(A.conj().T @ A - B.conj().T @ B) <= 1e-5
 
 
-def verify_generalized_qsp(
-    U: GateWithRegisters, P: Sequence[complex], *, only_real_coeffs: bool = False
-):
+def verify_generalized_qsp(U: GateWithRegisters, P: Sequence[complex]):
     input_unitary = cirq.unitary(U)
     N = input_unitary.shape[0]
-    gqsp_U = GeneralizedQSP(U, P, only_real_coeffs=only_real_coeffs)
+    gqsp_U = GeneralizedQSP(U, P)
     result_unitary = cirq.unitary(gqsp_U)
 
     expected_top_left = evaluate_polynomial_of_matrix(P, input_unitary)
@@ -155,14 +153,24 @@ def verify_generalized_qsp(
 
 @pytest.mark.parametrize("bitsize", [1, 2, 3])
 @pytest.mark.parametrize("degree", [2, 3, 4, 5, 50, 100, 150])
-@pytest.mark.parametrize("assume_real", [True, False])
-def test_generalized_real_qsp_on_random_unitaries(bitsize: int, degree: int, assume_real: bool):
+def test_generalized_real_qsp_on_random_unitaries(bitsize: int, degree: int):
     random_state = np.random.RandomState(42)
 
     for _ in range(10):
         U = RandomGate.create(bitsize, random_state=random_state)
         P = random_qsp_polynomial(degree, random_state=random_state, only_real_coeffs=True)
-        verify_generalized_qsp(U, P, only_real_coeffs=assume_real)
+        verify_generalized_qsp(U, P)
+
+
+@pytest.mark.parametrize("bitsize", [1, 2, 3])
+@pytest.mark.parametrize("degree", [2, 3, 4, 5, 50, 100])
+def test_generalized_qsp_on_random_unitaries(bitsize: int, degree: int):
+    random_state = np.random.RandomState(42)
+
+    for _ in range(10):
+        U = RandomGate.create(bitsize, random_state=random_state)
+        P = random_qsp_polynomial(degree, random_state=random_state)
+        verify_generalized_qsp(U, P)
 
 
 @define(slots=False)

--- a/qualtran/bloqs/generalized_qsp_test.py
+++ b/qualtran/bloqs/generalized_qsp_test.py
@@ -152,7 +152,7 @@ def verify_generalized_qsp(U: GateWithRegisters, P: Sequence[complex]):
 
 
 @pytest.mark.parametrize("bitsize", [1, 2, 3])
-@pytest.mark.parametrize("degree", [2, 3, 4, 5, 50, 100, 150])
+@pytest.mark.parametrize("degree", [2, 3, 4, 5, 50, 100, 150, 180])
 def test_generalized_real_qsp_on_random_unitaries(bitsize: int, degree: int):
     random_state = np.random.RandomState(42)
 
@@ -163,7 +163,7 @@ def test_generalized_real_qsp_on_random_unitaries(bitsize: int, degree: int):
 
 
 @pytest.mark.parametrize("bitsize", [1, 2, 3])
-@pytest.mark.parametrize("degree", [2, 3, 4, 5, 50, 100])
+@pytest.mark.parametrize("degree", [2, 3, 4, 5, 50, 100, 120])
 def test_generalized_qsp_on_random_unitaries(bitsize: int, degree: int):
     random_state = np.random.RandomState(42)
 

--- a/qualtran/bloqs/generalized_qsp_test.py
+++ b/qualtran/bloqs/generalized_qsp_test.py
@@ -231,10 +231,10 @@ class SymbolicGQSP:
         assert abs(error_QU) <= 1e-5
 
 
-@pytest.mark.parametrize("degree", [2, 3, 4])
+@pytest.mark.parametrize("degree", [2, 3, 4, 5, 10])
 def test_generalized_real_qsp_with_symbolic_signal_matrix(degree: int):
     random_state = np.random.RandomState(102)
 
     for _ in range(10):
-        P = random_qsp_polynomial(degree, random_state=random_state, only_real_coeffs=True)
+        P = random_qsp_polynomial(degree, random_state=random_state)
         SymbolicGQSP(P).verify()


### PR DESCRIPTION
Fixes issue in precision for real polynomials. The thetas seem robust to error, but not phis, as adding a small imaginary part can result in non zero angles. More discussion in #630. 