### PR TITLE
Fix failing circuit diagrams for Toffoli bloq when used in a Cirq circuit

### DIFF
--- a/qualtran/cirq_interop/_bloq_to_cirq.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq.py
@@ -300,7 +300,7 @@ def _wire_symbol_to_cirq_diagram_info(
         if isinstance(ws, (TextBox, RarrowTextBox, LarrowTextBox)):
             return ws.text
         if isinstance(ws, ModPlus):
-            return "⊕" if args.use_unicode_characters else 'X'
+            return 'X'
         raise NotImplementedError(f"Unknown cirq version of {ws}")
 
     wire_symbols = [_qualtran_wire_symbols_to_cirq_text(ws) for ws in wire_symbols]

--- a/qualtran/cirq_interop/_bloq_to_cirq.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq.py
@@ -42,7 +42,7 @@ from qualtran._infra.gate_with_registers import (
 )
 from qualtran.cirq_interop._cirq_to_bloq import _QReg, CirqQuregInT, CirqQuregT
 from qualtran.cirq_interop._interop_qubit_manager import InteropQubitManager
-from qualtran.drawing import Circle, LarrowTextBox, RarrowTextBox, TextBox, WireSymbol
+from qualtran.drawing import Circle, LarrowTextBox, ModPlus, RarrowTextBox, TextBox, WireSymbol
 
 
 def _cirq_style_decompose_from_decompose_bloq(
@@ -154,7 +154,7 @@ class BloqAsCirqGate(cirq.Gate):
         By default, we label each qubit with its register name. If `reg_to_wires` was provided
         in the class constructor, we use that to get a list of wire symbols for each register.
         """
-        return _wire_symbol_to_cirq_diagram_info(self._bloq)
+        return _wire_symbol_to_cirq_diagram_info(self._bloq, args)
 
     def __pow__(self, power, modulo=None):
         if power == 1:
@@ -273,7 +273,9 @@ def _cbloq_to_cirq_circuit(
     return cirq.FrozenCircuit(moments), out_quregs
 
 
-def _wire_symbol_to_cirq_diagram_info(bloq: Bloq) -> cirq.CircuitDiagramInfo:
+def _wire_symbol_to_cirq_diagram_info(
+    bloq: Bloq, args: cirq.CircuitDiagramInfoArgs
+) -> cirq.CircuitDiagramInfo:
     wire_symbols = []
     for reg in bloq.signature:
         # Note: all of our soqs lack a `binst`. The `bloq.wire_symbol` methods
@@ -297,7 +299,8 @@ def _wire_symbol_to_cirq_diagram_info(bloq: Bloq) -> cirq.CircuitDiagramInfo:
                 return '@(0)'
         if isinstance(ws, (TextBox, RarrowTextBox, LarrowTextBox)):
             return ws.text
-
+        if isinstance(ws, ModPlus):
+            return "⊕" if args.use_unicode_characters else 'X'
         raise NotImplementedError(f"Unknown cirq version of {ws}")
 
     wire_symbols = [_qualtran_wire_symbols_to_cirq_text(ws) for ws in wire_symbols]

--- a/qualtran/cirq_interop/_bloq_to_cirq_test.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq_test.py
@@ -298,7 +298,7 @@ def test_toffoli_circuit_diagram():
       │
 1: ───@───
       │
-2: ───⊕───
+2: ───X───
 """,
     )
     cirq.testing.assert_has_diagram(

--- a/qualtran/cirq_interop/_bloq_to_cirq_test.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq_test.py
@@ -22,7 +22,7 @@ from attrs import frozen
 from qualtran import Bloq, BloqBuilder, Signature, Soquet, SoquetT
 from qualtran._infra.gate_with_registers import get_named_qubits
 from qualtran.bloqs.and_bloq import And, MultiAnd
-from qualtran.bloqs.basic_gates import XGate
+from qualtran.bloqs.basic_gates import Toffoli, XGate
 from qualtran.bloqs.factoring import ModExp
 from qualtran.bloqs.swap_network import SwapWithZero
 from qualtran.cirq_interop._bloq_to_cirq import BloqAsCirqGate, CirqQuregT
@@ -286,6 +286,31 @@ exponent1: ───exponent───────┼─────┼───�
 exponent2: ───exponent───────┼─────@─────────────────
               │              │
 exponent3: ───exponent───────@───────────────────────''',
+    )
+
+
+def test_toffoli_circuit_diagram():
+    q = cirq.LineQubit.range(3)
+    cirq.testing.assert_has_diagram(
+        cirq.Circuit(Toffoli().on(*q)),
+        """
+0: ───@───
+      │
+1: ───@───
+      │
+2: ───⊕───
+""",
+    )
+    cirq.testing.assert_has_diagram(
+        cirq.Circuit(Toffoli().on(*q)),
+        """
+0: ---@---
+      |
+1: ---@---
+      |
+2: ---X---
+""",
+        use_unicode_characters=False,
     )
 
 


### PR DESCRIPTION
Currently using `CNOT` or `Toffoli` bloq's in a cirq circuit raises an error when you try to print the circuit

Adds `ModPlus` type to `_wire_symbol_to_cirq_diagram_info`. Also, @mpharrigan How do we keep the interop in sync with new `WireSymbol` classes? Should we add a text/pretty_str style property to `WireSymbol` class? 