### PR TITLE
Use functools.cached_property (instead of cirq)

### DIFF
--- a/qualtran/bloqs/apply_gate_to_lth_target.py
+++ b/qualtran/bloqs/apply_gate_to_lth_target.py
@@ -13,12 +13,12 @@
 #  limitations under the License.
 
 import itertools
+from functools import cached_property
 from typing import Callable, Sequence, Tuple
 
 import attrs
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 
 from qualtran import bloq_example, BloqDocSpec, BoundedQUInt, Register, Signature
 from qualtran._infra.gate_with_registers import total_bits

--- a/qualtran/bloqs/hubbard_model.py
+++ b/qualtran/bloqs/hubbard_model.py
@@ -46,12 +46,12 @@ considered in both the PREPARE and SELECT operations corresponding to the terms 
 
 See the documentation for `PrepareHubbard` and `SelectHubbard` for details.
 """
+from functools import cached_property
 from typing import Collection, Optional, Sequence, Tuple, Union
 
 import attrs
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import BoundedQUInt, Register, Signature

--- a/qualtran/bloqs/mean_estimation/complex_phase_oracle.py
+++ b/qualtran/bloqs/mean_estimation/complex_phase_oracle.py
@@ -12,11 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from functools import cached_property
 from typing import Tuple
 
 import attrs
 import cirq
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import GateWithRegisters, Register, Signature

--- a/qualtran/bloqs/mean_estimation/complex_phase_oracle_test.py
+++ b/qualtran/bloqs/mean_estimation/complex_phase_oracle_test.py
@@ -13,13 +13,13 @@
 #  limitations under the License.
 
 import math
+from functools import cached_property
 from typing import Optional, Tuple
 
 import cirq
 import numpy as np
 import pytest
 from attrs import frozen
-from cirq._compat import cached_property
 
 from qualtran import Register
 from qualtran.bloqs.mean_estimation.complex_phase_oracle import ComplexPhaseOracle

--- a/qualtran/bloqs/mean_estimation/mean_estimation_operator.py
+++ b/qualtran/bloqs/mean_estimation/mean_estimation_operator.py
@@ -12,11 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from functools import cached_property
 from typing import Collection, Optional, Sequence, Tuple, Union
 
 import attrs
 import cirq
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import GateWithRegisters, Register, Signature

--- a/qualtran/bloqs/mean_estimation/mean_estimation_operator_test.py
+++ b/qualtran/bloqs/mean_estimation/mean_estimation_operator_test.py
@@ -12,13 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from functools import cached_property
 from typing import Optional, Sequence, Tuple
 
 import cirq
 import numpy as np
 import pytest
 from attrs import frozen
-from cirq._compat import cached_property
 
 from qualtran import BoundedQUInt, Register
 from qualtran._infra.gate_with_registers import get_named_qubits, total_bits

--- a/qualtran/bloqs/prepare_uniform_superposition.py
+++ b/qualtran/bloqs/prepare_uniform_superposition.py
@@ -12,12 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from functools import cached_property
 from typing import Tuple
 
 import attrs
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import bloq_example, BloqDocSpec, GateWithRegisters, Signature

--- a/qualtran/bloqs/programmable_rotation_gate_array.py
+++ b/qualtran/bloqs/programmable_rotation_gate_array.py
@@ -13,11 +13,12 @@
 #  limitations under the License.
 
 import abc
+from functools import cached_property
 from typing import Sequence, Tuple
 
 import cirq
 import numpy as np
-from cirq._compat import cached_method, cached_property
+from cirq._compat import cached_method
 from numpy.typing import NDArray
 
 from qualtran import BoundedQUInt, GateWithRegisters, Register, Signature

--- a/qualtran/bloqs/programmable_rotation_gate_array_test.py
+++ b/qualtran/bloqs/programmable_rotation_gate_array_test.py
@@ -12,12 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from functools import cached_property
 from typing import Tuple
 
 import cirq
 import numpy as np
 import pytest
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import Register, Signature

--- a/qualtran/bloqs/qrom.py
+++ b/qualtran/bloqs/qrom.py
@@ -12,12 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from functools import cached_property
 from typing import Callable, Sequence, Set, Tuple
 
 import attrs
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from numpy.typing import ArrayLike, NDArray
 
 from qualtran import BoundedQUInt, Register, Soquet

--- a/qualtran/bloqs/qubitization_walk_operator.py
+++ b/qualtran/bloqs/qubitization_walk_operator.py
@@ -12,11 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from functools import cached_property
 from typing import Collection, Optional, Sequence, Tuple, Union
 
 import attrs
 import cirq
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import GateWithRegisters, Register, Signature

--- a/qualtran/bloqs/reflection_using_prepare.py
+++ b/qualtran/bloqs/reflection_using_prepare.py
@@ -12,11 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from functools import cached_property
 from typing import Collection, Optional, Sequence, Tuple, Union
 
 import attrs
 import cirq
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import GateWithRegisters, Register, Signature

--- a/qualtran/bloqs/select_and_prepare.py
+++ b/qualtran/bloqs/select_and_prepare.py
@@ -13,9 +13,8 @@
 #  limitations under the License.
 
 import abc
+from functools import cached_property
 from typing import Tuple
-
-from cirq._compat import cached_property
 
 from qualtran import GateWithRegisters, Register, Signature
 

--- a/qualtran/bloqs/select_pauli_lcu.py
+++ b/qualtran/bloqs/select_pauli_lcu.py
@@ -14,12 +14,12 @@
 
 """Bloqs for applying SELECT unitary for LCU of Pauli Strings."""
 
+from functools import cached_property
 from typing import Collection, Optional, Sequence, Tuple, Union
 
 import attrs
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import BoundedQUInt, Register

--- a/qualtran/bloqs/select_swap_qrom.py
+++ b/qualtran/bloqs/select_swap_qrom.py
@@ -12,11 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from functools import cached_property
 from typing import List, Optional, Sequence, Tuple
 
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import BoundedQUInt, GateWithRegisters, Register, Signature, Soquet

--- a/qualtran/bloqs/selected_majorana_fermion.py
+++ b/qualtran/bloqs/selected_majorana_fermion.py
@@ -12,12 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from functools import cached_property
 from typing import Sequence, Tuple, Union
 
 import attrs
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import Register

--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
@@ -20,12 +20,12 @@ database) with a number of T gates scaling as 4L + O(log(1/eps)) where eps is th
 largest absolute error that one can tolerate in the prepared amplitudes.
 """
 
