### PR TITLE
Add `t_counts_from_sigma` helper to extract T-counts from

### DIFF
--- a/qualtran/bloqs/basic_gates/__init__.py
+++ b/qualtran/bloqs/basic_gates/__init__.py
@@ -24,7 +24,7 @@ requirements.
 from .cnot import CNOT
 from .hadamard import Hadamard
 from .on_each import OnEach
-from .rotation import Rx, Ry, Rz, XPowGate, YPowGate, ZPowGate
+from .rotation import CZPowGate, Rx, Ry, Rz, XPowGate, YPowGate, ZPowGate
 from .swap import CSwap, TwoBitCSwap, TwoBitSwap
 from .t_gate import TGate
 from .toffoli import Toffoli

--- a/qualtran/resource_counting/symbolic_counting_utils.py
+++ b/qualtran/resource_counting/symbolic_counting_utils.py
@@ -1,0 +1,38 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import Union
+
+import numpy as np
+import sympy
+from cirq._doc import document
+
+SymbolicFloat = Union[float, sympy.Expr]
+document(SymbolicFloat, """A floating point value or a sympy expression.""")
+
+SymbolicInt = Union[int, sympy.Expr]
+document(SymbolicFloat, """A floating point value or a sympy expression.""")
+
+
+def log2(x: SymbolicFloat) -> SymbolicFloat:
+    from sympy.codegen.cfunctions import log2
+
+    if not isinstance(x, sympy.Basic):
+        return np.log2(x)
+    return log2(x)
+
+
+def ceil(x: SymbolicFloat) -> SymbolicInt:
+    if not isinstance(x, sympy.Basic):
+        return int(np.ceil(x))
+    return sympy.ceiling(x)

--- a/qualtran/resource_counting/symbolic_counting_utils_test.py
+++ b/qualtran/resource_counting/symbolic_counting_utils_test.py
@@ -1,0 +1,31 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import numpy as np
+import sympy
+from sympy.codegen.cfunctions import log2 as sympy_log2
+
+from qualtran.resource_counting.symbolic_counting_utils import ceil, log2
+
+
+def test_log2():
+    assert log2(sympy.Symbol('x')) == sympy_log2(sympy.Symbol('x'))
+    assert log2(sympy.Number(10)) == sympy_log2(sympy.Number(10))
+    assert log2(10) == np.log2(10)
+
+
+def test_ceil():
+    assert ceil(sympy.Symbol('x')) == sympy.ceiling(sympy.Symbol('x'))
+    assert ceil(sympy.Number(10.123)) == sympy.ceiling(sympy.Number(11))
+    assert isinstance(ceil(sympy.Number(10.123)), sympy.Basic)
+    assert ceil(10.123) == 11

--- a/qualtran/resource_counting/t_counts_from_sigma.py
+++ b/qualtran/resource_counting/t_counts_from_sigma.py
@@ -1,0 +1,51 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import inspect
+import sys
+from typing import Dict, Optional, Tuple, TYPE_CHECKING, Union
+
+from qualtran.bloqs.basic_gates import TGate
+from qualtran.cirq_interop.t_complexity_protocol import TComplexity
+from qualtran.resource_counting.symbolic_counting_utils import SymbolicFloat
+
+if TYPE_CHECKING:
+    import sympy
+
+    from qualtran import Bloq
+    from qualtran.bloqs.basic_gates.rotation import _HasEps
+
+
+def _get_all_rotation_types() -> Tuple['_HasEps', ...]:
+    """Returns all classes defined in bloqs.basic_gates which have an attribute `eps`."""
+    import qualtran.bloqs.basic_gates
+
+    return tuple(
+        v
+        for (k, v) in inspect.getmembers(sys.modules['qualtran.bloqs.basic_gates'], inspect.isclass)
+        if hasattr(v, 'eps')
+    )
+
+
+def t_counts_from_sigma(
+    sigma: Dict['Bloq', Union[int, 'sympy.Expr']],
+    rotation_types: Optional[Tuple['_HasEps', ...]] = None,
+) -> SymbolicFloat:
+    """Aggregates T-counts from a sigma dictionary by summing T-costs for all rotation bloqs."""
+    if rotation_types is None:
+        rotation_types = _get_all_rotation_types()
+    ret = sigma.get(TGate(), 0)
+    for bloq, counts in sigma.items():
+        if isinstance(bloq, rotation_types):
+            ret += TComplexity.rotation_cost(bloq.eps) * counts
+    return ret

--- a/qualtran/resource_counting/t_counts_from_sigma.py
+++ b/qualtran/resource_counting/t_counts_from_sigma.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 def _get_all_rotation_types() -> Tuple['_HasEps', ...]:
     """Returns all classes defined in bloqs.basic_gates which have an attribute `eps`."""
-    import qualtran.bloqs.basic_gates
+    import qualtran.bloqs.basic_gates  # pylint: disable=unused-import
 
     return tuple(
         v

--- a/qualtran/resource_counting/t_counts_from_sigma_test.py
+++ b/qualtran/resource_counting/t_counts_from_sigma_test.py
@@ -1,0 +1,61 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sympy
+
+from qualtran.bloqs.basic_gates import (
+    CZPowGate,
+    Rx,
+    Ry,
+    Rz,
+    TGate,
+    Toffoli,
+    XPowGate,
+    YPowGate,
+    ZPowGate,
+)
+from qualtran.cirq_interop.t_complexity_protocol import TComplexity
+from qualtran.resource_counting.t_counts_from_sigma import (
+    _get_all_rotation_types,
+    t_counts_from_sigma,
+)
+
+
+def test_all_rotation_types():
+    assert set(_get_all_rotation_types()) == {CZPowGate, Rx, Ry, Rz, XPowGate, YPowGate, ZPowGate}
+
+
+def test_t_counts_from_sigma():
+    z_eps1, z_eps2, x_eps, y_eps, cz_eps = sympy.symbols('z_eps1, z_eps2, x_eps, y_eps, cz_eps')
+    sigma = {
+        ZPowGate(eps=z_eps1): 1,
+        ZPowGate(eps=z_eps2): 2,
+        Rz(0.01, eps=z_eps2): 3,
+        Rx(0.01, eps=x_eps): 4,
+        XPowGate(eps=x_eps): 5,
+        Ry(0.01, eps=y_eps): 6,
+        YPowGate(eps=y_eps): 7,
+        CZPowGate(eps=cz_eps): 20,
+        TGate(): 100,
+        Toffoli(): 200,
+    }
+    expected_t_count = (
+        +100
+        + 1 * TComplexity.rotation_cost(z_eps1)
+        + 5 * TComplexity.rotation_cost(z_eps2)
+        + 9 * TComplexity.rotation_cost(x_eps)
+        + 13 * TComplexity.rotation_cost(y_eps)
+        + 20 * TComplexity.rotation_cost(cz_eps)
+    )
+    assert t_counts_from_sigma(sigma) == expected_t_count


### PR DESCRIPTION
After the recent change to T-complexity protocol https://github.com/quantumlib/Qualtran/pull/678/files, the correct way to extract T-counts for a Bloq is to process the bloq counts dictionary `sigma` obtained via `bloq.call_graph()`. 

This PR adds a helper that can process `sigma` and obtain the correct T-counts. This is a blocker for my analyses and can potentially be replaced by the upcoming generalized costs infrastructure. 

As part of this PR, I've also extracted the "utils" file, originally introduced in https://github.com/quantumlib/Qualtran/pull/688,  into `resource_counting/symbolic_counting_utils.py`.

