### PR TITLE
Signature.n_qubits

### DIFF
--- a/qualtran/_infra/registers.py
+++ b/qualtran/_infra/registers.py
@@ -180,6 +180,17 @@ class Signature:
         """Swap all RIGHT and LEFT registers in this collection."""
         return Signature(reg.adjoint() for reg in self._registers)
 
+    def n_qubits(self) -> int:
+        """The number of qubits in the signature.
+
+        If the signature has LEFT and RIGHT registers, the number of qubits in the signature
+        is taken to be the greater of the number of left or right qubits. A bloq with this
+        signature uses at least this many qubits.
+        """
+        left_size = sum(reg.total_bits() for reg in self.lefts())
+        right_size = sum(reg.total_bits() for reg in self.rights())
+        return max(left_size, right_size)
+
     def __repr__(self):
         return f'Signature({repr(self._registers)})'
 

--- a/qualtran/_infra/registers_test.py
+++ b/qualtran/_infra/registers_test.py
@@ -85,6 +85,7 @@ def test_signature():
     r3 = Register("r3", QBit())
     signature = Signature([r1, r2, r3])
     assert len(signature) == 3
+    assert signature.n_qubits() == 8
 
     assert signature[0] == r1
     assert signature[1] == r2
@@ -122,6 +123,7 @@ def test_signature_build():
     sig1 = Signature([Register("r1", QAny(5)), Register("r2", QAny(2))])
     sig2 = Signature.build(r1=5, r2=2)
     assert sig1 == sig2
+    assert sig1.n_qubits() == 7
     sig1 = Signature([Register("r1", QInt(7)), Register("r2", QBit())])
     sig2 = Signature.build_from_dtypes(r1=QInt(7), r2=QBit())
     assert sig1 == sig2
@@ -139,6 +141,7 @@ def test_and_regs():
         Register('control', QAny(2)),
         Register('target', QBit(), side=Side.RIGHT),
     ]
+    assert signature.n_qubits() == 3
 
     adj = signature.adjoint()
     assert list(adj.rights()) == [Register('control', QAny(2))]
@@ -146,6 +149,7 @@ def test_and_regs():
         Register('control', QAny(2)),
         Register('target', QBit(), side=Side.LEFT),
     ]
+    assert adj.n_qubits() == 3
 
 
 def test_agg_split():
@@ -161,6 +165,7 @@ def test_agg_split():
     assert sorted([k for k, v in sig.groups()]) == ['control', 'target']
     assert len(list(sig.lefts())) == 2
     assert len(list(sig.rights())) == 2
+    assert sig.n_qubits() == n_targets + 1
 
 
 def test_get_named_qubits_multidim():


### PR DESCRIPTION
This is the minimum number of qubits a bloq must use for input and/or output. A bloq can use more if it allocates more qubits within itself. This is a helpful method for the qubit counting infrastructure. 