### PR TITLE
Fix T-complexity obtained via `build_call_graph` for HWP and add automatic assertions

### DIFF
--- a/qualtran/bloqs/arithmetic/hamming_weight.py
+++ b/qualtran/bloqs/arithmetic/hamming_weight.py
@@ -115,10 +115,9 @@ class HammingWeightCompute(GateWithRegisters):
         return TComplexity(t=num_t, clifford=num_clifford)
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {
-            (And(uncompute=self.uncompute), self.bitsize),
-            (ArbitraryClifford(n=2), 5 * self.bitsize),
-        }
+        num_and = self.bitsize - self.bitsize.bit_count()
+        num_clifford = num_and * 5 + self.bitsize.bit_count()
+        return {(And(uncompute=self.uncompute), num_and), (ArbitraryClifford(n=2), num_clifford)}
 
     def adjoint(self) -> 'Bloq':
         # TODO: There is nothing special about the `uncompute` construction of this bloq.

--- a/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
@@ -24,7 +24,10 @@ from qualtran.bloqs.rotations.hamming_weight_phasing import (
     HammingWeightPhasingViaPhaseGradient,
 )
 from qualtran.bloqs.rotations.phase_gradient import PhaseGradientState
-from qualtran.cirq_interop.testing import GateHelper
+from qualtran.cirq_interop.testing import (
+    assert_decompose_is_consistent_with_t_complexity,
+    GateHelper,
+)
 from qualtran.testing import assert_valid_bloq_decomposition
 
 
@@ -33,6 +36,7 @@ from qualtran.testing import assert_valid_bloq_decomposition
 def test_hamming_weight_phasing(n: int, theta: float):
     gate = HammingWeightPhasing(n, theta)
     assert_valid_bloq_decomposition(gate)
+    assert_decompose_is_consistent_with_t_complexity(gate)
 
     assert gate.t_complexity().rotations == n.bit_length()
     assert gate.t_complexity().t == 4 * (n - n.bit_count())
@@ -47,6 +51,16 @@ def test_hamming_weight_phasing(n: int, theta: float):
     hw_phasing = cirq.Circuit(state_prep, HammingWeightPhasing(n, theta).on(*gh.quregs['x']))
     hw_final_state = sim.simulate(hw_phasing).final_state_vector
     assert np.allclose(expected_final_state, hw_final_state, atol=1e-7)
+
+
+@pytest.mark.parametrize('n', [10, 32, 64, 100, 1024])
+def test_hamming_weight_phasing_large(n: int):
+    gate = HammingWeightPhasing(n, 1 / 10)
+    assert_valid_bloq_decomposition(gate)
+    assert_decompose_is_consistent_with_t_complexity(gate)
+
+    assert gate.t_complexity().rotations == n.bit_length()
+    assert gate.t_complexity().t == 4 * (n - n.bit_count())
 
 
 @attrs.frozen

--- a/qualtran/cirq_interop/testing.py
+++ b/qualtran/cirq_interop/testing.py
@@ -138,3 +138,12 @@ def assert_decompose_is_consistent_with_t_complexity(val: Any):
         raise AssertionError("No consistent t_complexity: no decomposition.")
     from_decomposition = t_complexity(decomposition, fail_quietly=False)
     assert expected == from_decomposition, f'{expected} != {from_decomposition}'
+
+    from qualtran import Bloq
+    from qualtran.bloqs.basic_gates import TGate
+
+    if not isinstance(val, Bloq):
+        return
+    _, sigma = val.call_graph()
+    actual = sigma.get(TGate(), 0) + sigma.get(TGate(is_adjoint=True), 0)
+    assert expected.t == actual, f'{expected.t} != {actual}'


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Qualtran/issues/762


Also adds a test to `assert_decompose_is_consistent_with_t_complexity` to verify the T-counts against `sigma` obtained via `bloq.build_call_graph`