### PR TITLE
More improvements and bugfixes to t-complexity protocol to make things work with Adjoint

### DIFF
--- a/qualtran/_infra/adjoint.py
+++ b/qualtran/_infra/adjoint.py
@@ -187,6 +187,9 @@ class Adjoint(GateWithRegisters):
         of high-level bloqs, so we need to shim in an extra `adjoint` boolean flag.
         """
         # TODO: https://github.com/quantumlib/Qualtran/issues/735
+        if not hasattr(self.subbloq, '_t_complexity_'):
+            return NotImplemented
+
         try:
             return self.subbloq._t_complexity_(adjoint=True)
         except TypeError as e:

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -412,6 +412,9 @@ class Bloq(metaclass=abc.ABCMeta):
 
         return t_complexity(self)
 
+    def _t_complexity_(self) -> 'TComplexity':
+        return NotImplemented
+
     def as_cirq_op(
         self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'
     ) -> Tuple[Union['cirq.Operation', None], Dict[str, 'CirqQuregT']]:

--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -19,14 +19,13 @@ import cirq
 import numpy as np
 from numpy.typing import NDArray
 
-from qualtran._infra.bloq import Bloq, DecomposeNotImplementedError
+from qualtran._infra.bloq import Bloq, DecomposeNotImplementedError, DecomposeTypeError
 from qualtran._infra.composite_bloq import CompositeBloq
 from qualtran._infra.quantum_graph import Soquet
 from qualtran._infra.registers import Register, Side
 
 if TYPE_CHECKING:
     from qualtran.cirq_interop import CirqQuregT
-    from qualtran.cirq_interop.t_complexity_protocol import TComplexity
     from qualtran.drawing import WireSymbol
 
 
@@ -293,7 +292,7 @@ class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
             return _cirq_style_decompose_from_decompose_bloq(
                 bloq=self, quregs=quregs, context=context
             )
-        except DecomposeNotImplementedError:
+        except (DecomposeNotImplementedError, DecomposeTypeError):
             pass
         return NotImplemented
 

--- a/qualtran/cirq_interop/_bloq_to_cirq.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq.py
@@ -26,6 +26,7 @@ from qualtran import (
     Bloq,
     Connection,
     DecomposeNotImplementedError,
+    DecomposeTypeError,
     LeftDangle,
     Register,
     RightDangle,
@@ -136,7 +137,7 @@ class BloqAsCirqGate(cirq.Gate):
             return _cirq_style_decompose_from_decompose_bloq(
                 bloq=self.bloq, quregs=quregs, context=context
             )
-        except DecomposeNotImplementedError:
+        except (DecomposeNotImplementedError, DecomposeTypeError):
             pass
         return NotImplemented
 


### PR DESCRIPTION
Follow up of https://github.com/quantumlib/Qualtran/pull/736. See added tests for more bugfixes. 

One philosophical discussion - what's the difference between `DecomposeNotImplemented` and `DecomposeTypeErrror`? In Cirq, we just return `NotImplmented` if the decomposition is not implemented and I've updated the logic to map both the above errors to this behavior. 

@mpharrigan Can you check if this looks good? 