### PR TITLE
QROM - classical simulation and docs

### DIFF
--- a/dev_tools/autogenerate-bloqs-notebooks-v2.py
+++ b/dev_tools/autogenerate-bloqs-notebooks-v2.py
@@ -68,6 +68,7 @@ import qualtran.bloqs.chemistry.trotter.grid_ham.qvr
 import qualtran.bloqs.factoring.mod_exp
 import qualtran.bloqs.multi_control_multi_target_pauli
 import qualtran.bloqs.prepare_uniform_superposition
+import qualtran.bloqs.qrom
 import qualtran.bloqs.reflection
 import qualtran.bloqs.rotations.phasing_via_cost_function
 import qualtran.bloqs.rotations.quantum_variable_rotation
@@ -120,6 +121,9 @@ NOTEBOOK_SPECS: List[NotebookSpecV2] = [
         module=qualtran.bloqs.apply_gate_to_lth_target,
         bloq_specs=[qualtran.bloqs.apply_gate_to_lth_target._APPLYLTH_DOC],
         directory=f'{SOURCE_DIR}/bloqs/',
+    ),
+    NotebookSpecV2(
+        title='QROM', module=qualtran.bloqs.qrom, bloq_specs=[qualtran.bloqs.qrom._QROM_DOC]
     ),
     # --------------------------------------------------------------------------
     # -----   Chemistry   ------------------------------------------------------

--- a/dev_tools/qualtran_dev_tools/cirq_ft_jupyter_autogen_factories.py
+++ b/dev_tools/qualtran_dev_tools/cirq_ft_jupyter_autogen_factories.py
@@ -37,12 +37,6 @@ import qualtran.cirq_interop.testing as cq_testing
 # a notebook template.
 
 
-def _make_QROM():
-    from qualtran.bloqs.qrom import QROM
-
-    return QROM([np.array([1, 2, 3, 4, 5])], selection_bitsizes=(3,), target_bitsizes=(3,))
-
-
 def _make_MultiTargetCSwap():
     from qualtran.bloqs.basic_gates import CSwap
 

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -350,6 +350,7 @@ class _IntVector(Bloq):
             return {'val': self.val}
 
         assert val == self.val, val
+        return {}
 
     def _t_complexity_(self) -> 'TComplexity':
         return TComplexity()

