### PR TITLE
Automatically cross-check bloq counts

### DIFF
--- a/dev_tools/bloq-report-card.ipynb
+++ b/dev_tools/bloq-report-card.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qualtran_dev_tools.bloq_report_card import get_bloq_report_card, show_bloq_report_card\n",
+    "from qualtran_dev_tools.bloq_report_card import get_bloq_report_card, show_bloq_report_card, summarize_results\n",
     "report_card = get_bloq_report_card()"
    ]
   },
@@ -42,7 +42,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_bloq_report_card(report_card.query('package == \"qualtran.bloqs.basic_gates\"'))"
+    "show_bloq_report_card(report_card.query('package == \"basic_gates\"'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5ebb87f-8beb-467a-9e6c-ff228adaca2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summarize_results(report_card.query('package == \"basic_gates\"'))"
    ]
   },
   {
@@ -60,7 +70,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_bloq_report_card(report_card.query('package == \"qualtran.bloqs.arithmetic\"'))"
+    "show_bloq_report_card(report_card.query('package == \"arithmetic\"'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6daf297-f587-44a6-8bfb-907e421f024d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summarize_results(report_card.query('package == \"arithmetic\"'))"
    ]
   },
   {
@@ -78,7 +98,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_bloq_report_card(report_card.query('package.str.startswith(\"qualtran.bloqs.chemistry\")'))"
+    "show_bloq_report_card(report_card.query('package.str.startswith(\"chemistry\")'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e09d4aa9-a82a-4c80-b0aa-2548fd420eb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summarize_results(report_card.query('package.str.startswith(\"chemistry\")'))"
    ]
   },
   {
@@ -96,7 +126,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_bloq_report_card(report_card.query('package == \"qualtran.bloqs.factoring\"'))"
+    "show_bloq_report_card(report_card.query('package == \"factoring\"'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de77e155-b37d-469e-897f-12fd88dcc522",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summarize_results(report_card.query('package.str.startswith(\"factoring\")'))"
    ]
   },
   {
@@ -115,10 +155,28 @@
    "outputs": [],
    "source": [
     "show_bloq_report_card(report_card.query('package not in '\n",
-    "                                        '[\"qualtran.bloqs.basic_gates\",'\n",
-    "                                        '\"qualtran.bloqs.arithmetic\",'\n",
-    "                                        '\"qualtran.bloqs.factoring\"]')\n",
+    "                                        '[\"basic_gates\",'\n",
+    "                                        ' \"arithmetic\", '\n",
+    "                                        ' \"factoring\"]')\n",
     "                                 .query('not package.str.startswith(\"qualtran.bloqs.chemistry\")'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44c493af-695b-4887-b9cf-883e1446a4a4",
+   "metadata": {},
+   "source": [
+    "### Summary of All"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eceb5187-555e-4438-809a-ac2b1b0de12d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summarize_results(report_card)"
    ]
   }
  ],

--- a/dev_tools/qualtran_dev_tools/bloq_report_card.py
+++ b/dev_tools/qualtran_dev_tools/bloq_report_card.py
@@ -17,7 +17,12 @@ import pandas as pd
 import pandas.io.formats.style
 
 from qualtran import Bloq, BloqExample
-from qualtran.testing import BloqCheckResult, check_bloq_example_decompose, check_bloq_example_make
+from qualtran.testing import (
+    BloqCheckResult,
+    check_bloq_example_decompose,
+    check_bloq_example_make,
+    check_equivalent_bloq_example_counts,
+)
 
 from .bloq_finder import get_bloq_classes, get_bloq_examples
 
@@ -60,7 +65,7 @@ def bloq_classes_with_no_examples(
 
 
 IDCOLS = ['package', 'bloq_cls', 'name']
-CHECKCOLS = ['make', 'decomp']
+CHECKCOLS = ['make', 'decomp', 'counts']
 
 
 def record_for_class_with_no_examples(k: Type[Bloq]) -> Dict[str, Any]:
@@ -70,18 +75,18 @@ def record_for_class_with_no_examples(k: Type[Bloq]) -> Dict[str, Any]:
         'name': '-',
         'make': BloqCheckResult.MISSING,
         'decomp': BloqCheckResult.MISSING,
-        # 'counts': BloqCheckResult.MISSING,
+        'counts': BloqCheckResult.MISSING,
     }
 
 
