### PR TITLE
Override `__str__` of `Adjoint` to delegate to subloq's `__str__` instead of `__repr__`

### DIFF
--- a/qualtran/_infra/adjoint.py
+++ b/qualtran/_infra/adjoint.py
@@ -170,6 +170,10 @@ class Adjoint(GateWithRegisters):
         """The subbloq's pretty_name with a dagger."""
         return self.subbloq.pretty_name() + '†'
 
+    def __str__(self) -> str:
+        """Delegate to subbloq's `__str__` method."""
+        return f'Adjoint(subbloq={str(self.subbloq)})'
+
     def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
         # Note: since we pass are passed a soquet which has the 'new' side, we flip it before
         # delegating and then flip back. Subbloqs only have to answer this protocol

--- a/qualtran/_infra/adjoint_test.py
+++ b/qualtran/_infra/adjoint_test.py
@@ -147,6 +147,7 @@ def test_names():
     adj_atom = Adjoint(atom)
     assert adj_atom.pretty_name() == "TestAtom†"
     assert adj_atom.short_name() == "Atom†"
+    assert str(adj_atom) == "Adjoint(subbloq=TestAtom())"
 
 
 def test_wire_symbol():


### PR DESCRIPTION
Minor fix to help improve sigma output from callgraphs for Bloqs which have a custom `__str__` specified but auto generated `__repr__` from frozen attrs. 