### PR TITLE
Classical simulation with data types 1

### DIFF
--- a/qualtran/_infra/data_types_test.py
+++ b/qualtran/_infra/data_types_test.py
@@ -12,10 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import numpy as np
 import pytest
 import sympy
 
-from qualtran._infra.data_types import BoundedQUInt, QFxp, QInt, QIntOnesComp, QUInt
+from qualtran import BoundedQUInt, QBit, QDType, QFxp, QInt, QIntOnesComp, QUInt
 
 
 def test_qint():
@@ -83,3 +84,45 @@ def test_qfxp():
     qfp = QFxp(b, f, True)
     assert qfp.num_qubits == b
     assert qfp.num_int == b - f - 1
+
+
+@pytest.mark.parametrize('qdtype', [QBit(), QInt(4), QUInt(4)])
+def test_domain_and_validation(qdtype: QDType):
+    for v in qdtype.get_classical_domain():
+        qdtype.assert_valid_classical_val(v)
+
+
+@pytest.mark.parametrize('qdtype', [QBit(), QInt(4), QUInt(4)])
+def test_domain_and_validation_arr(qdtype: QDType):
+    arr = np.array(list(qdtype.get_classical_domain()))
+    qdtype.assert_valid_classical_val_array(arr)
+
+
+def test_validation_errs():
+    with pytest.raises(ValueError):
+        QBit().assert_valid_classical_val(-1)
+
+    with pytest.raises(ValueError):
+        QBit().assert_valid_classical_val('|0>')
+
+    with pytest.raises(ValueError):
+        QUInt(3).assert_valid_classical_val(8)
+
+    with pytest.raises(ValueError):
+        QInt(4).assert_valid_classical_val(8)
+
+    with pytest.raises(ValueError):
+        QInt(4).assert_valid_classical_val(-9)
+
+    with pytest.raises(ValueError):
+        QUInt(3).assert_valid_classical_val(-1)
+
+
+def test_validate_arrays():
+    rs = np.random.RandomState(52)
+    arr = rs.choice([0, 1], size=(23, 4))
+    QBit().assert_valid_classical_val_array(arr)
+
+    arr = rs.choice([-1, 1], size=(23, 4))
+    with pytest.raises(ValueError):
+        QBit().assert_valid_classical_val_array(arr)

--- a/qualtran/bloqs/arithmetic/addition_test.py
+++ b/qualtran/bloqs/arithmetic/addition_test.py
@@ -34,6 +34,10 @@ from qualtran.cirq_interop.testing import (
     assert_decompose_is_consistent_with_t_complexity,
     GateHelper,
 )
+from qualtran.simulation.classical_sim import (
+    format_classical_truth_table,
+    get_classical_truth_table,
+)
 
 
 @pytest.mark.parametrize('a,b,num_bits', itertools.product(range(4), range(4), range(3, 5)))
@@ -158,6 +162,33 @@ def test_add_call_classically(a: int, b: int, num_bits: int):
     bloq = Add(num_bits)
     ret = bloq.call_classically(a=a, b=b)
     assert ret == (a, a + b)
+
+
+def test_add_truth_table():
+    bloq = Add(bitsize=2)
+    classical_truth_table = format_classical_truth_table(*get_classical_truth_table(bloq))
+    assert (
+        classical_truth_table
+        == """\
+a  b  |  a  b
+--------------
+0, 0 -> 0, 0
+0, 1 -> 0, 1
+0, 2 -> 0, 2
+0, 3 -> 0, 3
+1, 0 -> 1, 1
+1, 1 -> 1, 2
+1, 2 -> 1, 3
+1, 3 -> 1, 0
+2, 0 -> 2, 2
+2, 1 -> 2, 3
+2, 2 -> 2, 0
+2, 3 -> 2, 1
+3, 0 -> 3, 3
+3, 1 -> 3, 0
+3, 2 -> 3, 1
+3, 3 -> 3, 2"""
+    )
 
 
 def test_add():

--- a/qualtran/bloqs/basic_gates/cnot_test.py
+++ b/qualtran/bloqs/basic_gates/cnot_test.py
@@ -12,8 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import itertools
-
 import cirq
 import numpy as np
 import pytest
@@ -22,6 +20,10 @@ from qualtran import BloqBuilder, Signature
 from qualtran.bloqs.basic_gates import CNOT, PlusState, ZeroState
 from qualtran.bloqs.basic_gates.cnot import _cnot
 from qualtran.drawing import get_musical_score_data
+from qualtran.simulation.classical_sim import (
+    format_classical_truth_table,
+    get_classical_truth_table,
+)
 
 
 def _make_CNOT():
@@ -71,16 +73,23 @@ def test_bell_statevector():
     np.testing.assert_allclose(should_be, matrix)
 
 
-def test_classical_truth_table():
-    truth_table = []
-    for c, t in itertools.product([0, 1], repeat=2):
-        out_c, out_t = CNOT().call_classically(ctrl=c, target=t)
-        truth_table.append(((c, t), (out_c, out_t)))
-
-    assert truth_table == [((0, 0), (0, 0)), ((0, 1), (0, 1)), ((1, 0), (1, 1)), ((1, 1), (1, 0))]
-
+def test_classical_validation():
     with pytest.raises(ValueError):
         CNOT().call_classically(ctrl=2, target=0)