-def records_for_bloq_example(be: BloqExample) -> Dict[str, Any]:
+def record_for_bloq_example(be: BloqExample) -> Dict[str, Any]:
     return {
         'bloq_cls': be.bloq_cls.__name__,
         'package': _get_package(be.bloq_cls),
         'name': be.name,
         'make': check_bloq_example_make(be)[0],
         'decomp': check_bloq_example_decompose(be)[0],
-        # 'counts': check_equivalent_bloq_example_counts(be)[0],
+        'counts': check_equivalent_bloq_example_counts(be)[0],
     }
 
 
@@ -92,6 +97,7 @@ def show_bloq_report_card(df: pd.DataFrame) -> pandas.io.formats.style.Styler:
 def get_bloq_report_card(
     bclasses: Optional[Iterable[Type[Bloq]]] = None,
     bexamples: Optional[Iterable[BloqExample]] = None,
+    package_prefix: str = 'qualtran.bloqs.',
 ) -> pd.DataFrame:
     if bclasses is None:
         bclasses = get_bloq_classes()
@@ -101,6 +107,19 @@ def get_bloq_report_card(
     records = []
     missing_bclasses = bloq_classes_with_no_examples(bclasses, bexamples)
     records.extend(record_for_class_with_no_examples(k) for k in missing_bclasses)
-    records.extend(records_for_bloq_example(be) for be in bexamples)
+    records.extend(record_for_bloq_example(be) for be in bexamples)
 
-    return pd.DataFrame(records).sort_values(by=IDCOLS).loc[:, IDCOLS + CHECKCOLS]
+    df = pd.DataFrame(records)
+    df['package'] = df['package'].str.removeprefix(package_prefix)
+    return df.sort_values(by=IDCOLS).loc[:, IDCOLS + CHECKCOLS].reindex()
+
+
+def summarize_results(report_card: pd.DataFrame) -> pd.DataFrame:
+    """Take a `report_card` data frame and return the number of times each status was noted."""
+    summary = (
+        pd.DataFrame([report_card[k].value_counts().rename(k) for k in CHECKCOLS])
+        .fillna(0)
+        .astype(int)
+    )
+    summary.columns = [v.name.lower() for v in summary.columns]
+    return summary

--- a/qualtran/bloqs/and_bloq.py
+++ b/qualtran/bloqs/and_bloq.py
@@ -53,6 +53,13 @@ from qualtran.cirq_interop import decompose_from_cirq_style_method
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, directional_text_box, WireSymbol
 from qualtran.resource_counting import big_O, BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting.generalizers import (
+    cirq_to_bloqs,
+    generalize_cvs,
+    generalize_rotation_angle,
+    ignore_alloc_free,
+    ignore_cliffords,
+)
 
 
 @frozen
@@ -208,7 +215,9 @@ class And(GateWithRegisters):
             return TComplexity(t=4 * 1, clifford=9 + 2 * pre_post_cliffords)
 
 
-@bloq_example
+@bloq_example(
+    generalizer=[cirq_to_bloqs, ignore_cliffords, ignore_alloc_free, generalize_rotation_angle]
+)
 def _and_bloq() -> And:
     and_bloq = And()
     return and_bloq
@@ -314,10 +323,13 @@ class MultiAnd(Bloq):
     def short_name(self) -> str:
         return 'And'
 
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+        return {(And(), len(self.cvs) - 1)}
 
-@bloq_example
+
+@bloq_example(generalizer=(ignore_cliffords, generalize_cvs))
 def _multi_and() -> MultiAnd:
-    multi_and = MultiAnd(cvs=(1,) * 4)
+    multi_and = MultiAnd(cvs=(1, 0, 1, 0, 1, 0))
     return multi_and
 
 

--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -36,6 +36,7 @@ from qualtran import (
 from qualtran.bloqs.util_bloqs import ArbitraryClifford
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, TextBox, WireSymbol
+from qualtran.resource_counting.generalizers import ignore_split_join
 
 from .t_gate import TGate
 
@@ -222,7 +223,7 @@ class Swap(Bloq):
         return self
 
 
-@bloq_example
+@bloq_example(generalizer=ignore_split_join)
 def _swap_small() -> Swap:
     swap_small = Swap(bitsize=4)
     return swap_small
@@ -318,14 +319,14 @@ def _cswap_symb() -> CSwap:
     return cswap_symb
 
 
-@bloq_example
+@bloq_example(generalizer=ignore_split_join)
 def _cswap_small() -> CSwap:
     # A small version on four bits.
     cswap_small = CSwap(bitsize=4)
     return cswap_small
 
 
-@bloq_example
+@bloq_example(generalizer=ignore_split_join)
 def _cswap_large() -> CSwap:
     # A large version that swaps 64-bit registers.
     cswap_large = CSwap(bitsize=64)

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -36,9 +36,7 @@ from qualtran import (
     Soquet,
     SoquetT,
 )
-from qualtran.bloqs.util_bloqs import ArbitraryClifford
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
-from qualtran.resource_counting import big_O
 from qualtran.simulation.classical_sim import ints_to_bits
 
 if TYPE_CHECKING:
@@ -353,9 +351,6 @@ class _IntVector(Bloq):
 
     def _t_complexity_(self) -> 'TComplexity':
         return TComplexity()
-
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(ArbitraryClifford(self.bitsize), big_O(1))}
 
     def short_name(self) -> str:
         return f'{self.val}'

--- a/qualtran/bloqs/chemistry/df/double_factorization.py
+++ b/qualtran/bloqs/chemistry/df/double_factorization.py
@@ -476,7 +476,6 @@ class DoubleFactorizationBlockEncoding(Bloq):
 
 @bloq_example
 def _df_one_body() -> DoubleFactorizationOneBody:
-    num_aux = 50
     num_bits_state_prep = 12
     num_bits_rot = 7
     num_spin_orb = 10

--- a/qualtran/bloqs/chemistry/sf/single_factorization.py
+++ b/qualtran/bloqs/chemistry/sf/single_factorization.py
@@ -241,7 +241,7 @@ class SingleFactorizationOneBody(Bloq):
             (iprep_dag, 1),
             (CSwap(n), 2),
             (SelectSingleFactorization(num_spin_orb=self.num_spin_orb), 1),
-            (ArbitraryClifford(1), 4),
+            (Hadamard(), 4),
         }
 
 

