### PR TITLE
Fix infinite recursion bug in `t_complexity` protocol

### DIFF
--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -127,18 +127,17 @@ def _from_bloq_build_call_graph(stc: Any, fail_quietly: bool) -> Optional[TCompl
     # Uses the depth 1 call graph of Bloq `stc` to recursively compute the complexity.
     if not isinstance(stc, Bloq):
         return None
-
-    try:
-        _, sigma = stc.call_graph(max_depth=1)
-        ret = TComplexity()
-        for bloq, n in sigma.items():
-            r = t_complexity(bloq, fail_quietly=fail_quietly)
-            if r is None:
-                return None
-            ret += n * t_complexity(bloq)
-        return ret
-    except (DecomposeNotImplementedError, DecomposeTypeError):
+    _, sigma = stc.call_graph(max_depth=1)
+    if sigma == {stc: 1}:
+        # No decomposition found.
         return None
+    ret = TComplexity()
+    for bloq, n in sigma.items():
+        r = t_complexity(bloq, fail_quietly=fail_quietly)
+        if r is None:
+            return None
+        ret += n * t_complexity(bloq)
+    return ret
 
 
 def _from_cirq_decomposition(stc: Any, fail_quietly: bool) -> Optional[TComplexity]:

--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -18,7 +18,7 @@ import attrs
 import cachetools
 import cirq
 
-from qualtran import Bloq, DecomposeNotImplementedError, DecomposeTypeError
+from qualtran import Bloq
 from qualtran.cirq_interop.decompose_protocol import _decompose_once_considering_known_decomposition
 from qualtran.resource_counting.symbolic_counting_utils import ceil, log2, SymbolicFloat
 

--- a/qualtran/cirq_interop/t_complexity_protocol_test.py
+++ b/qualtran/cirq_interop/t_complexity_protocol_test.py
@@ -55,6 +55,12 @@ class DoesNotSupportTComplexityGate(cirq.Gate):
         return 1
 
 
+class DoesNotSupportTComplexityBloq(Bloq):
+    @property
+    def signature(self) -> 'Signature':
+        return Signature.build(q=1)
+
+
 class SupportsTComplexityBloqViaBuildCallGraph(Bloq):
     @property
     def signature(self) -> 'Signature':
@@ -67,6 +73,12 @@ class SupportsTComplexityBloqViaBuildCallGraph(Bloq):
 def test_t_complexity_for_bloq_via_build_call_graph():
     bloq = SupportsTComplexityBloqViaBuildCallGraph()
     assert t_complexity(bloq) == TComplexity(t=5, clifford=10)
+
+
+def test_t_complexity_for_bloq_does_not_support():
+    with pytest.raises(TypeError):
+        _ = t_complexity(DoesNotSupportTComplexityBloq())
+    assert t_complexity(DoesNotSupportTComplexityBloq(), True) == None
 
 
 def test_t_complexity():


### PR DESCRIPTION
Recently added `_from_bloq_build_call_graph` strategy has a bug. If the bloq does not have a decomposition, there's no error raised and instead we get a `sigma` corresponding to `{stc : 1}`. 

This PR fixes the bug and adds a test for the same. 