### PR TITLE
Support symbolic analysis in rotations and phase gradient bloqs

### DIFF
--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -116,13 +116,7 @@ class CZPowGate(CirqGateAsBloqBase):
         return cirq.CZPowGate(exponent=self.exponent, global_shift=self.global_shift)
 
     def _t_complexity_(self) -> 'TComplexity':
-        from qualtran.bloqs.and_bloq import And
-
-        return (
-            And().t_complexity()
-            + And().adjoint().t_complexity()
-            + ZPowGate(exponent=self.exponent, eps=self.eps).t_complexity()
-        )
+        return TComplexity(rotations=1)
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         from qualtran.bloqs.and_bloq import And

--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -18,7 +18,6 @@ from typing import Protocol, Set, TYPE_CHECKING
 
 import cirq
 import numpy as np
-import sympy
 from attrs import frozen
 
 from qualtran import bloq_example

--- a/qualtran/bloqs/rotations/hamming_weight_phasing.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing.py
@@ -145,7 +145,14 @@ class HammingWeightPhasingViaPhaseGradient(GateWithRegisters):
     @cached_property
     def phase_oracle(self) -> PhaseOraclePhaseGradient:
         return PhaseOraclePhaseGradient(
-            Register('out', QFxp(bitsize=self.bitsize.bit_length(), num_frac=0, signed=False)),
+            Register(
+                'out',
+                QFxp(
+                    bitsize=self.bitsize.bit_length(),
+                    num_frac=self.bitsize.bit_length(),
+                    signed=False,
+                ),
+            ),
             self.exponent / 2,
             self.eps,
         )
