### PR TITLE
Bloqs for phasing by a cost function via addition into phase gradient register

### DIFF
--- a/qualtran/_infra/data_types.py
+++ b/qualtran/_infra/data_types.py
@@ -205,6 +205,10 @@ class QFxp(QDType):
     def num_int(self) -> Union[int, sympy.Expr]:
         return self.bitsize - self.num_frac - int(self.signed)
 
+    @property
+    def fxp_dtype_str(self) -> str:
+        return f'fxp-{"us"[self.signed]}{self.bitsize}/{self.num_frac}'
+
     def __attrs_post_init__(self):
         if isinstance(self.num_qubits, int):
             if self.num_qubits == 1 and self.signed:

--- a/qualtran/_infra/data_types_test.py
+++ b/qualtran/_infra/data_types_test.py
@@ -65,9 +65,11 @@ def test_qfxp():
     qfp_16 = QFxp(16, 15)
     assert qfp_16.num_qubits == 16
     assert qfp_16.num_int == 1
+    assert qfp_16.fxp_dtype_str == 'fxp-u16/15'
     qfp_16 = QFxp(16, 15, signed=True)
     assert qfp_16.num_qubits == 16
     assert qfp_16.num_int == 0
+    assert qfp_16.fxp_dtype_str == 'fxp-s16/15'
     with pytest.raises(ValueError, match="num_qubits must be > 1."):
         QFxp(1, 1, signed=True)
     QFxp(1, 1, signed=False)

--- a/qualtran/bloqs/arithmetic/multiplication.py
+++ b/qualtran/bloqs/arithmetic/multiplication.py
@@ -119,9 +119,13 @@ class Square(Bloq):
             [Register("a", self.bitsize), Register("result", 2 * self.bitsize, side=side)]
         )
 
-    def on_classical_vals(self, a: int, result: int) -> Dict[str, 'ClassicalValT']:
-        result_out = (result + a**2) % (2 ** (2 * self.bitsize))
-        return {'a': a, 'result': result_out}
+    def on_classical_vals(self, **vals: int) -> Dict[str, 'ClassicalValT']:
+        if self.uncompute:
+            a, result = vals["a"], vals["result"]
+            assert result == a**2
+            return {'a': a}
+        a = vals["a"]
+        return {'a': a, 'result': a**2}
 
     def short_name(self) -> str:
         return "a^2"

--- a/qualtran/bloqs/arithmetic/multiplication.py
+++ b/qualtran/bloqs/arithmetic/multiplication.py
@@ -15,8 +15,8 @@
 from typing import Any, Dict, Iterable, Sequence, Set, TYPE_CHECKING, Union
 
 import cirq
-from attrs import frozen
 import numpy as np
+from attrs import frozen
 
 from qualtran import Bloq, GateWithRegisters, Register, Side, Signature
 from qualtran.bloqs.basic_gates import Toffoli

--- a/qualtran/bloqs/arithmetic/multiplication_test.py
+++ b/qualtran/bloqs/arithmetic/multiplication_test.py
@@ -23,7 +23,7 @@ from qualtran.bloqs.arithmetic import (
     SquareRealNumber,
     SumOfSquares,
 )
-from qualtran.bloqs.basic_gates import IntEffect, IntState
+from qualtran.bloqs.basic_gates import IntState
 from qualtran.testing import execute_notebook
 
 

--- a/qualtran/bloqs/arithmetic/multiplication_test.py
+++ b/qualtran/bloqs/arithmetic/multiplication_test.py
@@ -23,6 +23,7 @@ from qualtran.bloqs.arithmetic import (
     SquareRealNumber,
     SumOfSquares,
 )
+from qualtran.bloqs.basic_gates import IntEffect, IntState
 from qualtran.testing import execute_notebook
 
 
@@ -65,10 +66,20 @@ def _make_square_real_number():
 def test_square():
     bb = BloqBuilder()
     bitsize = 4
-    q0 = bb.add_register('a', bitsize)
+
+    q0 = bb.add(IntState(10, bitsize))
     q0, q1 = bb.add(Square(bitsize), a=q0)
-    cbloq = bb.finalize(a=q0, result=q1)
+    cbloq = bb.finalize(val=q0, result=q1)
     cbloq.t_complexity()
+    assert cbloq.on_classical_vals() == {'val': 10, 'result': 100}
+    assert cbloq.tensor_contract().reshape(2**bitsize, 4**bitsize)[10, 100] == 1
+
+    bb = BloqBuilder()
+    val, result = bb.add_from(cbloq)
+    a = bb.add(Square(bitsize).adjoint(), a=val, result=result)
+    cbloq = bb.finalize(a=a)
+    assert cbloq.on_classical_vals(a=10, result=100) == {'a': 10}
+    assert cbloq.tensor_contract()[10] == 1
 
 
 def test_sum_of_squares():

