### PR TITLE
[data types] Add signature factory method build_from_dtypes

### DIFF
--- a/qualtran/_infra/registers.py
+++ b/qualtran/_infra/registers.py
@@ -198,7 +198,7 @@ class Signature:
 
     @classmethod
     def build(cls, **registers: int) -> 'Signature':
-        """Construct a Signature comprised of simple thru registers.
+        """Construct a Signature comprised of simple thru registers given the register bitsizes.
 
         Args:
             registers: keyword arguments mapping register name to bitsize. All registers
@@ -208,7 +208,7 @@ class Signature:
 
     @classmethod
     def build_from_dtypes(cls, **registers: QDType) -> 'Signature':
-        """Construct a Signature comprised of simple thru registers.
+        """Construct a Signature comprised of simple thru registers given the register dtypes.
 
         Args:
             registers: keyword arguments mapping register name to QDType. All registers

--- a/qualtran/_infra/registers.py
+++ b/qualtran/_infra/registers.py
@@ -214,15 +214,7 @@ class Signature:
             registers: keyword arguments mapping register name to QDType. All registers
                 will be 0-dimensional and THRU.
         """
-        regs = []
-        for k, v in registers.items():
-            if v.num_qubits:
-                regs.append(
-                    Register(name=k, bitsize=v)
-                    if v.num_qubits > 1
-                    else Register(name=k, bitsize=QBit())
-                )
-        return cls(regs)
+        return cls(Register(name=k, bitsize=v) for k, v in registers.items() if v.num_qubits)
 
     def lefts(self) -> Iterable[Register]:
         """Iterable over all registers that appear on the LEFT as input."""

--- a/qualtran/_infra/registers.py
+++ b/qualtran/_infra/registers.py
@@ -22,7 +22,7 @@ import attrs
 import numpy as np
 from attrs import field, frozen
 
-from .data_types import QAny, QBit, QDType, QBit
+from .data_types import QAny, QBit, QDType
 
 
 class Side(enum.Flag):
@@ -217,7 +217,11 @@ class Signature:
         regs = []
         for k, v in registers.items():
             if v.num_qubits:
-                regs.append(Register(name=k, bitsize=v) if v.num_qubits > 1 else Register(name=k, QBit()))
+                regs.append(
+                    Register(name=k, bitsize=v)
+                    if v.num_qubits > 1
+                    else Register(name=k, bitsize=QBit())
+                )
         return cls(regs)
 
     def lefts(self) -> Iterable[Register]:

--- a/qualtran/_infra/registers.py
+++ b/qualtran/_infra/registers.py
@@ -22,7 +22,7 @@ import attrs
 import numpy as np
 from attrs import field, frozen
 
-from .data_types import QAny, QBit, QDType
+from .data_types import QAny, QBit, QDType, QBit
 
 
 class Side(enum.Flag):
@@ -205,6 +205,20 @@ class Signature:
                 will be 0-dimensional and THRU.
         """
         return cls(Register(name=k, bitsize=v) for k, v in registers.items() if v)
+
+    @classmethod
+    def build_from_dtypes(cls, **registers: QDType) -> 'Signature':
+        """Construct a Signature comprised of simple thru registers.
+
+        Args:
+            registers: keyword arguments mapping register name to QDType. All registers
+                will be 0-dimensional and THRU.
+        """
+        regs = []
+        for k, v in registers.items():
+            if v.num_qubits:
+                regs.append(Register(name=k, bitsize=v) if v.num_qubits > 1 else Register(name=k, QBit()))
+        return cls(regs)
 
     def lefts(self) -> Iterable[Register]:
         """Iterable over all registers that appear on the LEFT as input."""

--- a/qualtran/_infra/registers_test.py
+++ b/qualtran/_infra/registers_test.py
@@ -125,6 +125,12 @@ def test_signature_build():
     sig1 = Signature([Register("r1", 5), Register("r2", 2)])
     sig2 = Signature.build(r1=5, r2=2)
     assert sig1 == sig2
+    sig1 = Signature([Register("r1", QInt(7)), Register("r2", QBit())])
+    sig2 = Signature.build_from_dtypes(r1=QInt(7), r2=QBit())
+    assert sig1 == sig2
+    sig1 = Signature([Register("r1", QInt(7))])
+    sig2 = Signature.build_from_dtypes(r1=QInt(7), r2=QAny(0))
+    assert sig1 == sig2
 
 
 def test_and_regs():


### PR DESCRIPTION
The ci is failing in #639 due to the comparator in the [unit test having zero bitsize](https://github.com/quantumlib/Qualtran/actions/runs/7805172959/job/21288750016#step:6:786). I'm not sure what our desired behavior is for registers of size zero, but the test previously passed  because signature.build would silently drop registers of size zero. I thought adding a similar method for dtypes would be helpful in this regard, which is implemented here, but it raises the question if we really want zero bitsize registers or should this just throw an error when constructing the type. I also thought it could be nice to handle the boilerplate of converting a QInt(1) to a QBit() but currently this will raise an ValueError during construction of QInt(1), so:

1. Should QDType(0) raise an error? I can update the test to use a lower epsilon so the bitsize is non-zero for the alias sampling comparator. I did this already but the notebook needs to be updated. 
2. Should QInt(1) be allowed and move the conversion to signature.build_from_dtypes. This seems fine, but I would need to add some attrs magic to Register too probably. 