@@ -168,7 +175,10 @@ class HammingWeightPhasingViaPhaseGradient(GateWithRegisters):
         x, junk, out = bb.add(HammingWeightCompute(self.bitsize), x=x)
         out, phase_grad = bb.add(
             AddScaledValIntoPhaseReg(
-                self.phase_oracle.cost_dtype, self.b_grad, self.exponent / 2, self.gamma_bitsize
+                self.phase_oracle.cost_dtype.bitsize,
+                self.b_grad,
+                (self.exponent / 2) * (2 ** self.bitsize.bit_length()),
+                self.gamma_bitsize,
             ),
             x=out,
             phase_grad=phase_grad,

--- a/qualtran/bloqs/rotations/phase_gradient.py
+++ b/qualtran/bloqs/rotations/phase_gradient.py
@@ -22,7 +22,7 @@ from cirq._compat import cached_method
 from fxpmath import Fxp
 from numpy.typing import NDArray
 
-from qualtran import GateWithRegisters, QBit, QFxp, QUInt, Register, Side, Signature
+from qualtran import GateWithRegisters, QBit, QFxp, Register, Side, Signature
 from qualtran.bloqs.basic_gates import Hadamard, Toffoli
 from qualtran.bloqs.basic_gates.rotation import CZPowGate, ZPowGate
 from qualtran.bloqs.on_each import OnEach

--- a/qualtran/bloqs/rotations/phase_gradient_test.py
+++ b/qualtran/bloqs/rotations/phase_gradient_test.py
@@ -16,14 +16,13 @@ import numpy as np
 import pytest
 
 from qualtran import BloqBuilder
-from qualtran._infra.data_types import QFxp
 from qualtran.bloqs.rotations.phase_gradient import (
     AddIntoPhaseGrad,
     AddScaledValIntoPhaseReg,
     PhaseGradientState,
     PhaseGradientUnitary,
 )
-from qualtran.cirq_interop.bit_tools import float_as_fixed_width_int
+from qualtran.cirq_interop.testing import GateHelper
 from qualtran.testing import assert_valid_bloq_decomposition
 
 
@@ -94,24 +93,25 @@ def test_add_into_phase_grad():
     cirq.testing.assert_equivalent_computational_basis_map(basis_map, circuit)
 
 
-@pytest.mark.slow
-def test_add_scaled_val_into_phase_reg():
-    x_bit, phase_bit, gamma, gamma_bit = 4, 7, 0.123, 6
-    bloq = AddScaledValIntoPhaseReg(QFxp(x_bit, 0), phase_bit, gamma, gamma_bit)
-    gamma_fixed_width_float = float_as_fixed_width_int(gamma, gamma_bit + 1)[1] / (2**gamma_bit)
-    gamma_int = float_as_fixed_width_int(gamma_fixed_width_float, phase_bit + 1)[1]
-    basis_map = {}
-    for x in range(2**x_bit):
-        for phase_grad in range(2**phase_bit):
-            phase_grad_out = (phase_grad + x * gamma_int) % 2**phase_bit
-            # Test Bloq style classical simulation.
-            assert bloq.call_classically(x=x, phase_grad=phase_grad) == (x, phase_grad_out)
-            # Prepare basis states mapping for cirq-style simulation.
-            input_state = int(f'{x:0{x_bit}b}' + f'{phase_grad:0{phase_bit}b}', 2)
-            output_state = int(f'{x:0{x_bit}b}' + f'{phase_grad_out:0{phase_bit}b}', 2)
-            basis_map[input_state] = output_state
-    # Test cirq style simulation.
-    num_bits = x_bit + phase_bit
-    assert len(basis_map) == len(set(basis_map.values()))
-    circuit = cirq.Circuit(bloq.on(*cirq.LineQubit.range(num_bits)))
-    cirq.testing.assert_equivalent_computational_basis_map(basis_map, circuit)
+@pytest.mark.parametrize(
+    'bloq',
+    [
+        AddScaledValIntoPhaseReg(4, 7, 0.123, 6),
+        AddScaledValIntoPhaseReg(x_bitsize=2, phase_bitsize=8, gamma=1.3868682, gamma_bitsize=8),
+        AddScaledValIntoPhaseReg(x_bitsize=4, phase_bitsize=9, gamma=-19.0949456, gamma_bitsize=5),
+        AddScaledValIntoPhaseReg(x_bitsize=6, phase_bitsize=4, gamma=2.5, gamma_bitsize=2),
+    ],
+)
+def test_add_scaled_val_into_phase_reg(bloq):
+    cbloq = bloq.decompose_bloq()
+    for x in range(2**bloq.x_bitsize):
+        for phase_grad in range(2**bloq.phase_bitsize):
+            d = {'x': x, 'phase_grad': phase_grad}
+            c1 = bloq.on_classical_vals(**d)
+            c2 = cbloq.on_classical_vals(**d)
+            assert c1 == c2
+    bloq_unitary = cirq.unitary(bloq)
+    op = GateHelper(bloq).operation
+    circuit = cirq.Circuit(cirq.I.on_each(*op.qubits), cirq.decompose_once(op))
+    decomposed_unitary = circuit.unitary(qubit_order=op.qubits)
+    np.testing.assert_allclose(bloq_unitary, decomposed_unitary)

--- a/qualtran/bloqs/rotations/phase_gradient_test.py
+++ b/qualtran/bloqs/rotations/phase_gradient_test.py
@@ -24,7 +24,6 @@ from qualtran.bloqs.rotations.phase_gradient import (
 )
 from qualtran.cirq_interop.testing import GateHelper
 from qualtran.testing import assert_valid_bloq_decomposition
-from fxpmath import Fxp
 
 
 @pytest.mark.parametrize('n', [6, 7, 8])

--- a/qualtran/bloqs/rotations/phasing_via_cost_function.py
+++ b/qualtran/bloqs/rotations/phasing_via_cost_function.py
@@ -15,6 +15,7 @@ from functools import cached_property
 from typing import Dict, Set, TYPE_CHECKING, Union
 
 import attrs
+import numpy as np
 import sympy
 
 from qualtran import Bloq, BloqBuilder, GateWithRegisters, QFxp, Register, Signature
@@ -162,7 +163,8 @@ class PhaseOraclePhaseGradient(GateWithRegisters):
     @cached_property
     def b_grad(self) -> int:
         # Using Equation A7 from https://arxiv.org/abs/2007.07391
-        return utils.ceil(utils.log2((self.gamma_bitsize + 2) * sympy.pi / self.eps))
+        pi = sympy.pi if isinstance(self.eps, sympy.Basic) else np.pi
+        return utils.ceil(utils.log2((self.gamma_bitsize + 2) * pi / self.eps))
 
     @cached_property
     def gamma_bitsize(self) -> int:

--- a/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
+++ b/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
@@ -100,6 +100,7 @@ def test_hamming_weight_phasing_using_phase_via_cost_function_quick():
     np.testing.assert_allclose(expected_final_state, hw_final_state, atol=eps)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize('normalize_cost_function', [True, False])
 @pytest.mark.parametrize('use_phase_gradient', [True, False])
 @pytest.mark.parametrize('exponent, eps', [(1 / 10, 5e-4), (1.20345, 5e-4), (-1.1934341, 5e-4)])

--- a/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
+++ b/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
@@ -64,11 +64,11 @@ class TestHammingWeightPhasing(GateWithRegisters):
 
     def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
         if self.use_phase_gradient:
-            soqs['phase_grad'] = bb.add(PhaseGradientState(self.phase_oracle.b_grad))
+            soqs['phase_grad'] = bb.add(PhaseGradientState(self.phase_oracle.b_grad, eps=self.eps))
         soqs = bb.add_d(PhasingViaCostFunction(self.cost_eval_oracle, self.phase_oracle), **soqs)
         if self.use_phase_gradient:
             bb.add(
-                PhaseGradientState(self.phase_oracle.b_grad).adjoint(),
+                PhaseGradientState(self.phase_oracle.b_grad, eps=self.eps).adjoint(),
                 phase_grad=soqs.pop('phase_grad'),
             )
         return soqs
@@ -154,11 +154,11 @@ class TestSquarePhasing(GateWithRegisters):
 
     def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
         if self.use_phase_gradient:
-            soqs['phase_grad'] = bb.add(PhaseGradientState(self.phase_oracle.b_grad))
+            soqs['phase_grad'] = bb.add(PhaseGradientState(self.phase_oracle.b_grad, eps=self.eps))
         soqs = bb.add_d(PhasingViaCostFunction(self.cost_eval_oracle, self.phase_oracle), **soqs)
         if self.use_phase_gradient:
             bb.add(
-                PhaseGradientState(self.phase_oracle.b_grad).adjoint(),
+                PhaseGradientState(self.phase_oracle.b_grad, eps=self.eps).adjoint(),
                 phase_grad=soqs.pop('phase_grad'),
             )
         return soqs

--- a/qualtran/bloqs/utils.py
+++ b/qualtran/bloqs/utils.py
@@ -1,0 +1,39 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import numbers
+from typing import Union
+
+import numpy as np
+import sympy
+from cirq._doc import document
+
+SymbolicFloat = Union[float, sympy.Expr]
+document(SymbolicFloat, """A floating point value or a sympy expression.""")
+
+SymbolicInt = Union[int, sympy.Expr]
+document(SymbolicFloat, """A floating point value or a sympy expression.""")
+
+
+def log2(x: SymbolicFloat) -> SymbolicFloat:
+    from sympy.codegen.cfunctions import log2
+
+    if isinstance(x, numbers.Number):
+        return np.log2(x)
+    return log2(x)
+
+
+def ceil(x: SymbolicFloat) -> SymbolicInt:
+    if isinstance(x, numbers.Number):
+        return int(np.ceil(x))
+    return sympy.ceiling(x)

--- a/qualtran/bloqs/utils.py
+++ b/qualtran/bloqs/utils.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import numbers
 from typing import Union
 
 import numpy as np
@@ -28,12 +27,12 @@ document(SymbolicFloat, """A floating point value or a sympy expression.""")
 def log2(x: SymbolicFloat) -> SymbolicFloat:
     from sympy.codegen.cfunctions import log2
 
-    if isinstance(x, numbers.Number):
+    if not isinstance(x, sympy.Basic):
         return np.log2(x)
     return log2(x)
 
 
 def ceil(x: SymbolicFloat) -> SymbolicInt:
-    if isinstance(x, numbers.Number):
+    if not isinstance(x, sympy.Basic):
         return int(np.ceil(x))
     return sympy.ceiling(x)

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -276,15 +276,15 @@ def _ensure_in_reg_exists(
     qreg_to_qvar.clear()
 
     # b. Join all 1-bit registers, corresponding to individual qubits, that make up `in_reg`.
-    soqs_to_join = []
+    soqs_to_join: Dict[cirq.Qid, Soquet] = {}
     for qreg, soq in new_qreg_to_qvar.items():
         if len(in_reg_qubits) > 1 and qreg.qubits and qreg.qubits[0] in in_reg_qubits:
             assert len(qreg.qubits) == 1, "Individual qubits should have been split by now."
-            soqs_to_join.append(soq)
+            soqs_to_join[qreg.qubits[0]] = soq
         else:
             qreg_to_qvar[qreg] = soq
     if soqs_to_join:
-        qreg_to_qvar[in_reg] = bb.join(np.array(soqs_to_join))
+        qreg_to_qvar[in_reg] = bb.join(np.array([soqs_to_join[q] for q in in_reg.qubits]))
 
 
 def _gather_input_soqs(


### PR DESCRIPTION
Currently based on top of https://github.com/quantumlib/Qualtran/pull/685

Adds a `utils.py` for to pick between numpy vs sympy functions for utilities like `log` / `ceil` etc. 