--- a/qualtran/bloqs/rotations/hamming_weight_phasing.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing.py
@@ -156,7 +156,7 @@ class HammingWeightPhasingViaPhaseGradient(GateWithRegisters):
                 QFxp(bitsize=self.bitsize.bit_length(), num_frac=0, signed=False),
                 self.b_grad,
                 self.exponent / 2,
-                self.b_phase,
+                self.b_phase + 1,
             ),
             x=out,
             phase_grad=phase_grad,

--- a/qualtran/bloqs/rotations/hamming_weight_phasing.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing.py
@@ -87,7 +87,10 @@ class HammingWeightPhasing(GateWithRegisters):
         return {
             (HammingWeightCompute(self.bitsize), 1),
             (HammingWeightCompute(self.bitsize).adjoint(), 1),
-            (ZPowGate(exponent=self.exponent), self.bitsize.bit_length()),
+            (
+                ZPowGate(exponent=self.exponent, eps=self.eps / self.bitsize.bit_length()),
+                self.bitsize.bit_length(),
+            ),
         }
 
 
@@ -157,7 +160,7 @@ class HammingWeightPhasingViaPhaseGradient(GateWithRegisters):
 
     @cached_property
     def gamma_bitsize(self) -> int:
-        return self.phase_oracle.b_grad
+        return self.phase_oracle.gamma_bitsize
 
     def build_composite_bloq(
         self, bb: 'BloqBuilder', *, x: 'SoquetT', phase_grad: 'SoquetT'

--- a/qualtran/bloqs/rotations/hamming_weight_phasing.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing.py
@@ -153,7 +153,10 @@ class HammingWeightPhasingViaPhaseGradient(GateWithRegisters):
         x, junk, out = bb.add(HammingWeightCompute(self.bitsize), x=x)
         out, phase_grad = bb.add(
             AddScaledValIntoPhaseReg(
-                self.bitsize.bit_length(), self.b_grad, self.exponent / 2, self.b_phase
+                QFxp(bitsize=self.bitsize.bit_length(), num_frac=0, signed=False),
+                self.b_grad,
+                self.exponent / 2,
+                self.eps,
             ),
             x=out,
             phase_grad=phase_grad,

--- a/qualtran/bloqs/rotations/hamming_weight_phasing.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing.py
@@ -60,7 +60,7 @@ class HammingWeightPhasing(GateWithRegisters):
 
     bitsize: int
     exponent: float
-    eps: int = 1e-10
+    eps: float = 1e-10
 
     @cached_property
     def signature(self) -> 'Signature':
@@ -131,7 +131,7 @@ class HammingWeightPhasingViaPhaseGradient(GateWithRegisters):
 
     bitsize: int
     exponent: float = 1
-    eps: int = 1e-10
+    eps: float = 1e-10
 
     @cached_property
     def signature(self) -> 'Signature':
@@ -156,7 +156,7 @@ class HammingWeightPhasingViaPhaseGradient(GateWithRegisters):
                 QFxp(bitsize=self.bitsize.bit_length(), num_frac=0, signed=False),
                 self.b_grad,
                 self.exponent / 2,
-                self.eps,
+                self.b_phase,
             ),
             x=out,
             phase_grad=phase_grad,

--- a/qualtran/bloqs/rotations/hamming_weight_phasing.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing.py
@@ -16,12 +16,12 @@ from functools import cached_property
 from typing import Dict, Set, TYPE_CHECKING
 
 import attrs
-import numpy as np
 
-from qualtran import GateWithRegisters, QFxp, QUInt, Signature
+from qualtran import GateWithRegisters, QFxp, QUInt, Register, Signature
 from qualtran.bloqs.arithmetic import HammingWeightCompute
 from qualtran.bloqs.basic_gates import ZPowGate
 from qualtran.bloqs.rotations.phase_gradient import AddScaledValIntoPhaseReg
+from qualtran.bloqs.rotations.phasing_via_cost_function import PhaseOraclePhaseGradient
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, SoquetT
@@ -140,12 +140,24 @@ class HammingWeightPhasingViaPhaseGradient(GateWithRegisters):
         )
 
     @cached_property
+    def phase_oracle(self) -> PhaseOraclePhaseGradient:
+        return PhaseOraclePhaseGradient(
+            Register('out', QFxp(bitsize=self.bitsize.bit_length(), num_frac=0, signed=False)),
+            self.exponent / 2,
+            self.eps,
+        )
+
+    @cached_property
     def b_phase(self) -> int:
