### PR TITLE
[Organizing Bloqs] Move `sorting` bloqs to arithmetic/

### DIFF
--- a/dev_tools/autogenerate-bloqs-notebooks-v2.py
+++ b/dev_tools/autogenerate-bloqs-notebooks-v2.py
@@ -51,26 +51,19 @@ from qualtran_dev_tools.jupyter_autogen_v2 import NotebookSpecV2, render_noteboo
 import qualtran.bloqs.and_bloq
 import qualtran.bloqs.apply_gate_to_lth_target
 import qualtran.bloqs.arithmetic.addition
-import qualtran.bloqs.arithmetic.comparison
-import qualtran.bloqs.arithmetic.conversions
-import qualtran.bloqs.arithmetic.multiplication
+import qualtran.bloqs.arithmetic.sorting
 import qualtran.bloqs.basic_gates.swap
 import qualtran.bloqs.block_encoding
 import qualtran.bloqs.chemistry.df.double_factorization
 import qualtran.bloqs.chemistry.pbc.first_quantization.prepare_t
 import qualtran.bloqs.chemistry.pbc.first_quantization.prepare_uv
 import qualtran.bloqs.chemistry.pbc.first_quantization.projectile.select_and_prepare
-import qualtran.bloqs.chemistry.pbc.first_quantization.select_and_prepare
 import qualtran.bloqs.chemistry.pbc.first_quantization.select_t
 import qualtran.bloqs.chemistry.pbc.first_quantization.select_uv
 import qualtran.bloqs.chemistry.sf.single_factorization
 import qualtran.bloqs.chemistry.sparse.prepare
-import qualtran.bloqs.chemistry.sparse.select_bloq
 import qualtran.bloqs.chemistry.thc.prepare
-import qualtran.bloqs.chemistry.thc.select_bloq
 import qualtran.bloqs.chemistry.trotter.inverse_sqrt
-import qualtran.bloqs.chemistry.trotter.kinetic
-import qualtran.bloqs.chemistry.trotter.potential
 import qualtran.bloqs.chemistry.trotter.qvr
 import qualtran.bloqs.factoring.mod_exp
 import qualtran.bloqs.multi_control_multi_target_pauli
@@ -78,7 +71,6 @@ import qualtran.bloqs.prepare_uniform_superposition
 import qualtran.bloqs.reflection
 import qualtran.bloqs.rotations.phasing_via_cost_function
 import qualtran.bloqs.rotations.quantum_variable_rotation
-import qualtran.bloqs.sorting
 import qualtran.bloqs.state_preparation.state_preparation_via_rotation
 import qualtran.bloqs.swap_network
 
@@ -205,15 +197,6 @@ NOTEBOOK_SPECS: List[NotebookSpecV2] = [
         directory=f'{SOURCE_DIR}/bloqs/chemistry/thc',
     ),
     NotebookSpecV2(
-        title='Sorting',
-        module=qualtran.bloqs.sorting,
-        bloq_specs=[
-            qualtran.bloqs.sorting._COMPARATOR_DOC,
-            qualtran.bloqs.sorting._BITONIC_SORT_DOC,
-        ],
-        directory=f'{SOURCE_DIR}/bloqs/',
-    ),
-    NotebookSpecV2(
         title='And',
         module=qualtran.bloqs.and_bloq,
         bloq_specs=[qualtran.bloqs.and_bloq._AND_DOC, qualtran.bloqs.and_bloq._MULTI_AND_DOC],
@@ -254,6 +237,15 @@ NOTEBOOK_SPECS: List[NotebookSpecV2] = [
             qualtran.bloqs.arithmetic.addition._ADD_OOP_DOC,
             qualtran.bloqs.arithmetic.addition._ADD_K_DOC,
         ],
+    ),
+    NotebookSpecV2(
+        title='Sorting',
+        module=qualtran.bloqs.arithmetic.sorting,
+        bloq_specs=[
+            qualtran.bloqs.arithmetic.sorting._COMPARATOR_DOC,
+            qualtran.bloqs.arithmetic.sorting._BITONIC_SORT_DOC,
+        ],
+        directory=f'{SOURCE_DIR}/bloqs/arithmetic/',
     ),
     NotebookSpecV2(
         title='State Preparation Using Rotations',

--- a/qualtran/bloqs/arithmetic/sorting.ipynb
+++ b/qualtran/bloqs/arithmetic/sorting.ipynb
@@ -65,7 +65,7 @@
    },
    "outputs": [],
    "source": [
-    "from qualtran.bloqs.sorting import Comparator"
+    "from qualtran.bloqs.arithmetic.sorting import Comparator"
    ]
   },
   {
@@ -174,7 +174,7 @@
    },
    "outputs": [],
    "source": [
-    "from qualtran.bloqs.sorting import BitonicSort"
+    "from qualtran.bloqs.arithmetic.sorting import BitonicSort"
    ]
   },
   {

--- a/qualtran/bloqs/arithmetic/sorting.py
+++ b/qualtran/bloqs/arithmetic/sorting.py
@@ -77,7 +77,7 @@ def _cmp_symb() -> Comparator:
 
 _COMPARATOR_DOC = BloqDocSpec(
     bloq_cls=Comparator,
-    import_line='from qualtran.bloqs.sorting import Comparator',
+    import_line='from qualtran.bloqs.arithmetic.sorting import Comparator',
     examples=(_cmp_symb,),
 )
 
@@ -133,6 +133,6 @@ def _bitonic_sort() -> BitonicSort:
 
 _BITONIC_SORT_DOC = BloqDocSpec(
     bloq_cls=BitonicSort,
-    import_line='from qualtran.bloqs.sorting import BitonicSort',
+    import_line='from qualtran.bloqs.arithmetic.sorting import BitonicSort',
     examples=(_bitonic_sort,),
 )

--- a/qualtran/bloqs/arithmetic/sorting_test.py
+++ b/qualtran/bloqs/arithmetic/sorting_test.py
@@ -15,7 +15,7 @@
 import pytest
 
 import qualtran.testing as qlt_testing
-from qualtran.bloqs.sorting import _bitonic_sort, _cmp_symb, BitonicSort, Comparator
+from qualtran.bloqs.arithmetic.sorting import _bitonic_sort, _cmp_symb, BitonicSort, Comparator
 
 
 def test_cmp_symb(bloq_autotester):

--- a/qualtran/serialization/bloq.py
+++ b/qualtran/serialization/bloq.py
@@ -32,7 +32,8 @@ from qualtran import (
     Signature,
     Soquet,
 )
-from qualtran.bloqs import and_bloq, arithmetic, basic_gates, factoring, sorting, swap_network
+from qualtran.bloqs import and_bloq, arithmetic, basic_gates, factoring, swap_network
+from qualtran.bloqs.arithmetic import sorting
 from qualtran.bloqs.util_bloqs import Allocate, ArbitraryClifford, Free, Join, Split
 from qualtran.cirq_interop import CirqGateAsBloq
 from qualtran.protos import args_pb2, bloq_pb2


### PR DESCRIPTION
Part of organizing bloqs into sub-modules within the `bloqs/` repository. 