### PR TITLE
Use `build_call_graph` instead of `decompose_bloq` to compute `TComplexity`for bloqs

### DIFF
--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -18,7 +18,7 @@ import attrs
 import cachetools
 import cirq
 
-from qualtran import Bloq, CompositeBloq, DecomposeNotImplementedError, DecomposeTypeError
+from qualtran import Bloq, DecomposeNotImplementedError, DecomposeTypeError
 from qualtran.cirq_interop.decompose_protocol import _decompose_once_considering_known_decomposition
 from qualtran.resource_counting.symbolic_counting_utils import ceil, log2, SymbolicFloat
 
@@ -128,11 +128,15 @@ def _from_bloq_decomposition(stc: Any, fail_quietly: bool) -> Optional[TComplexi
     if not isinstance(stc, Bloq):
         return None
 
-    if isinstance(stc, CompositeBloq):
-        return _is_iterable((binst.bloq for binst in stc.bloq_instances), fail_quietly=fail_quietly)
-
     try:
-        return _from_bloq_decomposition(stc.decompose_bloq(), fail_quietly=fail_quietly)
+        _, sigma = stc.call_graph(max_depth=1)
+        ret = TComplexity()
+        for bloq, n in sigma.items():
+            r = t_complexity(bloq, fail_quietly=fail_quietly)
+            if r is None:
+                return None
+            ret += n * t_complexity(bloq)
+        return ret
     except (DecomposeNotImplementedError, DecomposeTypeError):
         return None
 

--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -123,8 +123,8 @@ def _is_iterable(it: Any, fail_quietly: bool) -> Optional[TComplexity]:
     return t
 
 
-def _from_bloq_decomposition(stc: Any, fail_quietly: bool) -> Optional[TComplexity]:
-    # Decompose the object and recursively compute the complexity.
+def _from_bloq_build_call_graph(stc: Any, fail_quietly: bool) -> Optional[TComplexity]:
+    # Uses the depth 1 call graph of Bloq `stc` to recursively compute the complexity.
     if not isinstance(stc, Bloq):
         return None
 
@@ -188,7 +188,7 @@ def _t_complexity_for_gate_or_op(
     strategies = [
         _has_t_complexity,
         _is_clifford_or_t,
-        _from_bloq_decomposition,
+        _from_bloq_build_call_graph,
         _from_cirq_decomposition,
     ]
     return _t_complexity_from_strategies(gate_or_op, fail_quietly, strategies)
@@ -223,7 +223,7 @@ def t_complexity(stc: Any, fail_quietly: bool = False) -> Optional[TComplexity]:
         strategies = [
             _has_t_complexity,
             _is_clifford_or_t,
-            _from_bloq_decomposition,
+            _from_bloq_build_call_graph,
             _from_cirq_decomposition,
             _is_iterable,
         ]

--- a/qualtran/cirq_interop/t_complexity_protocol_test.py
+++ b/qualtran/cirq_interop/t_complexity_protocol_test.py
@@ -16,7 +16,7 @@ from typing import Set
 import cirq
 import pytest
 
-from qualtran import GateWithRegisters, Signature, Bloq
+from qualtran import Bloq, GateWithRegisters, Signature
 from qualtran._infra.gate_with_registers import get_named_qubits
 from qualtran.bloqs.and_bloq import And
 from qualtran.cirq_interop.t_complexity_protocol import t_complexity, TComplexity
@@ -56,6 +56,7 @@ class DoesNotSupportTComplexityGate(cirq.Gate):
 
 
 class SupportsTComplexityBloqViaBuildCallGraph(Bloq):
+    @property
     def signature(self) -> 'Signature':
         return Signature.build(q=1)
 

--- a/qualtran/cirq_interop/t_complexity_protocol_test.py
+++ b/qualtran/cirq_interop/t_complexity_protocol_test.py
@@ -11,11 +11,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from typing import Set
 
 import cirq
 import pytest
 
-from qualtran import GateWithRegisters, Signature
+from qualtran import GateWithRegisters, Signature, Bloq
 from qualtran._infra.gate_with_registers import get_named_qubits
 from qualtran.bloqs.and_bloq import And
 from qualtran.cirq_interop.t_complexity_protocol import t_complexity, TComplexity
@@ -52,6 +53,19 @@ class SupportTComplexityGate(cirq.Gate):
 class DoesNotSupportTComplexityGate(cirq.Gate):
     def _num_qubits_(self):
         return 1
+
+
+class SupportsTComplexityBloqViaBuildCallGraph(Bloq):
+    def signature(self) -> 'Signature':
+        return Signature.build(q=1)
+
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+        return {(SupportsTComplexityGateWithRegisters(), 5)}
+
+
+def test_t_complexity_for_bloq_via_build_call_graph():
+    bloq = SupportsTComplexityBloqViaBuildCallGraph()
+    assert t_complexity(bloq) == TComplexity(t=5, clifford=10)
 
 
 def test_t_complexity():


### PR DESCRIPTION
Needed in https://github.com/quantumlib/Qualtran/pull/732
Larger discussion on improving T-complexity in https://github.com/quantumlib/Qualtran/issues/735

This is strictly better because bloqs `build_call_graph` can fallback to `decompose_bloq` if user doesn't have a custom `build_call_graph` specified. The latter is often faster and more commonly specified (eg: all newly added chemistry bloqs)