### PR TITLE
Temporarily fix the failing T-Complexity for Adjoint

### DIFF
--- a/qualtran/_infra/adjoint.py
+++ b/qualtran/_infra/adjoint.py
@@ -186,5 +186,11 @@ class Adjoint(GateWithRegisters):
         The cirq-style t complexity protocol does not leverage the heirarchical decomposition
         of high-level bloqs, so we need to shim in an extra `adjoint` boolean flag.
         """
-        # TODO: https://github.com/quantumlib/Qualtran/issues/489
-        return self.subbloq._t_complexity_(adjoint=True)
+        # TODO: https://github.com/quantumlib/Qualtran/issues/735
+        try:
+            return self.subbloq._t_complexity_(adjoint=True)
+        except TypeError as e:
+            if 'adjoint' in str(e):
+                return self.subbloq._t_complexity_()
+            else:
+                raise e

--- a/qualtran/_infra/adjoint_test.py
+++ b/qualtran/_infra/adjoint_test.py
@@ -21,6 +21,7 @@ from qualtran.bloqs.basic_gates import CNOT, CSwap, ZeroState
 from qualtran.bloqs.for_testing.atom import TestAtom
 from qualtran.bloqs.for_testing.with_call_graph import TestBloqWithCallGraph
 from qualtran.bloqs.for_testing.with_decomposition import TestParallelCombo, TestSerialCombo
+from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import LarrowTextBox, RarrowTextBox
 
 
@@ -159,6 +160,23 @@ def test_wire_symbol():
     adj_ws = adj.wire_symbol(Soquet(None, reg.adjoint()))
     assert isinstance(ws, LarrowTextBox)
     assert isinstance(adj_ws, RarrowTextBox)
+
+
+class TAcceptsAdjoint(TestAtom):
+    def _t_complexity_(self, adjoint: bool = False) -> TComplexity:
+        return TComplexity(t=2 if adjoint else 1)
+
+
+class TDoesNotAcceptAdjoint(TestAtom):
+    def _t_complexity_(self) -> TComplexity:
+        return TComplexity(t=3)
+
+
+def test_t_complexity():
+    assert TAcceptsAdjoint().t_complexity().t == 1
+    assert Adjoint(TAcceptsAdjoint()).t_complexity().t == 2
+    assert TDoesNotAcceptAdjoint().t_complexity().t == 3
+    assert Adjoint(TDoesNotAcceptAdjoint()).t_complexity().t == 3
 
 
 @pytest.mark.notebook


### PR DESCRIPTION
T-complexity protocol is important and currently broken. This PR temporarily unblocks development and analysis of algorithms using the T-complexity protocol (encountered in https://github.com/quantumlib/Qualtran/pull/732 ). 

See  https://github.com/quantumlib/Qualtran/issues/735 for a more detailed discussion to design the future of T-complexity.