--- a/qualtran/bloqs/qrom.ipynb
+++ b/qualtran/bloqs/qrom.ipynb
@@ -1,35 +1,15 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "773cf7e2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#  Copyright 2023 Google LLC\n",
-    "#\n",
-    "#  Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "#  you may not use this file except in compliance with the License.\n",
-    "#  You may obtain a copy of the License at\n",
-    "#\n",
-    "#      https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "#  Unless required by applicable law or agreed to in writing, software\n",
-    "#  distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "#  See the License for the specific language governing permissions and\n",
-    "#  limitations under the License."
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "ffe91e97",
    "metadata": {
     "cq.autogen": "title_cell"
    },
    "source": [
-    "# QROM"
+    "# QROM\n",
+    "\n",
+    "Quantum read-only memory."
    ]
   },
   {
@@ -41,55 +21,159 @@
    },
    "outputs": [],
    "source": [
-    "import cirq\n",
+    "from qualtran import Bloq, CompositeBloq, BloqBuilder, Signature, Register\n",
+    "from qualtran.drawing import show_bloq, show_call_graph, show_counts_sigma\n",
+    "from typing import *\n",
     "import numpy as np\n",
-    "import qualtran.cirq_interop.testing as cq_testing\n",
-    "from qualtran.cirq_interop.jupyter_tools import display_gate_and_compilation\n",
-    "from typing import *"
+    "import sympy\n",
+    "import cirq"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5d6a18ce",
+   "id": "4ea4344b",
    "metadata": {
-    "cq.autogen": "_make_QROM.md"
+    "cq.autogen": "QROM.bloq_doc.md"
    },
    "source": [
     "## `QROM`\n",
-    "Gate to load data[l] in the target register when the selection stores an index l.\n",
+    "Bloq to load `data[l]` in the target register when the selection stores an index `l`.\n",
     "\n",
-    "In the case of multi-dimensional data[p,q,r,...] we use of multple name\n",
-    "selection signature [p, q, r, ...] to index and load the data.\n",
+    "In the case of multidimensional `data[p,q,r,...]` we use multiple named\n",
+    "selection registers to index and load the data named selection0, selection1, ...\n",
+    "\n",
+    "When the input data elements contain consecutive entries of identical data elements to\n",
+    "load, the QROM also implements the \"variable-spaced\" QROM optimization described in Ref [2].\n",
     "\n",
     "#### Parameters\n",
     " - `data`: List of numpy ndarrays specifying the data to load. If the length of this list is greater than one then we use the same selection indices to load each dataset (for example, to load alt and keep data for state preparation). Each data set is required to have the same shape and to be of integer type.\n",
     " - `selection_bitsizes`: The number of bits used to represent each selection register corresponding to the size of each dimension of the array. Should be the same length as the shape of each of the datasets.\n",
     " - `target_bitsizes`: The number of bits used to represent the data signature. This can be deduced from the maximum element of each of the datasets. Should be of length len(data), i.e. the number of datasets.\n",
-    " - `num_controls`: The number of control signature.\n"
+    " - `num_controls`: The number of control signature. \n",
+    "\n",
+    "#### References\n",
+    "[Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662).\n",
+    "    Babbush et. al. (2018). Figure 1.\n",
+    "\n",
+    "[Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](https://arxiv.org/abs/2007.07391).\n",
+    "    Babbush et. al. (2020). Figure 3.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a91a2db",
+   "id": "af317b30",
    "metadata": {
-    "cq.autogen": "_make_QROM.py"
+    "cq.autogen": "QROM.bloq_doc.py"
    },
    "outputs": [],
    "source": [
-    "from qualtran.bloqs.qrom import QROM\n",
-    "\n",
-    "g = cq_testing.GateHelper(\n",
-    "    QROM([np.array([1, 2, 3, 4, 5])], selection_bitsizes=(3,), target_bitsizes=(3,))\n",
-    ")\n",
-    "\n",
-    "display_gate_and_compilation(g)"
+    "from qualtran.bloqs.qrom import QROM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5d3a19d",
+   "metadata": {
+    "cq.autogen": "QROM.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f02d641",
+   "metadata": {
+    "cq.autogen": "QROM.qrom_small"
+   },
+   "outputs": [],
+   "source": [
+    "data = np.arange(5)\n",
+    "qrom_small = QROM([data], selection_bitsizes=(3,), target_bitsizes=(3,))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2f8b350",
+   "metadata": {
+    "cq.autogen": "QROM.qrom_multi_data"
+   },
+   "outputs": [],
+   "source": [
+    "data1 = np.arange(5)\n",
+    "data2 = np.arange(5) + 1\n",
+    "qrom_multi_data = QROM([data1, data2], selection_bitsizes=(3,), target_bitsizes=(3, 4))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "036cf220",
+   "metadata": {
+    "cq.autogen": "QROM.qrom_multi_dim"
+   },
+   "outputs": [],
+   "source": [
+    "data1 = np.arange(9).reshape((3,3))\n",
+    "data2 = (np.arange(9) + 1).reshape((3,3))\n",
+    "qrom_multi_dim = QROM([data1, data2], selection_bitsizes=(2,2), target_bitsizes=(8, 8))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b92d1c8e",
+   "metadata": {
+    "cq.autogen": "QROM.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9681cfed",
+   "metadata": {
+    "cq.autogen": "QROM.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([qrom_small, qrom_multi_data, qrom_multi_dim],\n",
+    "           ['`qrom_small`', '`qrom_multi_data`', '`qrom_multi_dim`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8eb02cb9",
+   "metadata": {
+    "cq.autogen": "QROM.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f29f104",
+   "metadata": {
+    "cq.autogen": "QROM.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "qrom_small_g, qrom_small_sigma = qrom_small.call_graph()\n",
+    "show_call_graph(qrom_small_g)\n",
+    "show_counts_sigma(qrom_small_sigma)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -103,7 +187,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/qualtran/bloqs/qrom.py
+++ b/qualtran/bloqs/qrom.py
@@ -12,34 +12,36 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+"""Quantum read-only memory."""
+
 from functools import cached_property
-from typing import Callable, Sequence, Set, Tuple
+from typing import Callable, Dict, Sequence, Set, Tuple
 
 import attrs
 import cirq
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from qualtran import BoundedQUInt, QAny, Register, Soquet
+from qualtran import bloq_example, BloqDocSpec, BoundedQUInt, QAny, Register, Soquet
 from qualtran._infra.gate_with_registers import merge_qubits, total_bits
 from qualtran.bloqs.and_bloq import And, MultiAnd
 from qualtran.bloqs.basic_gates import CNOT
 from qualtran.bloqs.unary_iteration_bloq import UnaryIterationGate
 from qualtran.drawing import Circle, TextBox, WireSymbol
 from qualtran.resource_counting import BloqCountT
+from qualtran.simulation.classical_sim import ClassicalValT
 
 
 @cirq.value_equality()
 @attrs.frozen
 class QROM(UnaryIterationGate):
-    """Bloq to load data[l] in the target register when the selection stores an index l.
+    """Bloq to load `data[l]` in the target register when the selection stores an index `l`.
 
-    In the case of multi-dimensional data[p,q,r,...] we use multiple named
-    selection signature [p, q, r, ...] to index and load the data. Here `p, q, r, ...`
-    correspond to signature named `selection0`, `selection1`, `selection2`, ... etc.
+    In the case of multidimensional `data[p,q,r,...]` we use multiple named
+    selection registers to index and load the data named selection0, selection1, ...
 
     When the input data elements contain consecutive entries of identical data elements to
-    load, the QROM also implements the "variable-spaced" QROM optimization described in Ref[2].
+    load, the QROM also implements the "variable-spaced" QROM optimization described in Ref [2].
 
     Args:
         data: List of numpy ndarrays specifying the data to load. If the length
@@ -56,12 +58,10 @@ class QROM(UnaryIterationGate):
         num_controls: The number of control signature.
 
     References:
-        [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity]
-        (https://arxiv.org/abs/1805.03662).
+        [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662).
             Babbush et. al. (2018). Figure 1.
 
-        [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization]
-        (https://arxiv.org/abs/2007.07391).
+        [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](https://arxiv.org/abs/2007.07391).
             Babbush et. al. (2020). Figure 3.
     """
 
@@ -103,16 +103,14 @@ class QROM(UnaryIterationGate):
 
     @cached_property
     def selection_registers(self) -> Tuple[Register, ...]:
-        ret = tuple(
-            Register(f'selection{i}', BoundedQUInt(sb, l))
-            for i, (l, sb) in enumerate(zip(self.data[0].shape, self.selection_bitsizes))
+        types = [
+            BoundedQUInt(sb, l)
+            for l, sb in zip(self.data[0].shape, self.selection_bitsizes)
             if sb > 0
-        )
-        if len(self.data[0].shape) == 1 and len(ret) == 1:
-            ret = (
-                Register('selection', BoundedQUInt(ret[0].bitsize, ret[0].dtype.iteration_length)),
-            )
-        return ret
+        ]
+        if len(types) == 1:
+            return (Register('selection', types[0]),)
+        return tuple(Register(f'selection{i}', qdtype) for i, qdtype in enumerate(types))
 
     @cached_property
     def target_registers(self) -> Tuple[Register, ...]:
@@ -141,7 +139,7 @@ class QROM(UnaryIterationGate):
         if self.num_controls == 0:
             yield self._load_nth_data(zero_indx, cirq.X, **target_regs)
         elif self.num_controls == 1:
-            yield self._load_nth_data(zero_indx, lambda q: cirq.CNOT(controls[0], q), **target_regs)
+            yield self._load_nth_data(zero_indx, lambda q: CNOT().on(controls[0], q), **target_regs)
         else:
             ctrl = np.array(controls)[:, np.newaxis]
             junk = np.array(context.qubit_manager.qalloc(len(controls) - 2))[:, np.newaxis]
@@ -153,7 +151,7 @@ class QROM(UnaryIterationGate):
                     ctrl=ctrl, junk=junk, target=and_target
                 )
             yield multi_controlled_and
-            yield self._load_nth_data(zero_indx, lambda q: cirq.CNOT(and_target, q), **target_regs)
+            yield self._load_nth_data(zero_indx, lambda q: CNOT().on(and_target, q), **target_regs)
             yield cirq.inverse(multi_controlled_and)
             context.qubit_manager.qfree(list(junk.flatten()) + [and_target])
 
@@ -171,7 +169,30 @@ class QROM(UnaryIterationGate):
     ) -> cirq.OP_TREE:
         selection_idx = tuple(kwargs[reg.name] for reg in self.selection_registers)
         target_regs = {reg.name: kwargs[reg.name] for reg in self.target_registers}
-        yield self._load_nth_data(selection_idx, lambda q: cirq.CNOT(control, q), **target_regs)
+        yield self._load_nth_data(selection_idx, lambda q: CNOT().on(control, q), **target_regs)
+
+    def on_classical_vals(self, **vals: 'ClassicalValT') -> Dict[str, 'ClassicalValT']:
+        if self.num_controls > 0:
+            control = vals['control']
+            if control != 2**self.num_controls - 1:
+                return vals
+            controls = {'control': control}
+        else:
+            controls = {}
+
+        n_dim = len(self.selection_bitsizes)
+        if n_dim == 1:
+            idx = vals['selection']
+            selections = {'selection': idx}
+        else:
+            # Multidimensional
+            idx = tuple(vals[f'selection{i}'] for i in range(n_dim))
+            selections = {f'selection{i}': idx[i] for i in range(n_dim)}
+
+        # Retrieve the data; bitwise add them in to the input target values
+        targets = {f'target{d_i}_': d[idx] for d_i, d in enumerate(self.data)}
+        targets = {k: v ^ vals[k] for k, v in targets.items()}
+        return controls | selections | targets
 
     def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
         wire_symbols = ["@"] * self.num_controls
@@ -209,3 +230,33 @@ class QROM(UnaryIterationGate):
     def nth_operation_callgraph(self, **kwargs: int) -> Set['BloqCountT']:
         selection_idx = tuple(kwargs[reg.name] for reg in self.selection_registers)
         return {(CNOT(), sum(int(d[selection_idx]).bit_count() for d in self.data))}
+
+
+@bloq_example
+def _qrom_small() -> QROM:
+    data = np.arange(5)
+    qrom_small = QROM([data], selection_bitsizes=(3,), target_bitsizes=(3,))
+    return qrom_small
+
+
+@bloq_example
+def _qrom_multi_data() -> QROM:
+    data1 = np.arange(5)
+    data2 = np.arange(5) + 1
+    qrom_multi_data = QROM([data1, data2], selection_bitsizes=(3,), target_bitsizes=(3, 4))
+    return qrom_multi_data
+
+
+@bloq_example
+def _qrom_multi_dim() -> QROM:
+    data1 = np.arange(9).reshape((3, 3))
+    data2 = (np.arange(9) + 1).reshape((3, 3))
+    qrom_multi_dim = QROM([data1, data2], selection_bitsizes=(2, 2), target_bitsizes=(8, 8))
+    return qrom_multi_dim
+
+
+_QROM_DOC = BloqDocSpec(
+    bloq_cls=QROM,
+    import_line='from qualtran.bloqs.qrom import QROM',
+    examples=[_qrom_small, _qrom_multi_data, _qrom_multi_dim],
+)

--- a/qualtran/bloqs/qrom_test.py
+++ b/qualtran/bloqs/qrom_test.py
@@ -20,7 +20,7 @@ import pytest
 
 from qualtran._infra.gate_with_registers import split_qubits, total_bits
 from qualtran.bloqs.basic_gates import CNOT, TGate
-from qualtran.bloqs.qrom import QROM
+from qualtran.bloqs.qrom import _qrom_multi_data, _qrom_multi_dim, _qrom_small, QROM
 from qualtran.cirq_interop.bit_tools import iter_bits
 from qualtran.cirq_interop.t_complexity_protocol import t_complexity
 from qualtran.cirq_interop.testing import assert_circuit_inp_out_cirqsim, GateHelper
@@ -32,16 +32,23 @@ from qualtran.testing import (
 )
 
 
+def test_qrom_small(bloq_autotester):
+    bloq_autotester(_qrom_small)
+
+
+def test_qrom_multi_data(bloq_autotester):
+    bloq_autotester(_qrom_multi_data)
+
+
+def test_qrom_multi_dim(bloq_autotester):
+    bloq_autotester(_qrom_multi_dim)
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "data,num_controls",
     [
-        pytest.param(
-            data,
-            num_controls,
-            id=f"{num_controls}-data{idx}",
-            marks=pytest.mark.slow if num_controls == 2 and idx == 2 else (),
-        )
+        pytest.param(data, num_controls, id=f"{num_controls}-data{idx}")
         for idx, data in enumerate(
             [[[1, 2, 3, 4, 5]], [[1, 2, 3], [4, 5, 10]], [[1], [2], [3], [4], [5], [6]]]
         )
@@ -91,6 +98,57 @@ def test_qrom_1d(data, num_controls):
             assert_circuit_inp_out_cirqsim(
                 decomposed_circuit + inverse, g.all_qubits, final_state, final_state
             )
+
+
+def test_qrom_1d_classical():
+    rs = np.random.RandomState()
+    data = rs.randint(0, 2**3, size=10)
+    sel_size = int(np.ceil(np.log2(10)))
+    qrom = QROM([data], (sel_size,), target_bitsizes=(3,))
+    for i in range(len(data)):
+        i_out, data_out = qrom.call_classically(selection=i, target0_=0)
+        assert i_out == i
+        assert data_out == data[i]
+
+
+def test_qrom_1d_classical_nonzero_target():
+    rs = np.random.RandomState()
+    data = rs.randint(0, 2**3, size=10)
+    sel_size = int(np.ceil(np.log2(10)))
+    qrom = QROM([data], (sel_size,), target_bitsizes=(3,))
+    for i in range(len(data)):
+        target_in = int('111', 2)
+        i_out, data_out = qrom.call_classically(selection=i, target0_=target_in)
+        assert i_out == i
+        assert data_out == data[i] ^ target_in
+
+
+def test_qrom_1d_multitarget_classical():
+    rs = np.random.RandomState()
+    n = 10
+    data_sets = [rs.randint(0, 2**3, size=n) for _ in range(3)]
+    sel_size = int(np.ceil(np.log2(10)))
+    qrom = QROM(data_sets, (sel_size,), target_bitsizes=(3, 3, 3))
+    for i in range(n):
+        init = {f'target{i}_': 0 for i in range(3)}
+        i_out, *data_out = qrom.call_classically(selection=i, **init)
+        assert i_out == i
+        assert data_out == [data[i] for data in data_sets]
+
+
+def test_qrom_3d_classical():
+    rs = np.random.RandomState()
+    data = rs.randint(0, 2**3, size=(3, 2, 4))
+    sel_sizes = (2, 1, 2)
+    qrom = QROM([data], sel_sizes, target_bitsizes=(3,))
+    for i in range(3):
+        for j in range(2):
+            for k in range(4):
+                *i_out, data_out = qrom.call_classically(
+                    selection0=i, selection1=j, selection2=k, target0_=0
+                )
+                assert i_out == [i, j, k]
+                assert data_out == data[i, j, k]
 
 
 def test_qrom_diagram():

--- a/qualtran/bloqs/qrom_test.py
+++ b/qualtran/bloqs/qrom_test.py
@@ -105,12 +105,13 @@ def test_qrom_1d_classical():
     data = rs.randint(0, 2**3, size=10)
     sel_size = int(np.ceil(np.log2(10)))
     qrom = QROM([data], (sel_size,), target_bitsizes=(3,))
+    cbloq = qrom.decompose_bloq()
     for i in range(len(data)):
         i_out, data_out = qrom.call_classically(selection=i, target0_=0)
         assert i_out == i
         assert data_out == data[i]
 
-        decomp_ret = qrom.decompose_bloq().call_classically(selection=i, target0_=0)
+        decomp_ret = cbloq.call_classically(selection=i, target0_=0)
         assert decomp_ret == (i_out, data_out)
 
 
@@ -119,13 +120,14 @@ def test_qrom_1d_classical_nonzero_target():
     data = rs.randint(0, 2**3, size=10)
     sel_size = int(np.ceil(np.log2(10)))
     qrom = QROM([data], (sel_size,), target_bitsizes=(3,))
+    cbloq = qrom.decompose_bloq()
     for i in range(len(data)):
         target_in = int('111', 2)
         i_out, data_out = qrom.call_classically(selection=i, target0_=target_in)
         assert i_out == i
         assert data_out == data[i] ^ target_in
 
-        decomp_ret = qrom.decompose_bloq().call_classically(selection=i, target0_=target_in)
+        decomp_ret = cbloq.call_classically(selection=i, target0_=target_in)
         assert decomp_ret == (i_out, data_out)
 
 
@@ -135,13 +137,14 @@ def test_qrom_1d_multitarget_classical():
     data_sets = [rs.randint(0, 2**3, size=n) for _ in range(3)]
     sel_size = int(np.ceil(np.log2(10)))
     qrom = QROM(data_sets, (sel_size,), target_bitsizes=(3, 3, 3))
+    cbloq = qrom.decompose_bloq()
     for i in range(n):
         init = {f'target{i}_': 0 for i in range(3)}
         i_out, *data_out = qrom.call_classically(selection=i, **init)
         assert i_out == i
         assert data_out == [data[i] for data in data_sets]
 
-        decomp_i_out, *decomp_data_out = qrom.decompose_bloq().call_classically(selection=i, **init)
+        decomp_i_out, *decomp_data_out = cbloq.call_classically(selection=i, **init)
         assert decomp_i_out == i_out
         assert len(data_out) == len(decomp_data_out)
         for do, decomp_do in zip(data_out, decomp_data_out):
@@ -153,6 +156,7 @@ def test_qrom_3d_classical():
     data = rs.randint(0, 2**3, size=(3, 2, 4))
     sel_sizes = (2, 1, 2)
     qrom = QROM([data], sel_sizes, target_bitsizes=(3,))
+    cbloq = qrom.decompose_bloq()
     for i in range(3):
         for j in range(2):
             for k in range(4):
@@ -162,7 +166,7 @@ def test_qrom_3d_classical():
                 assert i_out == [i, j, k]
                 assert data_out == data[i, j, k]
 
-                *decomp_i_out, decomp_data_out = qrom.decompose_bloq().call_classically(
+                *decomp_i_out, decomp_data_out = cbloq.call_classically(
                     selection0=i, selection1=j, selection2=k, target0_=0
                 )
                 assert decomp_i_out == i_out

--- a/qualtran/bloqs/unary_iteration_bloq.py
+++ b/qualtran/bloqs/unary_iteration_bloq.py
@@ -107,7 +107,7 @@ def _unary_iteration_segtree(
     yield from _unary_iteration_segtree(
         ops, anc, selection, ancilla, sl + 1, l, m, l_iter, r_iter, break_early
     )
-    ops.append(cirq.CNOT(control, anc))
+    ops.append(CNOT().on(control, anc))
     yield from _unary_iteration_segtree(
         ops, anc, selection, ancilla, sl + 1, m, r, l_iter, r_iter, break_early
     )
@@ -129,11 +129,11 @@ def _unary_iteration_zero_control(
             ops, selection[1:], ancilla, l_iter, r_iter, break_early
         )
         return
-    ops.append(cirq.X(selection[0]))
+    ops.append(XGate().on(selection[0]))
     yield from _unary_iteration_segtree(
         ops, selection[0], selection[1:], ancilla, sl, l, m, l_iter, r_iter, break_early
     )
-    ops.append(cirq.X(selection[0]))
+    ops.append(XGate().on(selection[0]))
     yield from _unary_iteration_segtree(
         ops, selection[0], selection[1:], ancilla, sl, m, r, l_iter, r_iter, break_early
     )
@@ -486,7 +486,7 @@ class UnaryIterationGate(GateWithRegisters):
         representing range `[l, r)`. If True, the internal node is considered equivalent to a leaf
         node and thus, `self.nth_operation` will be called for only integer `l` in the range [l, r).
 
-        When the `UnaryIteration` class is constructed using multiple selection signature, i.e. we
+        When the `UnaryIteration` class is constructed using multiple selection registers, i.e. we
         wish to perform nested coherent for-loops, a unary iteration segment tree is constructed
         corresponding to each nested coherent for-loop. For every such unary iteration segment tree,
         the `_break_early` condition is checked by passing the `selection_index_prefix` tuple.
@@ -622,5 +622,5 @@ class UnaryIterationGate(GateWithRegisters):
         try:
             unary_iteration_loops(0, {}, total_bits(self.control_registers))
             return {(bloq, count) for bloq, count in bloq_counts.items()}
-        except NotImplementedError as e:
+        except NotImplementedError:
             return super().build_call_graph(ssa)

--- a/qualtran/cirq_interop/_bloq_to_cirq.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq.py
@@ -144,6 +144,15 @@ class BloqAsCirqGate(cirq.Gate):
     def _decompose_(self, qubits: Sequence[cirq.Qid]) -> cirq.OP_TREE:
         return self._decompose_with_context_(qubits)
 
+    def _unitary_(self):
+        if self._num_qubits_() > 3:
+            # Prefer decomposition for large bloqs
+            return NotImplemented
+        tensor = self.bloq.tensor_contract()
+        if tensor.ndim != 2:
+            return NotImplemented
+        return tensor
+
     def on_registers(
         self, **qubit_regs: Union[cirq.Qid, Sequence[cirq.Qid], NDArray[cirq.Qid]]
     ) -> cirq.Operation:

--- a/qualtran/drawing/musical_score.py
+++ b/qualtran/drawing/musical_score.py
@@ -454,7 +454,7 @@ class ModPlus(WireSymbol):
             -y,
             "⊕",
             transform=ax.transData,
-            fontsize=20,
+            fontsize=18,
             ha='center',
             va='center',
             bbox={'fc': 'none', 'lw': 0},

--- a/qualtran/simulation/classical_sim.py
+++ b/qualtran/simulation/classical_sim.py
@@ -166,6 +166,8 @@ def _binst_on_classical_vals(
 
     # Apply function
     out_vals = bloq.on_classical_vals(**in_vals)
+    if not isinstance(out_vals, dict):
+        raise TypeError(f"{bloq.__class__.__name__}.on_classical_vals should return a dictionary.")
     _update_assign_from_vals(bloq.signature.rights(), binst, out_vals, soq_assign)
 
 


### PR DESCRIPTION
Add classical simulation capabilities to QROM. This involves switching some of the `cirq.CNOT`s over. Add autodocs for QROM. 