### PR TITLE
Delegate `pretty_name` to `cirq.<gate>` only for explicitly wrapped cirq gates in `CirqGateAsBloq` class

### DIFF
--- a/qualtran/bloqs/basic_gates/rotation_test.py
+++ b/qualtran/bloqs/basic_gates/rotation_test.py
@@ -86,6 +86,15 @@ def test_as_cirq_op():
     )
 
 
+def test_pretty_name():
+    assert ZPowGate().pretty_name() == "ZPowGate"
+    assert XPowGate().pretty_name() == "XPowGate"
+    assert YPowGate().pretty_name() == "YPowGate"
+    assert _ry().pretty_name() == "Ry"
+    assert _rx().pretty_name() == "Rx"
+    assert _rz().pretty_name() == "Rz"
+
+
 def test_rx(bloq_autotester):
     bloq_autotester(_rx)
 

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -68,10 +68,6 @@ class CirqGateAsBloqBase(GateWithRegisters):
     def cirq_gate(self) -> cirq.Gate:
         ...
 
-    def pretty_name(self) -> str:
-        g = min(self.cirq_gate.__class__.__name__, str(self.cirq_gate), key=len)
-        return f'cirq.{g}'
-
     @cached_property
     def signature(self) -> 'Signature':
         if isinstance(self.cirq_gate, Bloq):
@@ -145,6 +141,10 @@ class CirqGateAsBloqBase(GateWithRegisters):
 @frozen
 class CirqGateAsBloq(CirqGateAsBloqBase):
     gate: cirq.Gate
+
+    def pretty_name(self) -> str:
+        g = min(self.cirq_gate.__class__.__name__, str(self.cirq_gate), key=len)
+        return f'cirq.{g}'
 
     @property
     def cirq_gate(self) -> cirq.Gate:


### PR DESCRIPTION
Moves the `pretty_name()` override from `CirqGateAsBloqBase` to `CirqGateAsBloq` so that all explicitly defined Bloqs in Qualtran that derive from `CirqGateAsBloqBase` base class have their pretty name equal to their class name in Qualtran. This helps us more easily track the places in call graph where we yield the `cirq.<gate>` style gates vs where we directly use bloqs defined in Qualtran (which is preferable) 