--- a/qualtran/bloqs/chemistry/thc/prepare.py
+++ b/qualtran/bloqs/chemistry/thc/prepare.py
@@ -49,6 +49,7 @@ from qualtran.bloqs.select_swap_qrom import SelectSwapQROM
 from qualtran.bloqs.swap_network import CSwap
 from qualtran.cirq_interop import CirqGateAsBloq
 from qualtran.linalg.lcu_util import preprocess_lcu_coefficients_for_reversible_sampling
+from qualtran.resource_counting.generalizers import ignore_cliffords, ignore_split_join
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
@@ -458,7 +459,7 @@ def _thc_uni() -> UniformSuperpositionTHC:
     return thc_uni
 
 
-@bloq_example
+@bloq_example(generalizer=[ignore_split_join, ignore_cliffords])
 def _thc_prep() -> PrepareTHC:
     num_spat = 4
     num_mu = 8

--- a/qualtran/bloqs/reflection.py
+++ b/qualtran/bloqs/reflection.py
@@ -24,6 +24,7 @@ from qualtran import Bloq, bloq_example, BloqBuilder, BloqDocSpec, QAny, Registe
 from qualtran.bloqs.basic_gates import Toffoli
 from qualtran.bloqs.multi_control_multi_target_pauli import MultiControlPauli
 from qualtran.drawing import Circle, WireSymbol
+from qualtran.resource_counting.generalizers import ignore_split_join
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
@@ -83,7 +84,7 @@ class Reflection(Bloq):
         return {(Toffoli(), nbits - 1)}
 
 
-@bloq_example
+@bloq_example(generalizer=ignore_split_join)
 def _reflection() -> Reflection:
     reflection = Reflection(bitsizes=(2, 3, 1), cvs=(0, 1, 1))
     return reflection

