### PR TITLE
Support 0 and 1 controls in `MultiControlPauli` Bloq

### DIFF
--- a/qualtran/bloqs/multi_control_multi_target_pauli.py
+++ b/qualtran/bloqs/multi_control_multi_target_pauli.py
@@ -117,7 +117,10 @@ class MultiControlPauli(GateWithRegisters):
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray['cirq.Qid']
     ) -> cirq.OP_TREE:
-        controls, target = quregs['controls'], quregs['target']
+        controls, target = quregs.get('controls', ()), quregs['target']
+        if len(self.cvs) < 2:
+            yield self.target_gate.on(*target).controlled_by(*controls)
+            return
         qm = context.qubit_manager
         and_ancilla, and_target = np.array(qm.qalloc(len(self.cvs) - 2)), qm.qalloc(1)
         ctrl, junk = controls[:, np.newaxis], and_ancilla[:, np.newaxis]
@@ -139,6 +142,8 @@ class MultiControlPauli(GateWithRegisters):
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
     def _t_complexity_(self) -> TComplexity:
+        if len(self.cvs) < 2:
+            return TComplexity(clifford=1)
         and_gate = And(*self.cvs) if len(self.cvs) == 2 else MultiAnd(self.cvs)
         and_cost = t_complexity(and_gate)
         controlled_pauli_cost = t_complexity(self.target_gate.controlled(1))
@@ -202,7 +207,6 @@ class MultiControlX(Bloq):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', ctrls: SoquetT, x: SoquetT
     ) -> Dict[str, 'SoquetT']:
-
         # n = number of controls in the bloq.
         n = len(self.cvs)
 

--- a/qualtran/bloqs/multi_control_multi_target_pauli_test.py
+++ b/qualtran/bloqs/multi_control_multi_target_pauli_test.py
@@ -38,7 +38,7 @@ def test_multi_target_cnot(num_targets):
     assert_valid_bloq_decomposition(op.gate)
 
 
-@pytest.mark.parametrize("num_controls", [*range(7, 17)])
+@pytest.mark.parametrize("num_controls", [0, 1, *range(7, 17)])
 @pytest.mark.parametrize("pauli", [cirq.X, cirq.Y, cirq.Z])
 @pytest.mark.parametrize('cv', [0, 1])
 def test_t_complexity_mcp(num_controls: int, pauli: cirq.Pauli, cv: int):


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Qualtran/issues/677

cc [brempfer](https://github.com/brempfer)

Tests will start passing once https://github.com/quantumlib/Qualtran/pull/680 is merged because all controlled paulis are cliffords and the new `cirq.has_stabilizer_effect` implementation recognizes that. 