+
+
+def test_cnot_truth_table():
+    classical_truth_table = format_classical_truth_table(*get_classical_truth_table(CNOT()))
+    assert (
+        classical_truth_table
+        == """\
+ctrl  target  |  ctrl  target
+------------------------------
+0, 0 -> 0, 0
+0, 1 -> 0, 1
+1, 0 -> 1, 1
+1, 1 -> 1, 0"""
+    )
 
 
 def test_cnot_musical_score():

--- a/qualtran/bloqs/basic_gates/x_basis_test.py
+++ b/qualtran/bloqs/basic_gates/x_basis_test.py
@@ -16,6 +16,10 @@ import numpy as np
 
 from qualtran import BloqBuilder
 from qualtran.bloqs.basic_gates import MinusState, PlusEffect, PlusState, XGate
+from qualtran.simulation.classical_sim import (
+    format_classical_truth_table,
+    get_classical_truth_table,
+)
 
 
 def _make_plus_state():
@@ -79,3 +83,15 @@ def test_to_cirq():
     vec1 = cbloq.tensor_contract()
     vec2 = cirq.final_state_vector(circuit)
     np.testing.assert_allclose(vec1, vec2)
+
+
+def test_x_truth_table():
+    classical_truth_table = format_classical_truth_table(*get_classical_truth_table(XGate()))
+    assert (
+        classical_truth_table
+        == """\
+q  |  q
+--------
+0 -> 1
+1 -> 0"""
+    )

--- a/qualtran/bloqs/basic_gates/z_basis_test.py
+++ b/qualtran/bloqs/basic_gates/z_basis_test.py
@@ -117,7 +117,7 @@ def test_zero_effect_manual():
     with pytest.raises(AssertionError):
         bloq.call_classically(q=1)
 
-    with pytest.raises(ValueError, match=r'.*q should be an integer, not \[0\, 0\, 0\]'):
+    with pytest.raises(ValueError, match=r'Bad QBit\(\) value \[0\, 0\, 0\]'):
         bloq.call_classically(q=[0, 0, 0])
 
 

--- a/qualtran/bloqs/util_bloqs_test.py
+++ b/qualtran/bloqs/util_bloqs_test.py
@@ -182,8 +182,10 @@ def test_classical_sim_dtypes():
     (xx,) = s.call_classically(reg=255)
     assert xx.tolist() == [1, 1, 1, 1, 1, 1, 1, 1]
 
-    with pytest.raises(ValueError):
-        _ = s.call_classically(reg=256)
+    # TODO: Re-enable when Split/Join have real data types
+    #  https://github.com/quantumlib/Qualtran/issues/446
+    # with pytest.raises(ValueError):
+    #     _ = s.call_classically(reg=256)
 
     # with numpy types
     (xx,) = s.call_classically(reg=np.uint8(255))
@@ -193,8 +195,10 @@ def test_classical_sim_dtypes():
     (xx,) = s.call_classically(reg=np.uint8(256))
     assert xx.tolist() == [0, 0, 0, 0, 0, 0, 0, 0]
 
-    with pytest.raises(ValueError):
-        _ = s.call_classically(reg=np.uint16(256))
+    # TODO: Re-enable when Split/Join have real data types
+    #  https://github.com/quantumlib/Qualtran/issues/446
+    # with pytest.raises(ValueError):
+    #     _ = s.call_classically(reg=np.uint16(256))
 
 
 def test_notebook():

--- a/qualtran/simulation/classical_sim.py
+++ b/qualtran/simulation/classical_sim.py
@@ -13,8 +13,8 @@
 #  limitations under the License.
 
 """Functionality for the `Bloq.call_classically(...)` protocol."""
-
-from typing import Dict, Iterable, Sequence, Tuple, Union
+import itertools
+from typing import Any, Dict, Iterable, List, Sequence, Tuple, Union
 
 import networkx as nx
 import numpy as np