--- a/qualtran/bloqs/swap_network.py
+++ b/qualtran/bloqs/swap_network.py
@@ -40,6 +40,12 @@ from qualtran.bloqs.multi_control_multi_target_pauli import MultiTargetCNOT
 from qualtran.bloqs.unary_iteration_bloq import UnaryIterationGate
 from qualtran.bloqs.util_bloqs import ArbitraryClifford
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
+from qualtran.resource_counting.generalizers import (
+    cirq_to_bloqs,
+    generalize_rotation_angle,
+    ignore_cliffords,
+    ignore_split_join,
+)
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
@@ -144,14 +150,18 @@ def _approx_cswap_symb() -> CSwapApprox:
     return approx_cswap_symb
 
 
-@bloq_example
+@bloq_example(
+    generalizer=[cirq_to_bloqs, ignore_split_join, ignore_cliffords, generalize_rotation_angle]
+)
 def _approx_cswap_small() -> CSwapApprox:
     # A small version on four bits.
     approx_cswap_small = CSwapApprox(bitsize=4)
     return approx_cswap_small
 
 
-@bloq_example
+@bloq_example(
+    generalizer=[cirq_to_bloqs, ignore_split_join, ignore_cliffords, generalize_rotation_angle]
+)
 def _approx_cswap_large() -> CSwapApprox:
     # A large version that swaps 64-bit registers.
     approx_cswap_large = CSwapApprox(bitsize=64)
@@ -246,13 +256,13 @@ class SwapWithZero(GateWithRegisters):
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
 
-@bloq_example
+@bloq_example(generalizer=ignore_split_join)
 def _swz() -> SwapWithZero:
     swz = SwapWithZero(selection_bitsize=8, target_bitsize=32, n_target_registers=4)
     return swz
 
 
-@bloq_example
+@bloq_example(generalizer=ignore_split_join)
 def _swz_small() -> SwapWithZero:
     # A small version on four bits.
     swz_small = SwapWithZero(selection_bitsize=3, target_bitsize=2, n_target_registers=2)

--- a/qualtran/resource_counting/bloq_counts.ipynb
+++ b/qualtran/resource_counting/bloq_counts.ipynb
@@ -246,6 +246,31 @@
     "show_call_graph(graph)\n",
     "show_counts_sigma(sigma)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "250474d1",
