### PR TITLE
Update Cirq dependency to latest pre-release version

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -4,7 +4,7 @@ cachetools>=5.3
 networkx
 numpy
 sympy
-cirq-core==1.3.0.dev20231018023458
+cirq-core==1.4.0.dev20240216204049
 fxpmath
 
 # qualtran/testing.py

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -70,7 +70,7 @@ cffi==1.16.0
     #   cryptography
 charset-normalizer==3.3.2
     # via requests
-cirq-core==1.3.0.dev20231018023458
+cirq-core==1.4.0.dev20240216204049
     # via
     #   -r deps/runtime.txt
     #   openfermion
@@ -89,7 +89,7 @@ cotengra==0.5.6
     # via quimb
 coverage[toml]==7.4.1
     # via pytest-cov
-cryptography==42.0.2
+cryptography==42.0.3
     # via secretstorage
 cycler==0.12.1
     # via matplotlib
@@ -133,7 +133,7 @@ filelock==3.13.1
     #   virtualenv
 flynt==0.78
     # via -r deps/format.txt
-fonttools==4.48.1
+fonttools==4.49.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
@@ -406,7 +406,7 @@ pexpect==4.9.0
     # via ipython
 pillow==10.2.0
     # via matplotlib
-pip-tools==7.3.0
+pip-tools==7.4.0
     # via -r deps/pip-tools.txt
 pkginfo==1.9.6
     # via twine
@@ -422,7 +422,7 @@ prometheus-client==0.20.0
     # via jupyter-server
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==4.25.2
+protobuf==4.25.3
     # via
     #   -r deps/runtime.txt
     #   grpcio-tools
@@ -462,7 +462,9 @@ pyparsing==3.1.1
     #   matplotlib
     #   pydot
 pyproject-hooks==1.0.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 pyscf==2.5.0
     # via openfermion
 pytest==8.0.0

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -62,7 +62,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.3.0.dev20231018023458
+cirq-core==1.4.0.dev20240216204049
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -125,7 +125,7 @@ fastjsonschema==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.48.1
+fonttools==4.49.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -344,7 +344,7 @@ prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.2
+protobuf==4.25.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -39,7 +39,7 @@ cachetools==5.3.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-cirq-core==1.3.0.dev20231018023458
+cirq-core==1.4.0.dev20240216204049
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -95,7 +95,7 @@ flynt==0.78
     # via
     #   -c envs/dev.env.txt
     #   -r deps/format.txt
-fonttools==4.48.1
+fonttools==4.49.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -258,7 +258,7 @@ prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.2
+protobuf==4.25.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pip-tools.env.txt
+++ b/dev_tools/requirements/envs/pip-tools.env.txt
@@ -16,7 +16,7 @@ packaging==23.2
     # via
     #   -c envs/dev.env.txt
     #   build
-pip-tools==7.3.0
+pip-tools==7.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pip-tools.txt
@@ -24,6 +24,7 @@ pyproject-hooks==1.0.0
     # via
     #   -c envs/dev.env.txt
     #   build
+    #   pip-tools
 tomli==2.0.1
     # via
     #   -c envs/dev.env.txt

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -63,7 +63,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.3.0.dev20231018023458
+cirq-core==1.4.0.dev20240216204049
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -129,7 +129,7 @@ filelock==3.13.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
-fonttools==4.48.1
+fonttools==4.49.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -350,7 +350,7 @@ prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.2
+protobuf==4.25.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -43,7 +43,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.3.0.dev20231018023458
+cirq-core==1.4.0.dev20240216204049
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -114,7 +114,7 @@ filelock==3.13.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-fonttools==4.48.1
+fonttools==4.49.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -327,7 +327,7 @@ prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.2
+protobuf==4.25.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -31,7 +31,7 @@ cachetools==5.3.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-cirq-core==1.3.0.dev20231018023458
+cirq-core==1.4.0.dev20240216204049
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -79,7 +79,7 @@ fastjsonschema==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-fonttools==4.48.1
+fonttools==4.49.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -229,7 +229,7 @@ prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.2
+protobuf==4.25.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/qualtran/bloqs/unary_iteration.ipynb
+++ b/qualtran/bloqs/unary_iteration.ipynb
@@ -261,7 +261,7 @@
    "outputs": [],
    "source": [
     "import cirq\n",
-    "from cirq._compat import cached_property\n",
+    "from functools import cached_property\n",
     "from qualtran import Signature, GateWithRegisters\n",
     "from qualtran.cirq_interop.bit_tools import iter_bits\n",
     "\n",
@@ -473,7 +473,7 @@
    "source": [
     "from qualtran import QAny, Register, Register, BoundedQUInt\n",
     "from qualtran.bloqs.unary_iteration_bloq import UnaryIterationGate\n",
-    "from cirq._compat import cached_property\n",
+    "from functools import cached_property\n",
     "\n",
     "\n",
     "class ApplyXToLthQubit(UnaryIterationGate):\n",

--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -81,7 +81,7 @@ def _is_clifford_or_t(stc: Any, fail_quietly: bool) -> Optional[TComplexity]:
     if isinstance(stc, cirq.ClassicallyControlledOperation):
         stc = stc.without_classical_controls()
 
-    if cirq.has_stabilizer_effect(stc):
+    if cirq.num_qubits(stc) <= 2 and cirq.has_stabilizer_effect(stc):
         # Clifford operation.
         return TComplexity(clifford=1)
 


### PR DESCRIPTION
The latest feature is the new and improved `cirq.has_stabilizer_effect` protocol which works for arbitrary unitaries acting on <= 3 qubits (and gates / bloqs that decompose into such unitaries). 

The reason I need to modify the T-complexity protocol to include the check `cirq.num_qubits(stc) <= 2` is that right now, the T-complexity numbers count only 1/2q clifford gates as valid cliffords. As a result, t-compleixty tests start failing for gates like `MultiTargetCNOT` which can be an n-qubit gate but decomposes into a bunch of cliffords (sequence of CNOTs) so would have a lower T-complexity if we allow counting > 2q cliffords as a single clifford in our costs. 

We can revisit the strategy to count cliffords later. 