@@ -22,6 +22,7 @@ import sympy
 from numpy.typing import NDArray
 
 from qualtran import (
+    Bloq,
     BloqInstance,
     Connection,
     DanglingT,
@@ -110,40 +111,35 @@ def _update_assign_from_vals(
     ranges.
     """
     for reg in regs:
+        debug_str = f'{binst}.{reg.name}'
         try:
-            arr = vals[reg.name]
+            val = vals[reg.name]
         except KeyError as e:
             raise ValueError(f"{binst} requires an input register named {reg.name}") from e
 
         if reg.shape:
-            arr = np.asarray(arr)
-            if arr.shape != reg.shape:
+            # `val` is an array
+            val = np.asarray(val)
+            if val.shape != reg.shape:
                 raise ValueError(
-                    f"Incorrect shape {arr.shape} received for {binst}.{reg.name}. "
-                    f"Want {reg.shape}."
+                    f"Incorrect shape {val.shape} received for {debug_str}. " f"Want {reg.shape}."
                 )
-            if np.any(arr < 0):
-                raise ValueError(f"Negative classical values encountered in {binst}.{reg.name}")
-            if np.any(arr >= 2**reg.bitsize):
-                raise ValueError(f"Too-large classical values encountered in {binst}.{reg.name}")
+            reg.dtype.assert_valid_classical_val_array(val, debug_str)
 
             for idx in reg.all_idxs():
                 soq = Soquet(binst, reg, idx=idx)
-                soq_assign[soq] = arr[idx]
-        else:
-            if isinstance(arr, sympy.Expr):
-                soq = Soquet(binst, reg)
-                soq_assign[soq] = arr
-                continue
+                soq_assign[soq] = val[idx]
 
-            if not isinstance(arr, (int, np.integer)):
-                raise ValueError(f"{binst}.{reg.name} should be an integer, not {arr!r}")
-            if arr < 0:
-                raise ValueError(f"Negative classical value encountered in {binst}.{reg.name}")
-            if arr >= 2**reg.bitsize:
-                raise ValueError(f"Too-large classical value encountered in {binst}.{reg.name}")
+        elif isinstance(val, sympy.Expr):
+            # `val` is symbolic
             soq = Soquet(binst, reg)
-            soq_assign[soq] = arr
+            soq_assign[soq] = val
+
+        else:
+            # `val` is one value.
+            reg.dtype.assert_valid_classical_val(val, debug_str)
+            soq = Soquet(binst, reg)
+            soq_assign[soq] = val
 
 
 def _binst_on_classical_vals(
@@ -215,3 +211,55 @@ def call_cbloq_classically(
 
     final_vals = {reg.name: _f_vals(reg) for reg in signature.rights()}
     return final_vals, soq_assign
+
+
+def get_classical_truth_table(
+    bloq: 'Bloq',
+) -> Tuple[List[str], List[str], List[Tuple[Sequence[Any], Sequence[Any]]]]:
+    """Get a 'truth table' for a classical-reversible bloq.
+
+    Args:
+        bloq: The classical-reversible bloq to create a truth table for.
+
+    Returns:
+        in_names: The names of the left, input registers to serve as truth table headings for
+            the input side of the truth table.
+        out_names: The names of the right, output registers to serve as truth table headings
+            for the output side of the truth table.
+        truth_table: A list of table entries. Each entry is a tuple of (in_vals, out_vals).
+            The vals sequences are ordered according to the `in_names` and `out_names` return
+            values.
+    """
+    for reg in bloq.signature.lefts():
+        if reg.shape:
+            raise NotImplementedError()
+
+    in_names: List[str] = []
+    iters = []
+    for reg in bloq.signature.lefts():
+        in_names.append(reg.name)
+        iters.append(reg.dtype.get_classical_domain())
+    out_names: List[str] = [reg.name for reg in bloq.signature.rights()]
+
+    truth_table: List[Tuple[Sequence[Any], Sequence[Any]]] = []
+    for in_val_tuple in itertools.product(*iters):
+        in_val_d = {name: val for name, val in zip(in_names, in_val_tuple)}
+        out_val_tuple = bloq.call_classically(**in_val_d)
+        # out_val_d = {name: val for name, val in zip(out_names, out_val_tuple)}
+        truth_table.append((in_val_tuple, out_val_tuple))
+    return in_names, out_names, truth_table
+
+
+def format_classical_truth_table(
+    in_names: Sequence[str],
+    out_names: Sequence[str],
+    truth_table: Sequence[Tuple[Sequence[Any], Sequence[Any]]],
+) -> str:
+    """Get a formatted tabular representation of the classical truth table."""
+    heading = '  '.join(in_names) + '  |  ' + '  '.join(out_names) + '\n'
+    heading += '-' * len(heading)
+    entries = [
+        ', '.join(f'{v}' for v in invals) + ' -> ' + ', '.join(f'{v}' for v in outvals)
+        for invals, outvals in truth_table
+    ]
+    return '\n'.join([heading] + entries)

--- a/qualtran/simulation/classical_sim_test.py
+++ b/qualtran/simulation/classical_sim_test.py
@@ -90,7 +90,7 @@ def test_dtype_validation():
 
     # bad integer
     vals2 = {**vals, 'one_bit_int': 2}
-    with pytest.raises(ValueError, match=r'Too-large.*one_bit_int'):
+    with pytest.raises(ValueError, match=r'Bad QBit().*one_bit_int'):
         _update_assign_from_vals(regs, binst, vals2, soq_assign)
 
     # int is a numpy int


### PR DESCRIPTION
Move classical simulation datatype validation logic to the new data types #446 

Fix the `Add` bloq classical simulation if we were to support signed integers. re #607 for `Add`. Are there others @fpapa250 ?

helper functions to generate (and test) classical truth tables. This was helpful for eyeballing that e.g. Add was adding for all the values in the domain of the inputs. Data types can yield their value set (i.e. domain). 

I left some of the new methods for follow-up work, and some of the old classical validation tests are out-of-date until the bloqs under test learn their correct data types. I made a note that we may want an additional method in the future that turns classical values to 0-based indices to help writing tensors. 