### PR TITLE
Ignore cliffords in `t_counts_from_sigma` using `cirq.has_stabilizer_effect`

### DIFF
--- a/qualtran/resource_counting/t_counts_from_sigma.py
+++ b/qualtran/resource_counting/t_counts_from_sigma.py
@@ -15,9 +15,11 @@ import inspect
 import sys
 from typing import Dict, Optional, Tuple, TYPE_CHECKING, Union
 
+import cirq
+
 from qualtran.bloqs.basic_gates import TGate
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
-from qualtran.resource_counting.symbolic_counting_utils import SymbolicFloat
+from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
 
 if TYPE_CHECKING:
     import sympy
@@ -40,12 +42,12 @@ def _get_all_rotation_types() -> Tuple['_HasEps', ...]:
 def t_counts_from_sigma(
     sigma: Dict['Bloq', Union[int, 'sympy.Expr']],
     rotation_types: Optional[Tuple['_HasEps', ...]] = None,
-) -> SymbolicFloat:
+) -> SymbolicInt:
     """Aggregates T-counts from a sigma dictionary by summing T-costs for all rotation bloqs."""
     if rotation_types is None:
         rotation_types = _get_all_rotation_types()
     ret = sigma.get(TGate(), 0)
     for bloq, counts in sigma.items():
-        if isinstance(bloq, rotation_types):
+        if isinstance(bloq, rotation_types) and not cirq.has_stabilizer_effect(bloq):
             ret += TComplexity.rotation_cost(bloq.eps) * counts
     return ret

--- a/qualtran/resource_counting/t_counts_from_sigma_test.py
+++ b/qualtran/resource_counting/t_counts_from_sigma_test.py
@@ -41,12 +41,17 @@ def test_t_counts_from_sigma():
     sigma = {
         ZPowGate(eps=z_eps1): 1,
         ZPowGate(eps=z_eps2): 2,
+        ZPowGate(0.01, eps=z_eps1): 1,
+        ZPowGate(0.01, eps=z_eps2): 2,
         Rz(0.01, eps=z_eps2): 3,
         Rx(0.01, eps=x_eps): 4,
         XPowGate(eps=x_eps): 5,
+        XPowGate(0.01, eps=x_eps): 5,
         Ry(0.01, eps=y_eps): 6,
         YPowGate(eps=y_eps): 7,
+        YPowGate(0.01, eps=y_eps): 7,
         CZPowGate(eps=cz_eps): 20,
+        CZPowGate(0.01, eps=cz_eps): 20,
         TGate(): 100,
         Toffoli(): 200,
     }


### PR DESCRIPTION
Pulled out from https://github.com/quantumlib/Qualtran/pull/732