+   "metadata": {},
+   "source": [
+    "## Testing\n",
+    "\n",
+    "`qlt_testing.check_equivalent_bloq_example_counts` is used to automatically compare manually-annotated counts against those derived from the bloq's decomposition. If they match, the check returns `PASS`. If there is only one source of bloq counts, the check returns `UNVERIFIED`. If there are no bloq counts (either via annotation or decomposition), the check returns `MISSING`. If the bloq counts do not match, the check returns `FAIL` with more information about the mismatch. \n",
+    "\n",
+    "`BloqExample`s have an optional `generalizer` attribute that this check will use during the comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c88072d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qualtran.testing as qlt_testing\n",
+    "from qualtran.bloqs.and_bloq import _multi_and as MULTI_AND_BLOQ_EXAMPLE\n",
+    "\n",
+    "qlt_testing.check_equivalent_bloq_example_counts(MULTI_AND_BLOQ_EXAMPLE)"
+   ]
   }
  ],
  "metadata": {
@@ -264,7 +289,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/qualtran/resource_counting/generalizers.py
+++ b/qualtran/resource_counting/generalizers.py
@@ -50,10 +50,14 @@ def ignore_alloc_free(b: Bloq) -> Optional[Bloq]:
 
 def generalize_rotation_angle(b: Bloq) -> Optional[Bloq]:
     """A generalizer that replaces rotation angles with a shared symbol."""
-    from qualtran.bloqs.basic_gates import Rx, Ry, Rz
+    from qualtran.bloqs.basic_gates import Rx, Ry, Rz, TGate
 
     if isinstance(b, (Rx, Ry, Rz)):
         return attrs.evolve(b, angle=PHI)
+
+    if isinstance(b, TGate):
+        # ignore `is_adjoint`.
+        return TGate()
 
     return b
 
@@ -72,11 +76,21 @@ def generalize_cvs(b: Bloq) -> Optional[Bloq]:
 
 def ignore_cliffords(b: Bloq) -> Optional[Bloq]:
     """A generalizer that ignores known clifford bloqs."""
-    from qualtran.bloqs.basic_gates import CNOT, Hadamard, TwoBitSwap, XGate, ZGate
-    from qualtran.bloqs.util_bloqs import ArbitraryClifford
+    import cirq
 
-    if isinstance(b, (TwoBitSwap, Hadamard, XGate, ZGate, ArbitraryClifford, CNOT)):
+    from qualtran.bloqs.basic_gates import CNOT, Hadamard, TwoBitSwap, XGate, ZGate
+    from qualtran.bloqs.multi_control_multi_target_pauli import MultiTargetCNOT
+    from qualtran.bloqs.util_bloqs import ArbitraryClifford
+    from qualtran.cirq_interop import CirqGateAsBloq
+
+    if isinstance(
+        b, (TwoBitSwap, Hadamard, XGate, ZGate, ArbitraryClifford, CNOT, MultiTargetCNOT)
+    ):
         return None
+
+    if isinstance(b, CirqGateAsBloq):
+        if b.gate == cirq.S or b.gate == cirq.S**-1:
+            return None
 
     return b
 
@@ -94,6 +108,8 @@ def cirq_to_bloqs(b: Bloq) -> Optional[Bloq]:
     gate = b.gate
     if gate == cirq.T:
         return TGate()
+    if gate == cirq.T**-1:
+        return TGate().adjoint()
     if gate == cirq.H:
         return Hadamard()
     if gate == cirq.CNOT:

--- a/qualtran/testing.py
+++ b/qualtran/testing.py
@@ -201,6 +201,23 @@ def assert_valid_bloq_decomposition(bloq: Bloq) -> CompositeBloq:
     return cbloq
 
 
+def assert_wire_symbols_match_expected(bloq: Bloq, expected_ws: List[str]):
+    """Assert a bloq's wire symbols match the expected ones.
+
+    Args:
+        bloq: the bloq whose wire symbols we want to check.
+        expected_ws: A list of the expected wire symbols.
+    """
+    ws = []
+    regs = bloq.signature
+    for i, r in enumerate(regs):
+        # note this will only work if shape = ().
+        # See: https://github.com/quantumlib/Qualtran/issues/608
+        ws.append(bloq.wire_symbol(Soquet(i, r)).text)
+
+    assert ws == expected_ws
+
+
 def execute_notebook(name: str):
     """Execute a jupyter notebook in the caller's directory.
 
@@ -258,7 +275,7 @@ class BloqCheckException(AssertionError):
     """
 
     def __init__(self, check_result: BloqCheckResult, msg: str):
-        super().__init__(check_result, msg)
+        super().__init__(msg)
         self._check_result = check_result
         self._msg = msg
 
@@ -373,18 +390,91 @@ def check_bloq_example_decompose(bloq_ex: BloqExample) -> Tuple[BloqCheckResult,
     return BloqCheckResult.PASS, ''
 
 
-def assert_wire_symbols_match_expected(bloq: Bloq, expected_ws: List[str]):
-    """Assert a bloq's wire symbols match the expected ones.
+def assert_equivalent_bloq_example_counts(bloq_ex: BloqExample) -> None:
+    """Assert that the BloqExample has consistent bloq counts.
 
-    Args:
-        bloq: the bloq whose wire symbols we want to check.
-        expected_ws: A list of the expected wire symbols.
+    Bloq counts can be annotated directly via the `Bloq.build_call_graph` override.
+    They can be inferred from a bloq's decomposition. This function asserts that both
+    data sources are present and that they produce the same values.
+
+    If both sources are present, and they disagree, that results in a `FAIL`. If only one source
+    is present, an `UNVERIFIED` exception is raised. If neither are present, a `MISSING` result
+    is raised.
+
+    Returns:
+        None if the assertions are satisfied.
+
+    Raises:
+        BloqCheckException if any assertions are violated or unverifiable due to partial
+        or missing information.
     """
-    ws = []
-    regs = bloq.signature
-    for i, r in enumerate(regs):
-        # note this will only work if shape = ().
-        # See: https://github.com/quantumlib/Qualtran/issues/608
-        ws.append(bloq.wire_symbol(Soquet(i, r)).text)
+    bloq = bloq_ex.make()
+    generalizer = bloq_ex.generalizer
 
-    assert ws == expected_ws
+    has_manual_counts: bool
+    has_decomp_counts: bool
+    manual_counts = None
+    decomp_counts = None
+
+    if bloq.build_call_graph.__qualname__.startswith('Bloq.'):
+        has_manual_counts = False
+    else:
+        has_manual_counts = True
+        # TODO: don't let the author sneak in decomposition??
+        manual_counts = bloq.bloq_counts(generalizer=generalizer)  # TODO: get exactly level 1
+
+    try:
+        cbloq = bloq.decompose_bloq()
+        decomp_counts = cbloq.bloq_counts(generalizer=generalizer)
+        has_decomp_counts = True
+    except (DecomposeTypeError, DecomposeNotImplementedError) as e:
+        has_decomp_counts = False
+
+    if (not has_decomp_counts) and (not has_manual_counts):
+        raise BloqCheckException.missing('No block counts')
+
+    if has_manual_counts and has_decomp_counts:
+        if manual_counts == decomp_counts:
+            return
+        else:
+            msg = [f'{bloq_ex.name} does not have equivalent bloq counts.']
+            only_manual = set(manual_counts.keys()) - set(decomp_counts.keys())
+            if only_manual:
+                msg.append(f"Bloq's missing from decomposition: {only_manual}")
+            only_decomp = set(decomp_counts.keys()) - set(manual_counts.keys())
+            if only_decomp:
+                msg.append(f"Bloq's missing from annotation: {only_decomp}")
+            msg.append(f'Annotation: {manual_counts}')
+            msg.append(f'Decomp:     {decomp_counts}')
+            raise BloqCheckException.fail('\n'.join(msg))
+
+    assert has_manual_counts or has_decomp_counts
+    if has_manual_counts:
+        raise BloqCheckException.unverified(f'{bloq_ex.name} only has counts from build_call_graph')
+    if has_decomp_counts:
+        raise BloqCheckException.unverified(f'{bloq_ex.name} only has counts from decomposition.')
+
+
+def check_equivalent_bloq_example_counts(bloq_ex: BloqExample) -> Tuple[BloqCheckResult, str]:
+    """Check that the BloqExample has consistent bloq counts.
+
+    Bloq counts can be annotated directly via the `Bloq.build_call_graph` override.
+    They can be inferred from a bloq's decomposition. This function checks that both
+    data sources are present and that they produce the same values.
+
+    If both sources are present, and they disagree, that results in a `FAIL`. If only one source
+    is present, an `UNVERIFIED` result is returned. If neither are present, a `MISSING` result
+    is returned.
+
+    Returns:
+        result: The `BloqCheckResult`.
+        msg: A message providing details from the check.
+    """
+    try:
+        assert_equivalent_bloq_example_counts(bloq_ex)
+    except BloqCheckException as bce:
+        return bce.check_result, bce.msg
+    except Exception as e:
+        return BloqCheckResult.ERROR, f'{bloq_ex.name}: {e}'
+
+    return BloqCheckResult.PASS, ''


### PR DESCRIPTION
#### `check_equivalent_bloq_example_counts`

Check that the BloqExample has consistent bloq counts.

Bloq counts can be annotated directly via the `Bloq.build_call_graph` override.
They can be inferred from a bloq's decomposition. This function checks that both
data sources are present and that they produce the same values.

If both sources are present, and they disagree, that results in a `FAIL`. If only one source
is present, an `UNVERIFIED` result is returned. If neither are present, a `MISSING` result
is returned.

----

This adds a new check and wires it up through the `bloq_autotester` fixture. I've marked any failures as `pytest.xfail` as part of this original PR so we can fix or exempt the more complicated ones in their own PRs. You can always check all bloq examples (whether or not the developer has remembered to add a unit test using the test fixture) via the bloq-report-card notebook which now reports statistics.

There's 101 bloq examples. For the new "counts" check: 19 pass, 56 are unverified, 11 fail. The failures are generally of the flavor of: the `build_call_graph` reports callees at a low level like T counts but the decomposition uses higher-level primitives. 

I made sure the pytest error messages are helpful. We can also `xfail` specific tests by doing:

```python
def test_whatever(bloq_autotester):
  if bloq_autotester.check_name == 'counts':
    pytest.xfail('reason')
  bloq_autotester(_whatever)
```