+from functools import cached_property
 from typing import List, Tuple
 
 import attrs
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import BoundedQUInt, Register, Signature

--- a/qualtran/bloqs/unary_iteration_bloq.py
+++ b/qualtran/bloqs/unary_iteration_bloq.py
@@ -14,11 +14,11 @@
 
 import abc
 from collections import defaultdict
+from functools import cached_property
 from typing import Callable, Dict, Iterator, List, Sequence, Set, Tuple, TYPE_CHECKING, Union
 
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import GateWithRegisters, Register, Signature

--- a/qualtran/bloqs/unary_iteration_bloq_test.py
+++ b/qualtran/bloqs/unary_iteration_bloq_test.py
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 import itertools
+from functools import cached_property
 from typing import Sequence, Set, Tuple, TYPE_CHECKING
 
 import cirq
 import pytest
-from cirq._compat import cached_property
 
 from qualtran import BoundedQUInt, Register, Signature
 from qualtran._infra.gate_with_registers import get_named_qubits, total_bits

--- a/qualtran/cirq_interop/testing.py
+++ b/qualtran/cirq_interop/testing.py
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 from dataclasses import dataclass
+from functools import cached_property
 from typing import Any, Dict, List, Sequence, Tuple
 
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from qualtran import Signature


### PR DESCRIPTION
fixes #663 