### PR TITLE
Remove adjoint attribute from PhaseGradientState and use the default Adjoint Bloq instead

### DIFF
--- a/qualtran/_infra/adjoint.py
+++ b/qualtran/_infra/adjoint.py
@@ -16,7 +16,9 @@ from functools import cached_property
 from typing import Dict, List, Set, Tuple, TYPE_CHECKING
 
 import attrs
+import cirq
 from attrs import frozen
+from numpy.typing import NDArray
 
 from .composite_bloq import _binst_to_cxns, _cxn_to_soq_dict, _map_soqs, _reg_to_soq, BloqBuilder
 from .gate_with_registers import GateWithRegisters
@@ -140,6 +142,13 @@ class Adjoint(GateWithRegisters):
     def decompose_bloq(self) -> 'CompositeBloq':
         """The decomposition is the adjoint of `subbloq`'s decomposition."""
         return self.subbloq.decompose_bloq().adjoint()
+
+    def decompose_from_registers(
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+    ) -> cirq.OP_TREE:
+        if isinstance(self.subbloq, GateWithRegisters):
+            return cirq.inverse(self.subbloq.decompose_from_registers(context=context, **quregs))
+        return super().decompose_from_registers(context=context, **quregs)
 
     def supports_decompose_bloq(self) -> bool:
         """Delegate to `subbloq.supports_decompose_bloq()`"""

--- a/qualtran/bloqs/qft/qft_phase_gradient_test.py
+++ b/qualtran/bloqs/qft/qft_phase_gradient_test.py
@@ -42,7 +42,7 @@ class TestQFTWithPhaseGradient(GateWithRegisters):
         q, phase_grad = bb.add(
             QFTPhaseGradient(self.bitsize, self.with_reverse), q=q, phase_grad=phase_grad
         )
-        bb.add(PhaseGradientState(self.bitsize, adjoint=True), phase_grad=phase_grad)
+        bb.add(PhaseGradientState(self.bitsize).adjoint(), phase_grad=phase_grad)
         return {'q': q}
 
 

--- a/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
@@ -72,7 +72,7 @@ class TestHammingWeightPhasingViaPhaseGradient(GateWithRegisters):
             x=x,
             phase_grad=phase_grad,
         )
-        bb.add(PhaseGradientState(b_grad, adjoint=True), phase_grad=phase_grad)
+        bb.add(PhaseGradientState(b_grad).adjoint(), phase_grad=phase_grad)
         return {'x': x}
 
 

--- a/qualtran/bloqs/rotations/phase_gradient_test.py
+++ b/qualtran/bloqs/rotations/phase_gradient_test.py
@@ -31,7 +31,7 @@ from qualtran.testing import assert_valid_bloq_decomposition
 def test_phase_gradient_state(n: int):
     gate = PhaseGradientState(n)
     assert_valid_bloq_decomposition(gate)
-    assert_valid_bloq_decomposition(gate**-1)
+    assert_valid_bloq_decomposition(gate.adjoint())
 
     q = cirq.LineQubit.range(n)
     state_prep_cirq_circuit = cirq.Circuit(
@@ -39,7 +39,7 @@ def test_phase_gradient_state(n: int):
     )
     assert np.allclose(cirq.unitary(gate), cirq.unitary(state_prep_cirq_circuit))
     assert np.allclose(
-        cirq.unitary(gate**-1), cirq.unitary(cirq.inverse(state_prep_cirq_circuit))
+        cirq.unitary(gate.adjoint()), cirq.unitary(cirq.inverse(state_prep_cirq_circuit))
     )
     assert gate.t_complexity().rotations == n - 2
     assert gate.t_complexity().clifford == n + 2
@@ -55,7 +55,7 @@ def test_phase_gradient_state_tensor_contract(n: int, t: float):
 
     bb = BloqBuilder()
     phase_reg = bb.add(bloq)
-    bb.add(PhaseGradientState(n, t, adjoint=True), phase_grad=phase_reg)
+    bb.add(PhaseGradientState(n, t).adjoint(), phase_grad=phase_reg)
     circuit = bb.finalize()
     assert np.isclose(circuit.tensor_contract(), 1)
 

--- a/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
+++ b/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
@@ -66,7 +66,7 @@ class TestHammingWeightPhasing(GateWithRegisters):
         soqs = bb.add_d(PhasingViaCostFunction(self.cost_eval_oracle, self.phase_oracle), **soqs)
         if self.use_phase_gradient:
             bb.add(
-                PhaseGradientState(self.phase_oracle.b_grad, adjoint=True),
+                PhaseGradientState(self.phase_oracle.b_grad).adjoint(),
                 phase_grad=soqs.pop('phase_grad'),
             )
         return soqs
@@ -126,7 +126,7 @@ class TestSquarePhasing(GateWithRegisters):
         soqs = bb.add_d(PhasingViaCostFunction(self.cost_eval_oracle, self.phase_oracle), **soqs)
         if self.use_phase_gradient:
             bb.add(
-                PhaseGradientState(self.phase_oracle.b_grad, adjoint=True),
+                PhaseGradientState(self.phase_oracle.b_grad).adjoint(),
                 phase_grad=soqs.pop('phase_grad'),
             )
         return soqs


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Qualtran/issues/668

I also fixed an issue because of which Cirq simulations would fail on using `Adjoint`. I remember @mpharrigan had encountered this before but I'm unable to find the relevant issue. 