### PR TITLE
Unify t-complexity protocol

### DIFF
--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -408,7 +408,9 @@ class Bloq(metaclass=abc.ABCMeta):
         By default, this will recurse into this bloq's decomposition but this
         method can be overriden with a known value.
         """
-        return self.decompose_bloq().t_complexity()
+        from qualtran.cirq_interop.t_complexity_protocol import t_complexity
+
+        return t_complexity(self)
 
     def as_cirq_op(
         self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'

--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -175,15 +175,6 @@ class CompositeBloq(Bloq):
         out_vals, _ = call_cbloq_classically(self.signature, vals, self._binst_graph)
         return tuple(out_vals[reg.name] for reg in self.signature.rights())
 
-    def t_complexity(self) -> 'TComplexity':
-        """The `TComplexity` for a composite bloq is the sum of its components' counts."""
-        from qualtran.cirq_interop.t_complexity_protocol import TComplexity
-
-        rc = TComplexity()
-        for binst in self.bloq_instances:
-            rc += binst.bloq.t_complexity()
-        return rc
-
     def as_composite_bloq(self) -> 'CompositeBloq':
         """This override just returns the present composite bloq."""
         return self

--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -262,11 +262,6 @@ class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
         )
         return self.on_registers(**all_quregs), out_quregs
 
-    def t_complexity(self) -> 'TComplexity':
-        from qualtran.cirq_interop.t_complexity_protocol import t_complexity
-
-        return t_complexity(self)
-
     def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
         from qualtran.cirq_interop._cirq_to_bloq import _wire_symbol_from_gate
 

--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -274,7 +274,7 @@ class OutOfPlaceAdder(GateWithRegisters, cirq.ArithmeticGate):
         ]
         return cirq.inverse(optree) if self.adjoint else optree
 
-    def t_complexity(self) -> TComplexity:
+    def _t_complexity_(self) -> TComplexity:
         and_t = And(uncompute=self.adjoint).t_complexity()
         num_clifford = self.bitsize * (5 + and_t.clifford)
         num_t = self.bitsize * and_t.t

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -502,7 +502,7 @@ class GreaterThan(Bloq):
     def short_name(self) -> str:
         return "a>b"
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return t_complexity(LessThanEqual(self.a_bitsize, self.b_bitsize))
 
     def wire_symbol(self, soq: Soquet) -> WireSymbol:
@@ -716,7 +716,7 @@ class GreaterThanConstant(Bloq):
     def signature(self) -> Signature:
         return Signature.build_from_dtypes(x=QUInt(self.bitsize), target=QBit())
 
-    def t_complexity(self) -> TComplexity:
+    def _t_complexity_(self) -> TComplexity:
         return t_complexity(LessThanConstant(self.bitsize, less_than_val=self.val))
 
     def short_name(self) -> str:
@@ -759,7 +759,7 @@ class EqualsAConstant(Bloq):
     def signature(self) -> Signature:
         return Signature.build_from_dtypes(x=QUInt(self.bitsize), target=QBit())
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return TComplexity(t=4 * (self.bitsize - 1))
 
     def short_name(self) -> str:

--- a/qualtran/bloqs/arithmetic/conversions.py
+++ b/qualtran/bloqs/arithmetic/conversions.py
@@ -85,7 +85,7 @@ class ToContiguousIndex(Bloq):
     ) -> Dict[str, 'ClassicalValT']:
         return {'mu': mu, 'nu': nu, 's': nu * (nu + 1) // 2 + mu}
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         num_toffoli = self.bitsize**2 + self.bitsize - 1
         return TComplexity(t=4 * num_toffoli)
 

--- a/qualtran/bloqs/arithmetic/multiplication.py
+++ b/qualtran/bloqs/arithmetic/multiplication.py
@@ -161,7 +161,7 @@ class Square(Bloq):
     def short_name(self) -> str:
         return "a^2"
 
-    def t_complexity(self):
+    def _t_complexity_(self):
         # TODO Determine precise clifford count and/or ignore.
         # See: https://github.com/quantumlib/Qualtran/issues/219
         # See: https://github.com/quantumlib/Qualtran/issues/217
@@ -252,7 +252,7 @@ class SumOfSquares(Bloq):
     def short_name(self) -> str:
         return "SOS"
 
-    def t_complexity(self):
+    def _t_complexity_(self):
         # TODO Determine precise clifford count and/or ignore.
         # See: https://github.com/quantumlib/Qualtran/issues/219
         # See: https://github.com/quantumlib/Qualtran/issues/217
@@ -319,7 +319,7 @@ class Product(Bloq):
     def short_name(self) -> str:
         return "a*b"
 
-    def t_complexity(self):
+    def _t_complexity_(self):
         # TODO Determine precise clifford count and/or ignore.
         # See: https://github.com/quantumlib/Qualtran/issues/219
         # See: https://github.com/quantumlib/Qualtran/issues/217
@@ -388,7 +388,7 @@ class ScaleIntByReal(Bloq):
     def short_name(self) -> str:
         return "r*i"
 
-    def t_complexity(self):
+    def _t_complexity_(self):
         # Eq. D8, we are assuming dA and dB there are assumed as inputs and the
         # user has ensured these are large enough for their desired precision.
         num_toff = self.r_bitsize * (2 * self.i_bitsize - 1) - self.i_bitsize**2
@@ -455,7 +455,7 @@ class MultiplyTwoReals(Bloq):
     def short_name(self) -> str:
         return "a*b"
 
-    def t_complexity(self):
+    def _t_complexity_(self):
         # Eq. D13, there it is suggested keeping both registers the same size is optimal.
         num_toff = self.bitsize**2 - self.bitsize - 1
         return TComplexity(t=4 * num_toff)
@@ -523,7 +523,7 @@ class SquareRealNumber(Bloq):
     def short_name(self) -> str:
         return "a^2"
 
-    def t_complexity(self):
+    def _t_complexity_(self):
         num_toff = self.bitsize**2 // 2 - 4
         return TComplexity(t=4 * num_toff)
 

--- a/qualtran/bloqs/basic_gates/cnot.py
+++ b/qualtran/bloqs/basic_gates/cnot.py
@@ -137,7 +137,7 @@ class CNOT(Bloq):
             return ModPlus()
         raise ValueError(f'Bad wire symbol soquet: {soq}')
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return TComplexity(clifford=1)
 
 

--- a/qualtran/bloqs/basic_gates/hadamard.py
+++ b/qualtran/bloqs/basic_gates/hadamard.py
@@ -82,7 +82,7 @@ class Hadamard(Bloq):
         (q,) = q
         return cirq.H(q), {'q': np.array([q])}
 
-    def t_complexity(self):
+    def _t_complexity_(self):
         return TComplexity(clifford=1)
 
 

--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import abc
 from functools import cached_property
 from typing import Protocol
 

--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -31,13 +31,8 @@ class _HasEps(Protocol):
     eps: float
 
 
-class _RotationBloq(CirqGateAsBloqBase, metaclass=abc.ABCMeta):
-    def _t_complexity_(self: _HasEps):
-        return TComplexity(rotations=1)
-
-
 @frozen
-class ZPowGate(_RotationBloq):
+class ZPowGate(CirqGateAsBloqBase):
     r"""A gate that rotates around the Z axis of the Bloch sphere.
 
     The unitary matrix of `ZPowGate(exponent=t, global_shift=s)` is:
@@ -109,7 +104,7 @@ class CZPowGate(CirqGateAsBloqBase):
 
 
 @frozen
-class XPowGate(_RotationBloq):
+class XPowGate(CirqGateAsBloqBase):
     r"""A gate that rotates around the X axis of the Bloch sphere.
 
     The unitary matrix of `XPowGate(exponent=t, global_shift=s)` is:
@@ -158,7 +153,7 @@ class XPowGate(_RotationBloq):
 
 
 @frozen
-class YPowGate(_RotationBloq):
+class YPowGate(CirqGateAsBloqBase):
     r"""A gate that rotates around the Y axis of the Bloch sphere.
 
     The unitary matrix of `YPowGate(exponent=t)` is:
@@ -207,7 +202,7 @@ class YPowGate(_RotationBloq):
 
 
 @frozen
-class Rz(_RotationBloq):
+class Rz(CirqGateAsBloqBase):
     """Single-qubit Rz gate.
 
     Args:
@@ -233,7 +228,7 @@ class Rz(_RotationBloq):
 
 
 @frozen
-class Rx(_RotationBloq):
+class Rx(CirqGateAsBloqBase):
     angle: float
     eps: float = 1e-11
 
@@ -243,7 +238,7 @@ class Rx(_RotationBloq):
 
 
 @frozen
-class Ry(_RotationBloq):
+class Ry(CirqGateAsBloqBase):
     angle: float
     eps: float = 1e-11
 

--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -14,19 +14,15 @@
 
 import abc
 from functools import cached_property
-from typing import Protocol, Set, TYPE_CHECKING
+from typing import Protocol
 
 import cirq
 import numpy as np
 from attrs import frozen
 
 from qualtran import bloq_example
-from qualtran.bloqs.basic_gates.t_gate import TGate
 from qualtran.cirq_interop import CirqGateAsBloqBase
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
-
-if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 
 
 class _HasEps(Protocol):
@@ -36,18 +32,8 @@ class _HasEps(Protocol):
 
 
 class _RotationBloq(CirqGateAsBloqBase, metaclass=abc.ABCMeta):
-    def t_complexity(self: _HasEps):
-        # TODO Determine precise clifford count and/or ignore.
-        # This is an improvement over Ref. 2 from the docstring which provides
-        # a bound of 3 log(1/eps).
-        # See: https://github.com/quantumlib/Qualtran/issues/219
-        # See: https://github.com/quantumlib/Qualtran/issues/217
-        num_t = int(np.ceil(1.149 * np.log2(1.0 / self.eps) + 9.2))
-        return TComplexity(t=num_t)
-
-    def build_call_graph(self: _HasEps, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        num_t = _RotationBloq.t_complexity(self).t
-        return {(TGate(), num_t)}
+    def _t_complexity_(self: _HasEps):
+        return TComplexity(rotations=1)
 
 
 @frozen

--- a/qualtran/bloqs/basic_gates/rotation_test.py
+++ b/qualtran/bloqs/basic_gates/rotation_test.py
@@ -44,7 +44,7 @@ def test_rotation_gates():
     tcount = 52
     assert Rx(angle).t_complexity().t_incl_rotations() == tcount
     assert Ry(angle).t_complexity().t_incl_rotations() == tcount
-    assert Rz(angle).t_complexity().t_incl_rotations() == tcount
+    assert Rz(angle).t_complexity().t_incl_rotations() == 1
 
 
 def test_as_cirq_op():

--- a/qualtran/bloqs/basic_gates/rotation_test.py
+++ b/qualtran/bloqs/basic_gates/rotation_test.py
@@ -42,9 +42,9 @@ def _make_Rz():
 def test_rotation_gates():
     angle = np.pi / 4.0
     tcount = 52
-    assert Rx(angle).t_complexity().t == tcount
-    assert Ry(angle).t_complexity().t == tcount
-    assert Rz(angle).t_complexity().t == tcount
+    assert Rx(angle).t_complexity().t_incl_rotations() == tcount
+    assert Ry(angle).t_complexity().t_incl_rotations() == tcount
+    assert Rz(angle).t_complexity().t_incl_rotations() == tcount
 
 
 def test_as_cirq_op():

--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -151,7 +151,7 @@ class TwoBitCSwap(Bloq):
             return {'ctrl': 1, 'x': y, 'y': x}
         raise ValueError("Bad control value for TwoBitCSwap classical simulation.")
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         """The t complexity.
 
         References:

--- a/qualtran/bloqs/basic_gates/t_gate.py
+++ b/qualtran/bloqs/basic_gates/t_gate.py
@@ -72,7 +72,7 @@ class TGate(Bloq):
     def signature(self) -> 'Signature':
         return Signature.build(q=1)
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return TComplexity(t=1)
 
     def add_my_tensors(

--- a/qualtran/bloqs/basic_gates/toffoli.py
+++ b/qualtran/bloqs/basic_gates/toffoli.py
@@ -58,7 +58,7 @@ class Toffoli(Bloq):
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         return {(TGate(), 4)}
 
-    def t_complexity(self):
+    def _t_complexity_(self):
         return TComplexity(t=4)
 
     def add_my_tensors(

--- a/qualtran/bloqs/basic_gates/x_basis.py
+++ b/qualtran/bloqs/basic_gates/x_basis.py
@@ -225,7 +225,7 @@ class XGate(Bloq):
         (q,) = q
         return cirq.X(q), {'q': [q]}
 
-    def t_complexity(self):
+    def _t_complexity_(self):
         return TComplexity(clifford=1)
 
     def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -351,7 +351,7 @@ class _IntVector(Bloq):
 
         assert val == self.val, val
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return TComplexity()
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:

--- a/qualtran/bloqs/chemistry/trotter/inverse_sqrt.py
+++ b/qualtran/bloqs/chemistry/trotter/inverse_sqrt.py
@@ -169,7 +169,7 @@ class NewtonRaphsonApproxInverseSquareRoot(Bloq):
     def short_name(self) -> str:
         return 'y = x^{-1/2}'
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return (
             SquareRealNumber(self.poly_bitsize).t_complexity()
             + ScaleIntByReal(self.poly_bitsize, self.x_sq_bitsize).t_complexity()
@@ -228,7 +228,7 @@ class PolynmomialEvaluationInverseSquareRoot(Bloq):
     def short_name(self) -> str:
         return 'y ~ x^{-1/2}'
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         # There are 3 multiplications and subtractions, the shifts (-1, -3/2)
         # are not included in Fusion estimates as these can be achieved with
         # Clifford gates only.

--- a/qualtran/bloqs/chemistry/trotter/qvr.py
+++ b/qualtran/bloqs/chemistry/trotter/qvr.py
@@ -56,7 +56,7 @@ class QuantumVariableRotation(Bloq):
     def short_name(self) -> str:
         return 'e^{i*phi}'
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         # Upper bounding for the moment with just phi_bitsize * Rz rotation gates.
         return self.phi_bitsize * Rz(0.0).t_complexity()
 

--- a/qualtran/bloqs/factoring/mod_add.py
+++ b/qualtran/bloqs/factoring/mod_add.py
@@ -58,7 +58,7 @@ class CtrlScaleModAdd(Bloq):
         k = ssa.new_symbol('k')
         return {(CtrlModAddK(k=k, bitsize=self.bitsize, mod=self.mod), self.bitsize)}
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         ((bloq, n),) = self.bloq_counts().items()
         return n * bloq.t_complexity()
 
@@ -102,7 +102,7 @@ class CtrlModAddK(Bloq):
         k = ssa.new_symbol('k')
         return {(CtrlAddK(k=k, bitsize=self.bitsize), 5)}
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         ((bloq, n),) = self.bloq_counts().items()
         return n * bloq.t_complexity()
 
@@ -136,5 +136,5 @@ class CtrlAddK(Bloq):
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         return {(TGate(), 2 * self.bitsize)}
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return TComplexity(t=2 * self.bitsize)

--- a/qualtran/bloqs/for_testing/atom.py
+++ b/qualtran/bloqs/for_testing/atom.py
@@ -63,7 +63,7 @@ class TestAtom(Bloq):
             )
         )
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return TComplexity(100)
 
     def __repr__(self):

--- a/qualtran/bloqs/qft/qft_phase_gradient_test.py
+++ b/qualtran/bloqs/qft/qft_phase_gradient_test.py
@@ -52,8 +52,8 @@ def test_qft_with_phase_gradient(n: int, without_reverse: bool):
     qft_bloq = TestQFTWithPhaseGradient(n, not without_reverse)
     qft_cirq = cirq.QuantumFourierTransformGate(n, without_reverse=without_reverse)
 
-    assert np.allclose(cirq.unitary(qft_bloq), cirq.unitary(qft_cirq))
-    assert np.allclose(cirq.unitary(qft_bloq**-1), cirq.unitary(qft_cirq**-1))
+    np.testing.assert_allclose(cirq.unitary(qft_bloq), cirq.unitary(qft_cirq))
+    np.testing.assert_allclose(cirq.unitary(qft_bloq**-1), cirq.unitary(qft_cirq**-1))
 
     assert_valid_bloq_decomposition(qft_bloq)
 

--- a/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
@@ -102,7 +102,10 @@ def test_hamming_weight_phasing_via_phase_gradient_t_complexity(n: int, theta: f
     gate = HammingWeightPhasingViaPhaseGradient(n, theta, eps)
     naive_hwp_t_complexity = HammingWeightPhasing(n, theta, eps).t_complexity()
     assert (
-        gate.t_complexity().t
+        gate.t_complexity().t_incl_rotations()
         < naive_hwp_t_complexity.t
-        + naive_hwp_t_complexity.rotations * ZPowGate(eps=eps / n.bit_length()).t_complexity().t
+        + naive_hwp_t_complexity.rotations
+        * ZPowGate(eps=eps / n.bit_length())
+        .t_complexity()
+        .t_incl_rotations(eps=eps / n.bit_length())
     )

--- a/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
@@ -99,13 +99,10 @@ def test_hamming_weight_phasing_via_phase_gradient(n: int, theta: float, eps: fl
 
 @pytest.mark.parametrize('n, theta, eps', [(5_000, 1 / 100, 1e-1)])
 def test_hamming_weight_phasing_via_phase_gradient_t_complexity(n: int, theta: float, eps: float):
-    gate = HammingWeightPhasingViaPhaseGradient(n, theta, eps)
+    hwp_t_complexity = HammingWeightPhasingViaPhaseGradient(n, theta, eps).t_complexity()
     naive_hwp_t_complexity = HammingWeightPhasing(n, theta, eps).t_complexity()
-    assert (
-        gate.t_complexity().t_incl_rotations()
-        < naive_hwp_t_complexity.t
-        + naive_hwp_t_complexity.rotations
-        * ZPowGate(eps=eps / n.bit_length())
-        .t_complexity()
-        .t_incl_rotations(eps=eps / n.bit_length())
-    )
+
+    total_t = hwp_t_complexity.t_incl_rotations(eps=eps / n.bit_length())
+    naive_total_t = naive_hwp_t_complexity.t_incl_rotations(eps=eps / n.bit_length())
+
+    assert total_t < naive_total_t

--- a/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
@@ -19,7 +19,6 @@ import numpy as np
 import pytest
 
 from qualtran import GateWithRegisters, Signature
-from qualtran.bloqs.basic_gates import ZPowGate
 from qualtran.bloqs.rotations.hamming_weight_phasing import (
     HammingWeightPhasing,
     HammingWeightPhasingViaPhaseGradient,

--- a/qualtran/bloqs/rotations/phase_gradient_test.py
+++ b/qualtran/bloqs/rotations/phase_gradient_test.py
@@ -37,12 +37,13 @@ def test_phase_gradient_state(n: int):
     state_prep_cirq_circuit = cirq.Circuit(
         cirq.H.on_each(*q), cirq.PhaseGradientGate(num_qubits=n, exponent=-1).on(*q)
     )
-    assert np.allclose(cirq.unitary(gate), cirq.unitary(state_prep_cirq_circuit))
-    assert np.allclose(
+    np.testing.assert_allclose(cirq.unitary(gate), cirq.unitary(state_prep_cirq_circuit))
+    np.testing.assert_allclose(
         cirq.unitary(gate**-1), cirq.unitary(cirq.inverse(state_prep_cirq_circuit))
     )
-    assert gate.t_complexity().rotations == n - 2
-    assert gate.t_complexity().clifford == n + 2
+    assert gate.t_complexity().t == 0
+    assert gate.t_complexity().rotations == n
+    assert gate.t_complexity().clifford == n
 
 
 @pytest.mark.parametrize('n', [6, 7, 8])

--- a/qualtran/bloqs/rotations/phase_gradient_test.py
+++ b/qualtran/bloqs/rotations/phase_gradient_test.py
@@ -41,9 +41,9 @@ def test_phase_gradient_state(n: int):
     np.testing.assert_allclose(
         cirq.unitary(gate.adjoint()), cirq.unitary(cirq.inverse(state_prep_cirq_circuit))
     )
-    assert gate.t_complexity().t == 0
-    assert gate.t_complexity().rotations == n
-    assert gate.t_complexity().clifford == n
+    assert gate.t_complexity().t == 1  # one of the rotations is a T gate
+    assert gate.t_complexity().rotations == n - 3
+    assert gate.t_complexity().clifford == n + 2  # two of the rotations are clifford
 
 
 @pytest.mark.parametrize('n', [6, 7, 8])

--- a/qualtran/bloqs/sorting.py
+++ b/qualtran/bloqs/sorting.py
@@ -59,7 +59,7 @@ class Comparator(Bloq):
     def short_name(self) -> str:
         return "Cmprtr"
 
-    def t_complexity(self):
+    def _t_complexity_(self):
         # complexity is from less than on two n qubit numbers + controlled swap
         # Hard code for now until CSwap-Bloq is merged.
         # See: https://github.com/quantumlib/Qualtran/issues/219
@@ -112,7 +112,7 @@ class BitonicSort(Bloq):
     def short_name(self) -> str:
         return "BSort"
 
-    def t_complexity(self):
+    def _t_complexity_(self):
         # Need O(k * log^2(k)) comparisons.
         # TODO: This is Big-O complexity.
         # Should work out constant factors or

--- a/qualtran/bloqs/util_bloqs.py
+++ b/qualtran/bloqs/util_bloqs.py
@@ -61,7 +61,7 @@ class Split(Bloq):
     def as_cirq_op(self, qubit_manager, reg: 'CirqQuregT') -> Tuple[None, Dict[str, 'CirqQuregT']]:
         return None, {'reg': reg.reshape((self.n, 1))}
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return TComplexity()
 
     def on_classical_vals(self, reg: int) -> Dict[str, 'ClassicalValT']:
@@ -127,7 +127,7 @@ class Join(Bloq):
     def as_cirq_op(self, qubit_manager, reg: 'CirqQuregT') -> Tuple[None, Dict[str, 'CirqQuregT']]:
         return None, {'reg': reg.reshape(self.n)}
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return TComplexity()
 
     def add_my_tensors(
@@ -212,7 +212,7 @@ class Partition(Bloq):
         else:
             return None, {'x': np.concatenate([v.ravel() for _, v in cirq_quregs.items()])}
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return TComplexity()
 
     def add_my_tensors(
@@ -308,7 +308,7 @@ class Allocate(Bloq):
     def on_classical_vals(self) -> Dict[str, int]:
         return {'reg': 0}
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return TComplexity()
 
     def add_my_tensors(
@@ -350,7 +350,7 @@ class Free(Bloq):
             raise ValueError(f"Tried to free a non-zero register: {reg}.")
         return {}
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return TComplexity()
 
     def add_my_tensors(
@@ -385,5 +385,5 @@ class ArbitraryClifford(Bloq):
     def signature(self) -> Signature:
         return Signature([Register('x', QAny(bitsize=self.n))])
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return TComplexity(clifford=1)

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -60,7 +60,7 @@ def _get_cirq_quregs(signature: Signature, qm: InteropQubitManager):
     return ret
 
 
-class CirqGateAsBloqBase(GateWithRegisters):
+class CirqGateAsBloqBase(GateWithRegisters, metaclass=abc.ABCMeta):
     """A Bloq wrapper around a `cirq.Gate`"""
 
     @property

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -114,7 +114,7 @@ class CirqGateAsBloqBase(GateWithRegisters):
             outgoing=outgoing,
         )
 
-    def t_complexity(self) -> 'TComplexity':
+    def _t_complexity_(self) -> 'TComplexity':
         return t_complexity(self.cirq_gate)
 
     def as_cirq_op(

--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -17,7 +17,9 @@ from typing import Any, Callable, Hashable, Iterable, Literal, Optional, overloa
 import attrs
 import cachetools
 import cirq
+import numpy as np
 
+from qualtran import Bloq, CompositeBloq, DecomposeNotImplementedError, DecomposeTypeError
 from qualtran.cirq_interop.decompose_protocol import _decompose_once_considering_known_decomposition
 
 _T_GATESET = cirq.Gateset(cirq.T, cirq.T**-1, unroll_circuit_op=False)
@@ -30,6 +32,17 @@ class TComplexity:
     t: int = 0
     clifford: int = 0
     rotations: int = 0
+
+    def t_incl_rotations(self, eps: float = 1e-11) -> int:
+        """Return the total number of T gates after compiling rotations"""
+
+        # TODO Determine precise clifford count and/or ignore.
+        # This is an improvement over Ref. 2 from the docstring which provides
+        # a bound of 3 log(1/eps).
+        # See: https://github.com/quantumlib/Qualtran/issues/219
+        # See: https://github.com/quantumlib/Qualtran/issues/217
+        t_per_rot = int(np.ceil(1.149 * np.log2(1.0 / eps) + 9.2))
+        return self.t + t_per_rot * self.rotations
 
     def __add__(self, other: 'TComplexity') -> 'TComplexity':
         return TComplexity(
@@ -107,7 +120,21 @@ def _is_iterable(it: Any, fail_quietly: bool) -> Optional[TComplexity]:
     return t
 
 
-def _from_decomposition(stc: Any, fail_quietly: bool) -> Optional[TComplexity]:
+def _from_bloq_decomposition(stc: Any, fail_quietly: bool) -> Optional[TComplexity]:
+    # Decompose the object and recursively compute the complexity.
+    if not isinstance(stc, Bloq):
+        return None
+
+    if isinstance(stc, CompositeBloq):
+        return _is_iterable((binst.bloq for binst in stc.bloq_instances), fail_quietly=fail_quietly)
+
+    try:
+        return _from_bloq_decomposition(stc.decompose_bloq(), fail_quietly=fail_quietly)
+    except (DecomposeNotImplementedError, DecomposeTypeError):
+        return None
+
+
+def _from_cirq_decomposition(stc: Any, fail_quietly: bool) -> Optional[TComplexity]:
     # Decompose the object and recursively compute the complexity.
     decomposition = _decompose_once_considering_known_decomposition(stc)
     if decomposition is None:
@@ -149,9 +176,14 @@ def _t_complexity_from_strategies(
 
 @cachetools.cached(cachetools.LRUCache(128), key=_get_hash, info=True)
 def _t_complexity_for_gate_or_op(
-    gate_or_op: Union[cirq.Gate, cirq.Operation], fail_quietly: bool
+    gate_or_op: Union[cirq.Gate, cirq.Operation, Bloq], fail_quietly: bool
 ) -> Optional[TComplexity]:
-    strategies = [_has_t_complexity, _is_clifford_or_t, _from_decomposition]
+    strategies = [
+        _has_t_complexity,
+        _is_clifford_or_t,
+        _from_bloq_decomposition,
+        _from_cirq_decomposition,
+    ]
     return _t_complexity_from_strategies(gate_or_op, fail_quietly, strategies)
 
 
@@ -178,10 +210,16 @@ def t_complexity(stc: Any, fail_quietly: bool = False) -> Optional[TComplexity]:
     Raises:
         TypeError: if fail_quietly=False and the methods fails to compute TComplexity.
     """
-    if isinstance(stc, (cirq.Gate, cirq.Operation)) and isinstance(stc, Hashable):
+    if isinstance(stc, (cirq.Gate, cirq.Operation, Bloq)) and isinstance(stc, Hashable):
         ret = _t_complexity_for_gate_or_op(stc, fail_quietly)
     else:
-        strategies = [_has_t_complexity, _is_clifford_or_t, _from_decomposition, _is_iterable]
+        strategies = [
+            _has_t_complexity,
+            _is_clifford_or_t,
+            _from_bloq_decomposition,
+            _from_cirq_decomposition,
+            _is_iterable,
+        ]
         ret = _t_complexity_from_strategies(stc, fail_quietly, strategies)
 
     if ret is None and not fail_quietly:

--- a/qualtran/serialization/bloq_test.py
+++ b/qualtran/serialization/bloq_test.py
@@ -70,7 +70,7 @@ class TestCSwap(Bloq):
     def signature(self) -> 'Signature':
         return Signature.build(ctrl=1, x=self.bitsize, y=self.bitsize)
 
-    def t_complexity(self) -> TComplexity:
+    def _t_complexity_(self) -> TComplexity:
         return TComplexity(t=7 * self.bitsize, clifford=10 * self.bitsize)
 
 


### PR DESCRIPTION
 - switch to using cirq-style `t_complexity(x: Any)` strategies-based protocol for counting T gates
 - Remove `Bloq.t_complexity()` overridable method. For convenience `Bloq.t_complexity` just forwards to the above function
 - Add strategies for dealing with bloqs and compositebloqs
 - Move rotations to `rotations=1` and a new method on `TComplexity` if you want an estimate for everything in terms of T instead of T+rotations. 


Fixes #662 
Fixes #489