-        return int(np.ceil(np.log2(1 / self.eps)))
+        return self.phase_oracle.b_phase
 
     @cached_property
     def b_grad(self) -> int:
-        return max(self.bitsize.bit_length(), self.b_phase + int(np.ceil(np.log2(self.b_phase))))
+        return self.phase_oracle.b_grad
+
+    @cached_property
+    def gamma_bitsize(self) -> int:
+        return self.phase_oracle.b_grad
 
     def build_composite_bloq(
         self, bb: 'BloqBuilder', *, x: 'SoquetT', phase_grad: 'SoquetT'
@@ -153,10 +165,7 @@ class HammingWeightPhasingViaPhaseGradient(GateWithRegisters):
         x, junk, out = bb.add(HammingWeightCompute(self.bitsize), x=x)
         out, phase_grad = bb.add(
             AddScaledValIntoPhaseReg(
-                QFxp(bitsize=self.bitsize.bit_length(), num_frac=0, signed=False),
-                self.b_grad,
-                self.exponent / 2,
-                self.b_phase + 1,
+                self.phase_oracle.cost_dtype, self.b_grad, self.exponent / 2, self.gamma_bitsize
             ),
             x=out,
             phase_grad=phase_grad,

--- a/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
@@ -96,7 +96,7 @@ def test_hamming_weight_phasing_via_phase_gradient(n: int, theta: float, eps: fl
     np.testing.assert_allclose(expected_final_state, hw_final_state, atol=eps)
 
 
-@pytest.mark.parametrize('n, theta, eps', [(5_000, 1 / 100, 1e-2)])
+@pytest.mark.parametrize('n, theta, eps', [(5_000, 1 / 100, 1e-1)])
 def test_hamming_weight_phasing_via_phase_gradient_t_complexity(n: int, theta: float, eps: float):
     gate = HammingWeightPhasingViaPhaseGradient(n, theta, eps)
     naive_hwp_t_complexity = HammingWeightPhasing(n, theta, eps).t_complexity()

--- a/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
@@ -78,7 +78,7 @@ class TestHammingWeightPhasingViaPhaseGradient(GateWithRegisters):
 
 @pytest.mark.parametrize('n', [2, 3])
 @pytest.mark.parametrize(
-    'theta, eps', [(1, 1e-1), (0.5, 1e-2), (1 / 10, 1e-4), (1.20345, 1e-4), (-4.1934341, 1e-4)]
+    'theta, eps', [(1, 1e-1), (0.5, 1e-2), (1 / 10, 1e-4), (1.20345, 1e-4), (-1.1934341, 1e-4)]
 )
 def test_hamming_weight_phasing_via_phase_gradient(n: int, theta: float, eps: float):
     gate = TestHammingWeightPhasingViaPhaseGradient(n, theta, eps)

--- a/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
@@ -77,7 +77,9 @@ class TestHammingWeightPhasingViaPhaseGradient(GateWithRegisters):
 
 
 @pytest.mark.parametrize('n', [2, 3])
-@pytest.mark.parametrize('theta, eps', [(1, 1e-1), (0.5, 1e-2), (1 / 10, 1e-3)])
+@pytest.mark.parametrize(
+    'theta, eps', [(1, 1e-1), (0.5, 1e-2), (1 / 10, 1e-4), (1.20345, 1e-4), (-4.1934341, 1e-4)]
+)
 def test_hamming_weight_phasing_via_phase_gradient(n: int, theta: float, eps: float):
     gate = TestHammingWeightPhasingViaPhaseGradient(n, theta, eps)
     assert_valid_bloq_decomposition(gate)

--- a/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
@@ -54,7 +54,7 @@ def test_hamming_weight_phasing(n: int, theta: float):
 class TestHammingWeightPhasingViaPhaseGradient(GateWithRegisters):
     bitsize: int
     exponent: float
-    eps: int = 1e-2
+    eps: float
 
     @property
     def signature(self) -> 'Signature':

--- a/qualtran/bloqs/rotations/phase_gradient.py
+++ b/qualtran/bloqs/rotations/phase_gradient.py
@@ -145,6 +145,8 @@ class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):
         U|x\rangle|\text{phase\_grad}\rangle = |x\rangle|\text{phase\_grad} + x\rangle
     $$
 
+    TODO(#654): Check whether phase_bitsize >= inp_bitsize needs to be enforced.
+
     Args:
         inp_bitsize: Size of input register.
         phase_bitsize: Size of phase gradient register to which the input value should be added.
@@ -159,9 +161,6 @@ class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):
     """
     inp_bitsize: int
     phase_bitsize: int
-
-    def __attrs_post_init__(self):
-        assert self.phase_bitsize >= self.inp_bitsize
 
     @cached_property
     def signature(self) -> 'Signature':

--- a/qualtran/bloqs/rotations/phase_gradient.py
+++ b/qualtran/bloqs/rotations/phase_gradient.py
@@ -233,7 +233,7 @@ class AddScaledValIntoPhaseReg(GateWithRegisters, cirq.ArithmeticGate):
 
     @cached_property
     def phase_dtype(self) -> QFxp:
-        return QFxp(self.phase_bitsize, self.phase_bitsize)
+        return QFxp(self.phase_bitsize, self.phase_bitsize, signed=False)
 
     @cached_property
     def gamma_dtype(self) -> QFxp:
@@ -247,9 +247,8 @@ class AddScaledValIntoPhaseReg(GateWithRegisters, cirq.ArithmeticGate):
         gamma_fxp = Fxp(abs(self.gamma), dtype=self.gamma_dtype.fxp_dtype_str)
         result = x_fxp * gamma_fxp
         result -= np.floor(result)
-        result = (
-            result.like(Fxp(None, dtype=self.phase_dtype.fxp_dtype_str)) << self.phase_dtype.bitsize
-        )
+        result = result.like(Fxp(None, dtype=self.phase_dtype.fxp_dtype_str))
+        result <<= self.phase_dtype.bitsize
         return int(result) * int(sign)
 
     def apply(self, x: int, phase_grad: int) -> Union[int, Iterable[int]]:

--- a/qualtran/bloqs/rotations/phase_gradient.py
+++ b/qualtran/bloqs/rotations/phase_gradient.py
@@ -201,10 +201,10 @@ class AddScaledValIntoPhaseReg(GateWithRegisters, cirq.ArithmeticGate):
     The operation calls `AddIntoPhaseGrad` gate $(gamma_bitsize + 2) / 2$ times.
 
     Args:
-        inp_bitsize: Size of input register.
+        inp_dtype: Fixed point specification of the input register.
         phase_bitsize: Size of phase gradient register to which the scaled input should be added.
         gamma: Floating point scaling factor.
-        eps: Number of bits of precisions to be used for fractional part of `gamma`.
+        gamma_bitsize: Number of bits of precisions to be used for fractional part of `gamma`.
 
     Registers:
         - x : Input THRU register storing input value x to be scaled and added to the phase

--- a/qualtran/bloqs/rotations/phase_gradient_test.py
+++ b/qualtran/bloqs/rotations/phase_gradient_test.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 from qualtran import BloqBuilder
+from qualtran._infra.data_types import QFxp
 from qualtran.bloqs.rotations.phase_gradient import (
     AddIntoPhaseGrad,
     AddScaledValIntoPhaseReg,
@@ -94,7 +95,7 @@ def test_add_into_phase_grad():
 
 def test_add_scaled_val_into_phase_reg():
     x_bit, phase_bit, gamma, gamma_bit = 4, 7, 0.123, 6
-    bloq = AddScaledValIntoPhaseReg(x_bit, phase_bit, gamma, gamma_bit)
+    bloq = AddScaledValIntoPhaseReg(QFxp(x_bit, 0), phase_bit, gamma, 1 / 2**5)
     gamma_fixed_width_float = float_as_fixed_width_int(gamma, gamma_bit + 1)[1] / (2**gamma_bit)
     gamma_int = float_as_fixed_width_int(gamma_fixed_width_float, phase_bit + 1)[1]
     basis_map = {}

--- a/qualtran/bloqs/rotations/phase_gradient_test.py
+++ b/qualtran/bloqs/rotations/phase_gradient_test.py
@@ -95,7 +95,7 @@ def test_add_into_phase_grad():
 
 def test_add_scaled_val_into_phase_reg():
     x_bit, phase_bit, gamma, gamma_bit = 4, 7, 0.123, 6
-    bloq = AddScaledValIntoPhaseReg(QFxp(x_bit, 0), phase_bit, gamma, 1 / 2**5)
+    bloq = AddScaledValIntoPhaseReg(QFxp(x_bit, 0), phase_bit, gamma, gamma_bit)
     gamma_fixed_width_float = float_as_fixed_width_int(gamma, gamma_bit + 1)[1] / (2**gamma_bit)
     gamma_int = float_as_fixed_width_int(gamma_fixed_width_float, phase_bit + 1)[1]
     basis_map = {}

--- a/qualtran/bloqs/rotations/phasing_via_cost_function.py
+++ b/qualtran/bloqs/rotations/phasing_via_cost_function.py
@@ -1,0 +1,129 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import sympy
+from functools import cached_property
+from typing import Dict, TYPE_CHECKING, Union
+
+import attrs
+import numpy as np
+
+from qualtran import GateWithRegisters, QFxp, Signature, Bloq, BloqBuilder, Register
+from qualtran.bloqs.basic_gates.rotation import ZPowGate
+from qualtran.bloqs.rotations.phase_gradient import AddScaledValIntoPhaseReg
+
+if TYPE_CHECKING:
+    from qualtran import SoquetT
+
+
+@attrs.frozen
+class PhasingViaCostFunction(Bloq):
+    cost_eval_oracle: Bloq
+    phase_oracle: Bloq
+
+    @cached_property
+    def signature(self) -> 'Signature':
+        registers = [*self.cost_eval_oracle.signature.lefts()]
+        for reg in self.phase_oracle.signature.lefts():
+            try:
+                _ = self.cost_eval_oracle.signature.get_right(reg.name)
+            except KeyError:
+                registers.append(reg)
+        registers = list(dict.fromkeys(registers).keys())
+        return Signature(registers)
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
+        def _extract_soqs(bloq: Bloq) -> Dict[str, 'SoquetT']:
+            return {reg.name: soqs.pop(reg.name) for reg in bloq.signature.lefts()}
+
+        soqs |= bb.add_d(self.cost_eval_oracle, **_extract_soqs(self.cost_eval_oracle))
+        soqs |= bb.add_d(self.phase_oracle, **_extract_soqs(self.phase_oracle))
+        cost_eval_adjoint = self.cost_eval_oracle.adjoint()
+        soqs |= bb.add_d(cost_eval_adjoint, **_extract_soqs(cost_eval_adjoint))
+        return soqs
+
+
+@attrs.frozen
+class PhaseOracleZPow(GateWithRegisters):
+    cost_reg: Register
+    gamma: float = 1.0
+    eps: Union[float, sympy.Expr] = 1e-9
+
+    @cached_property
+    def cost_dtype(self) -> QFxp:
+        dtype = self.cost_reg.dtype
+        assert isinstance(dtype, QFxp)
+        return dtype
+
+    @cached_property
+    def signature(self) -> 'Signature':
+        return Signature([self.cost_reg])
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
+        out = soqs[self.cost_reg.name]
+        out = bb.split(out)
+        eps = self.eps / len(out)
+        if self.cost_dtype.signed:
+            out[0] = bb.add(ZPowGate(exponent=1, eps=eps), q=out[0])
+        for i in range(self.cost_dtype.bitsize):
+            power_of_two = i - self.cost_dtype.num_frac
+            out[-(i + 1)] = bb.add(
+                ZPowGate(exponent=(2**power_of_two) * self.gamma * 2, eps=self.eps / len(out)),
+                q=out[-(i + 1)],
+            )
+        return {self.cost_reg.name: bb.join(out)}
+
+
+@attrs.frozen
+class PhaseOraclePhaseGradient(GateWithRegisters):
+    cost_reg: Register
+    gamma: float = 1.0
+    eps: Union[float, sympy.Expr] = 1e-9
+
+    @cached_property
+    def signature(self) -> 'Signature':
+        return Signature([self.cost_reg, Register('phase_grad', QFxp(self.b_grad, self.b_grad))])
+
+    @cached_property
+    def cost_dtype(self) -> QFxp:
+        dtype = self.cost_reg.dtype
+        assert isinstance(dtype, QFxp)
+        return dtype
+
+    @cached_property
+    def b_phase(self) -> int:
+        return int(np.ceil(np.log2(1 / self.eps)))
+
+    @cached_property
+    def b_grad(self) -> int:
+        # Using Equation A7 from https://arxiv.org/abs/2007.07391
+        eq_a7 = int(np.ceil(np.log2((self.gamma_bitsize + 2) * np.pi / self.eps)))
+        # Using Equation 35 from https://arxiv.org/abs/2007.07391
+        eq_35 = self.b_phase + int(np.ceil(np.log2(self.b_phase)))
+        assert eq_a7 >= eq_35 >= self.cost_dtype.bitsize
+        return eq_35
+
+    @cached_property
+    def gamma_bitsize(self) -> int:
+        # TODO: Verify that gamma_bitsize computation is correct. The +5 is currently arbitrary to
+        #  make tests pass. Paragraph b/w equation 34 & 35 of https://arxiv.org/abs/2007.07391
+        #  gives `gamma_bitsize` to be `log(gamma) + b_{phase} + O(1)`
+        return self.b_phase + self.cost_dtype.num_frac + 5
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
+        out, phase_grad = bb.add(
+            AddScaledValIntoPhaseReg(self.cost_dtype, self.b_grad, self.gamma, self.gamma_bitsize),
+            x=soqs[self.cost_reg.name],
+            phase_grad=soqs['phase_grad'],
+        )
+        return {self.cost_reg.name: out, 'phase_grad': phase_grad}

--- a/qualtran/bloqs/rotations/phasing_via_cost_function.py
+++ b/qualtran/bloqs/rotations/phasing_via_cost_function.py
@@ -110,10 +110,13 @@ class PhaseOraclePhaseGradient(GateWithRegisters):
         eq_a7 = int(np.ceil(np.log2((self.gamma_bitsize + 2) * np.pi / self.eps)))
         # Using Equation 35 from https://arxiv.org/abs/2007.07391
         eq_35 = self.b_phase + int(np.ceil(np.log2(self.b_phase)))
-        # Note: Eq A7 will result in a bigger gradient bitsize and is probably the right size to use.
-        # However, we don't yet have a test that fails for Eq 35 but not for EqA7.
+        # TODO(#654): Eq A7 will result in a bigger gradient bitsize but blows up the cost
+        #   for doing phase gradient based cost computations significantly (which leads to
+        #   the cost using PhaseOracleZPow to be cheaper). Also, we don't yet have a test that
+        #   fails for Eq 35. The only concern is that value of `eq_35` can be smaller than
+        #   `cost_reg.bitsize`.
         assert eq_a7 >= eq_35
-        return eq_a7
+        return eq_35
 
     @cached_property
     def gamma_bitsize(self) -> int:

--- a/qualtran/bloqs/rotations/phasing_via_cost_function.py
+++ b/qualtran/bloqs/rotations/phasing_via_cost_function.py
@@ -11,14 +11,14 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import sympy
 from functools import cached_property
 from typing import Dict, TYPE_CHECKING, Union
 
 import attrs
 import numpy as np
+import sympy
 
-from qualtran import GateWithRegisters, QFxp, Signature, Bloq, BloqBuilder, Register
+from qualtran import Bloq, BloqBuilder, GateWithRegisters, QFxp, Register, Signature
 from qualtran.bloqs.basic_gates.rotation import ZPowGate
 from qualtran.bloqs.rotations.phase_gradient import AddScaledValIntoPhaseReg
 

--- a/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
+++ b/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
@@ -73,7 +73,7 @@ class TestHammingWeightPhasing(GateWithRegisters):
 
 
 @pytest.mark.parametrize('n', [2, 3])
-@pytest.mark.parametrize('exponent, eps', [(1 / 10, 1e-4), (1.20345, 1e-4), (-4.1934341, 1e-4)])
+@pytest.mark.parametrize('exponent, eps', [(1 / 10, 5e-4), (1.20345, 5e-4), (-1.1934341, 5e-4)])
 @pytest.mark.parametrize('use_phase_gradient', [True, False])
 def test_hamming_weight_phasing_using_phase_via_cost_function(
     n: int, exponent: float, eps: float, use_phase_gradient: bool
@@ -133,7 +133,7 @@ class TestSquarePhasing(GateWithRegisters):
 
 
 @pytest.mark.parametrize('n', [2])
-@pytest.mark.parametrize('gamma, eps', [(0.1, 1e-2), (1.20345, 1e-2), (-4.1934341, 1e-2)])
+@pytest.mark.parametrize('gamma, eps', [(0.1, 5e-2), (1.20345, 5e-2), (-1.1934341, 5e-2)])
 @pytest.mark.parametrize('use_phase_gradient', [True, False])
 def test_square_phasing_via_phase_gradient(
     n: int, gamma: float, eps: float, use_phase_gradient: bool

--- a/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
+++ b/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
@@ -1,0 +1,152 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import Dict
+
+import attrs
+import cirq
+import numpy as np
+import pytest
+
+from qualtran import GateWithRegisters, Signature, Bloq, BloqBuilder, SoquetT, Register
+from qualtran._infra.data_types import QFxp
+from qualtran.bloqs.rotations.phasing_via_cost_function import (
+    PhasingViaCostFunction,
+    PhaseOracleZPow,
+    PhaseOraclePhaseGradient,
+)
+from qualtran.bloqs.on_each import OnEach
+from qualtran.bloqs.basic_gates import Hadamard
+from qualtran.bloqs.arithmetic.hamming_weight import HammingWeightCompute
+from qualtran.bloqs.arithmetic.multiplication import Square
+from qualtran.bloqs.rotations.phase_gradient import PhaseGradientState
+from qualtran.cirq_interop.testing import GateHelper
+from qualtran.testing import assert_valid_bloq_decomposition
+
+
+@attrs.frozen
+class TestHammingWeightPhasing(GateWithRegisters):
+    bitsize: int
+    exponent: float
+    eps: float
+    use_phase_gradient: bool = False
+
+    @property
+    def signature(self) -> 'Signature':
+        return Signature.build(x=self.bitsize)
+
+    @property
+    def cost_reg(self) -> Register:
+        return Register('out', QFxp(self.bitsize.bit_length(), 0, signed=False))
+
+    @property
+    def phase_oracle(self) -> Bloq:
+        if self.use_phase_gradient:
+            return PhaseOraclePhaseGradient(self.cost_reg, self.exponent / 2, self.eps)
+        else:
+            return PhaseOracleZPow(self.cost_reg, self.exponent / 2, self.eps)
+
+    @property
+    def cost_eval_oracle(self) -> Bloq:
+        return HammingWeightCompute(self.bitsize)
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
+        if self.use_phase_gradient:
+            soqs['phase_grad'] = bb.add(PhaseGradientState(self.phase_oracle.b_grad))
+        soqs = bb.add_d(PhasingViaCostFunction(self.cost_eval_oracle, self.phase_oracle), **soqs)
+        if self.use_phase_gradient:
+            bb.add(
+                PhaseGradientState(self.phase_oracle.b_grad, adjoint=True),
+                phase_grad=soqs.pop('phase_grad'),
+            )
+        return soqs
+
+
+@pytest.mark.parametrize('n', [2, 3])
+@pytest.mark.parametrize('exponent, eps', [(1 / 10, 1e-4), (1.20345, 1e-4), (-4.1934341, 1e-4)])
+@pytest.mark.parametrize('use_phase_gradient', [True, False])
+def test_hamming_weight_phasing_using_phase_via_cost_function(
+    n: int, exponent: float, eps: float, use_phase_gradient: bool
+):
+    gate = TestHammingWeightPhasing(n, exponent, eps, use_phase_gradient)
+    assert_valid_bloq_decomposition(gate)
+
+    gh = GateHelper(gate)
+    sim = cirq.Simulator(dtype=np.complex128)
+    initial_state = cirq.testing.random_superposition(dim=2**n, random_state=12345)
+    gamma = exponent / 2
+    phases = np.array([np.exp(1j * 2 * np.pi * gamma * x.bit_count()) for x in range(2**n)])
+    expected_final_state = np.multiply(initial_state, phases)
+
+    state_prep = cirq.Circuit(cirq.StatePreparationChannel(initial_state).on(*gh.quregs['x']))
+    hw_phasing = cirq.Circuit(state_prep, gh.operation)
+    hw_final_state = sim.simulate(hw_phasing).final_state_vector
+    np.testing.assert_allclose(expected_final_state, hw_final_state, atol=eps)
+
+
+@attrs.frozen
+class TestSquarePhasing(GateWithRegisters):
+    bitsize: int
+    gamma: float
+    eps: float
+    use_phase_gradient: bool = False
+
+    @property
+    def signature(self) -> 'Signature':
+        return Signature.build(a=self.bitsize)
+
+    @property
+    def cost_reg(self) -> Register:
+        return Register('result', QFxp(2 * self.bitsize, 0, signed=False))
+
+    @property
+    def phase_oracle(self) -> Bloq:
+        if self.use_phase_gradient:
+            return PhaseOraclePhaseGradient(self.cost_reg, self.gamma, self.eps)
+        else:
+            return PhaseOracleZPow(self.cost_reg, self.gamma, self.eps)
+
+    @property
+    def cost_eval_oracle(self) -> Bloq:
+        return Square(self.bitsize)
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
+        if self.use_phase_gradient:
+            soqs['phase_grad'] = bb.add(PhaseGradientState(self.phase_oracle.b_grad))
+        soqs = bb.add_d(PhasingViaCostFunction(self.cost_eval_oracle, self.phase_oracle), **soqs)
+        if self.use_phase_gradient:
+            bb.add(
+                PhaseGradientState(self.phase_oracle.b_grad, adjoint=True),
+                phase_grad=soqs.pop('phase_grad'),
+            )
+        return soqs
+
+
+@pytest.mark.parametrize('n', [2])
+@pytest.mark.parametrize('gamma, eps', [(0.1, 1e-2), (1.20345, 1e-2), (-4.1934341, 1e-2)])
+@pytest.mark.parametrize('use_phase_gradient', [True, False])
+def test_square_phasing_via_phase_gradient(
+    n: int, gamma: float, eps: float, use_phase_gradient: bool
+):
+    initial_state = np.array([1 / np.sqrt(2**n)] * 2**n)
+    phases = np.array([np.exp(1j * 2 * np.pi * gamma * x**2) for x in range(2**n)])
+    expected_final_state = np.multiply(initial_state, phases)
+
+    test_bloq = TestSquarePhasing(n, gamma, eps, use_phase_gradient)
+    bb = BloqBuilder()
+    a = bb.allocate(n)
+    a = bb.add(OnEach(n, Hadamard()), q=a)
+    a = bb.add(test_bloq, a=a)
+    cbloq = bb.finalize(a=a)
+    hw_final_state = cbloq.tensor_contract()
+    np.testing.assert_allclose(expected_final_state, hw_final_state, atol=eps)

--- a/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
+++ b/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
@@ -18,18 +18,18 @@ import cirq
 import numpy as np
 import pytest
 
-from qualtran import GateWithRegisters, Signature, Bloq, BloqBuilder, SoquetT, Register
+from qualtran import Bloq, BloqBuilder, GateWithRegisters, Register, Signature, SoquetT
 from qualtran._infra.data_types import QFxp
-from qualtran.bloqs.rotations.phasing_via_cost_function import (
-    PhasingViaCostFunction,
-    PhaseOracleZPow,
-    PhaseOraclePhaseGradient,
-)
-from qualtran.bloqs.on_each import OnEach
-from qualtran.bloqs.basic_gates import Hadamard
 from qualtran.bloqs.arithmetic.hamming_weight import HammingWeightCompute
 from qualtran.bloqs.arithmetic.multiplication import Square
+from qualtran.bloqs.basic_gates import Hadamard
+from qualtran.bloqs.on_each import OnEach
 from qualtran.bloqs.rotations.phase_gradient import PhaseGradientState
+from qualtran.bloqs.rotations.phasing_via_cost_function import (
+    PhaseOraclePhaseGradient,
+    PhaseOracleZPow,
+    PhasingViaCostFunction,
+)
 from qualtran.cirq_interop.testing import GateHelper
 from qualtran.testing import assert_valid_bloq_decomposition
 


### PR DESCRIPTION
This PR introduces Bloqs and a generalized framework to implement oracles for phasing by a cost function as described in Section-3 of https://arxiv.org/abs/2007.07391. Specifically, the PR introduces the following changes:

* `PhasingViaCostFunction` : New Bloq that expects (a) $O_{\text{direct}}$ - cost function function evaluation oracle and (b) $O_{\text{phase}}$ - phasing oracle.  This bloq implements the general unitary 

$$
U_f(\gamma) = \sum_{x=0}^{N-1} e^{i 2 \pi \gamma f(x)} |x\rangle \langle x| 
$$

using 

$$
U_f(\gamma) = O_{\text{direct}}^{\dagger} O_{\text{phase}}(\gamma) O_{\text{direct}}
$$

where

$$
O_{\text{direct}}|x\rangle |0\rangle^{\otimes b_{\text{dir}}}  = |x\rangle |f(x)\rangle
$$

$$
O_{phase}(\gamma) |x\rangle |f(x)\rangle = e^{i 2 \pi \gamma f(x)} |x\rangle |f(x)\rangle
$$

* `PhaseOracleZPow` : A brute-force based implementation of the phase oracle which applies a series of $Z^{2^i}$ on the cost register $b_{\text{dir}}$
* `PhaseOraclePhaseGradient` : A phase gradient based implementation of the phase oracle which synthesizes the phase rotations via an addition into the phase gradient register. 
* Tests that demonstrate using these oracles for implementing phasing via (a) `f(x) = hamming_weight(x)` and (b) `f(x) = x ** 2`


As part of implementing these oracles and tests, I also updated
* `QFxp` :  To return a data type string that can be passed to `fxpmath.Fxp`. 
* `Square` : Added classical simulation and tensor network simulation support. Also added support for uncomputation.
* `AddScaledValIntoPhaseReg` : Implementation now uses `QFxp` quantum data types and `Fxp` classical data types to support simulating arbitrary fixed point values. This removes the previous constraint that `gamma` must be between `[0, 1]`. Also added tests for the same. 


The formulas in then paper for computing bitsizes of `gamma` and phase gradient register are incorrect and convoluted. I've added detailed docstrings highlighting the equation numbers and there are still some TODOs left, which are tracked in  https://github.com/quantumlib/Qualtran/issues/654


cc @ncrubin @fdmalone 

