### PR TITLE
Improvements to `MultiControlPauli` 

### DIFF
--- a/qualtran/bloqs/chemistry/thc/prepare.py
+++ b/qualtran/bloqs/chemistry/thc/prepare.py
@@ -182,11 +182,11 @@ class UniformSuperpositionTHC(Bloq):
             GreaterThanConstant(num_bits_mu, self.num_spin_orb // 2), x=mu, target=gt_mu_n
         )
         (nu_eq_mp1, gt_mu_n), junk = bb.add(Toffoli(), ctrl=[nu_eq_mp1, gt_mu_n], target=junk)
-        ctrls = bb.join(np.array([lte_nu_mp1, lte_mu_nu, junk]))
-        ctrls, succ = bb.add(
-            MultiControlPauli(cvs=(1, 1, 1), target_gate=cirq.X), controls=ctrls, target=succ
+        (lte_nu_mp1, lte_mu_nu, junk), succ = bb.add(
+            MultiControlPauli(cvs=(1, 1, 1), target_gate=cirq.X),
+            controls=np.array([lte_nu_mp1, lte_mu_nu, junk]),
+            target=succ,
         )
-        lte_nu_mp1, lte_mu_nu, junk = bb.split(ctrls)
         (nu_eq_mp1, gt_mu_n), junk = bb.add(Toffoli(), ctrl=[nu_eq_mp1, gt_mu_n], target=junk)
         nu, lte_nu_mp1 = bb.add(lt_gate, x=nu, target=lte_nu_mp1)
         mu, nu, lte_mu_nu = bb.add(lte_gate, x=mu, y=nu, target=lte_mu_nu)
@@ -405,11 +405,11 @@ class PrepareTHC(PrepareOracle):
         plus_a = bb.add(Hadamard(), q=plus_a)
         plus_b = bb.add(Hadamard(), q=plus_b)
         plus_mn = bb.add(Hadamard(), q=plus_mn)
-        ctrls = bb.join(np.array([nu_eq_mp1, plus_a]))
-        ctrls, extra_ctrl = bb.add(
-            MultiControlPauli(cvs=(0, 1), target_gate=cirq.X), controls=ctrls, target=extra_ctrl
+        (nu_eq_mp1, plus_a), extra_ctrl = bb.add(
+            MultiControlPauli(cvs=(0, 1), target_gate=cirq.X),
+            controls=np.array([nu_eq_mp1, plus_a]),
+            target=extra_ctrl,
         )
-        nu_eq_mp1, plus_a = bb.split(ctrls)
         extra_ctrl, mu, nu = bb.add(CSwap(bitsize=log_mu), ctrl=extra_ctrl, x=mu, y=nu)
         out_regs = {
             'mu': mu,

--- a/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
+++ b/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Tuple
+from typing import Any, Dict, Tuple
 
 import cirq
 import numpy as np
@@ -168,7 +168,24 @@ class MultiControlPauli(GateWithRegisters):
         return and_cost + controlled_pauli_cost + and_inv_cost
 
     def _apply_unitary_(self, args: 'cirq.ApplyUnitaryArgs') -> np.ndarray:
-        return cirq.apply_unitary(self.target_gate.controlled(control_values=self.cvs), args)
+        cpauli = (
+            self.target_gate.controlled(control_values=self.cvs) if self.cvs else self.target_gate
+        )
+        return cirq.apply_unitary(cpauli, args)
+
+    def add_my_tensors(
+        self,
+        tn: 'qtn.TensorNetwork',
+        tag: Any,
+        *,
+        incoming: Dict[str, 'SoquetT'],
+        outgoing: Dict[str, 'SoquetT'],
+    ):
+        from qualtran.cirq_interop._cirq_to_bloq import _add_my_tensors_from_gate
+
+        _add_my_tensors_from_gate(
+            self, self.signature, self.short_name(), tn, tag, incoming=incoming, outgoing=outgoing
+        )
 
     def _has_unitary_(self) -> bool:
         return True

--- a/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
+++ b/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
@@ -33,7 +33,7 @@ from qualtran import (
     SoquetT,
 )
 from qualtran.bloqs.basic_gates import CNOT, Toffoli, XGate
-from qualtran.bloqs.mcmt.and_bloq import And, MultiAnd
+from qualtran.bloqs.mcmt.and_bloq import MultiAnd
 from qualtran.cirq_interop.t_complexity_protocol import t_complexity, TComplexity
 
 
@@ -108,46 +108,63 @@ class MultiControlPauli(GateWithRegisters):
     """
 
     cvs: Tuple[int, ...] = field(converter=lambda v: (v,) if isinstance(v, int) else tuple(v))
-    target_gate: cirq.Pauli = cirq.X
+    target_gate: cirq.Pauli
 
     @cached_property
-    def signature(self) -> Signature:
-        return Signature.build(controls=len(self.cvs), target=1)
+    def signature(self) -> 'Signature':
+        ctrl = Register('controls', QBit(), shape=(len(self.cvs),))
+        target = Register('target', QBit())
+        return Signature([ctrl, target] if len(self.cvs) > 0 else [target])
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray['cirq.Qid']
     ) -> cirq.OP_TREE:
-        controls, target = quregs.get('controls', ()), quregs['target']
-        if len(self.cvs) < 2:
+        controls, target = quregs.get('controls', np.array([])), quregs['target']
+        if len(self.cvs) <= 2:
+            controls = controls.flatten()
+            yield [cirq.X(q) for cv, q in zip(self.cvs, controls) if cv == 0]
             yield self.target_gate.on(*target).controlled_by(*controls)
+            yield [cirq.X(q) for cv, q in zip(self.cvs, controls) if cv == 0]
             return
         qm = context.qubit_manager
         and_ancilla, and_target = np.array(qm.qalloc(len(self.cvs) - 2)), qm.qalloc(1)
-        ctrl, junk = controls[:, np.newaxis], and_ancilla[:, np.newaxis]
-        if len(self.cvs) == 2:
-            and_op = And(*self.cvs).on_registers(ctrl=ctrl, target=and_target)
-        else:
-            and_op = MultiAnd(self.cvs).on_registers(ctrl=ctrl, junk=junk, target=and_target)
+        and_op = MultiAnd(self.cvs).on_registers(
+            ctrl=controls, junk=and_ancilla[:, np.newaxis], target=and_target
+        )
         yield and_op
         yield self.target_gate.on(*target).controlled_by(*and_target)
         yield and_op**-1
         qm.qfree([*and_ancilla, *and_target])
 
     def short_name(self) -> str:
-        return r'$C^{n}(P)$'
+        n = len(self.cvs)
+        ctrl = f'C^{n}' if n > 2 else ['', 'C', 'CC'][n]
+        return f'{ctrl}{self.target_gate!s}'
 
     def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
         wire_symbols = ["@" if b else "@(0)" for b in self.cvs]
         wire_symbols += [str(self.target_gate)]
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
+    def on_classical_vals(self, **vals: 'ClassicalValT') -> Dict[str, 'ClassicalValT']:
+        controls, target = vals.get('controls', np.array([])), vals.get('target')
+        if self.target_gate not in (cirq.X, XGate()):
+            raise NotImplementedError(f"{self} is not classically simulatable.")
+
+        if (self.cvs == controls).all():
+            target = (target + 1) % 2
+
+        return {'controls': controls, 'target': target}
+
     def _t_complexity_(self) -> TComplexity:
-        if len(self.cvs) < 2:
-            return TComplexity(clifford=1)
-        and_gate = And(*self.cvs) if len(self.cvs) == 2 else MultiAnd(self.cvs)
-        and_cost = t_complexity(and_gate)
+        n = len(self.cvs)
+        if n <= 2:
+            pre_post_clifford = TComplexity(clifford=2 * (len(self.cvs) - sum(self.cvs)))
+            target_cost = t_complexity(self.target_gate.controlled(n))
+            return pre_post_clifford + target_cost
+        and_cost = t_complexity(MultiAnd(self.cvs))
         controlled_pauli_cost = t_complexity(self.target_gate.controlled(1))
-        and_inv_cost = t_complexity(and_gate**-1)
+        and_inv_cost = t_complexity(MultiAnd(self.cvs).adjoint())
         return and_cost + controlled_pauli_cost + and_inv_cost
 
     def _apply_unitary_(self, args: 'cirq.ApplyUnitaryArgs') -> np.ndarray:

--- a/qualtran/bloqs/mcmt/multi_control_multi_target_pauli_test.py
+++ b/qualtran/bloqs/mcmt/multi_control_multi_target_pauli_test.py
@@ -61,6 +61,31 @@ def test_multi_control_x(cvs):
         ((1, 1, 1), 1, (1, 1, 1), 0),
         ((1, 0, 1, 0), 1, (1, 0, 1, 0), 0),
         ((1,), 0, (0,), 0),
+        ((), 0, (), 1),
+    ],
+)
+def test_classical_multi_control_pauli_target_x(cvs, x, ctrls, result):
+    bloq = MultiControlPauli(cvs=cvs, target_gate=cirq.X)
+    cbloq = bloq.decompose_bloq()
+    kwargs = {'target': x} | ({'controls': ctrls} if ctrls else {})
+    bloq_classical = bloq.call_classically(**kwargs)
+    cbloq_classical = cbloq.call_classically(**kwargs)
+
+    assert len(bloq_classical) == len(cbloq_classical)
+    for i in range(len(bloq_classical)):
+        np.testing.assert_array_equal(bloq_classical[i], cbloq_classical[i])
+
+    assert bloq_classical[-1] == result
+
+
+@pytest.mark.parametrize(
+    "cvs,x,ctrls,result",
+    [
+        ((0,), 1, (0,), 0),
+        ((1, 0), 0, (1, 0), 1),
+        ((1, 1, 1), 1, (1, 1, 1), 0),
+        ((1, 0, 1, 0), 1, (1, 0, 1, 0), 0),
+        ((1,), 0, (0,), 0),
     ],
 )
 def test_classical_multi_control_x(cvs, x, ctrls, result):

--- a/qualtran/bloqs/mcmt/multi_control_multi_target_pauli_test.py
+++ b/qualtran/bloqs/mcmt/multi_control_multi_target_pauli_test.py
@@ -47,6 +47,16 @@ def test_t_complexity_mcp(num_controls: int, pauli: cirq.Pauli, cv: int):
     assert_decompose_is_consistent_with_t_complexity(gate)
 
 
+@pytest.mark.parametrize("num_controls", [*range(10)])
+@pytest.mark.parametrize("pauli", [cirq.X, cirq.Y, cirq.Z])
+@pytest.mark.parametrize('cv', [0, 1])
+def test_mcp_unitary(num_controls: int, pauli: cirq.Pauli, cv: int):
+    cvs = (cv,) * num_controls
+    gate = MultiControlPauli(cvs, target_gate=pauli)
+    cpauli = pauli.controlled(control_values=cvs) if num_controls else pauli
+    np.testing.assert_allclose(gate.tensor_contract(), cirq.unitary(cpauli))
+
+
 @pytest.mark.parametrize("cvs", [(0,), (1, 0), (1, 1, 1), (1, 0, 1, 0)])
 def test_multi_control_x(cvs):
     bloq = MultiControlX(cvs=cvs)

--- a/qualtran/bloqs/reflection.py
+++ b/qualtran/bloqs/reflection.py
@@ -69,9 +69,8 @@ class Reflection(Bloq):
         # the last qubit is used as the target for the Z
         mcp = MultiControlPauli(cvs=unpacked_cvs[:-1], target_gate=cirq.Z)
         split_regs = np.concatenate([bb.split(r) for r in regs.values()])
-        ctrls, target = bb.add(mcp, controls=bb.join(split_regs[:-1]), target=split_regs[-1])
-        splt_ctrls = bb.split(ctrls)
-        join_regs = np.concatenate([splt_ctrls, [target]])
+        ctrls, target = bb.add(mcp, controls=split_regs[:-1], target=split_regs[-1])
+        join_regs = np.concatenate([ctrls, [target]])
         out_regs = {}
         start = 0
         for i, b in enumerate(self.bitsizes):

--- a/qualtran/bloqs/reflection_using_prepare.py
+++ b/qualtran/bloqs/reflection_using_prepare.py
@@ -17,6 +17,7 @@ from typing import Collection, Optional, Sequence, Tuple, Union
 
 import attrs
 import cirq
+import numpy as np
 from numpy.typing import NDArray
 
 from qualtran import GateWithRegisters, QBit, Register, Signature
@@ -87,10 +88,12 @@ class ReflectionUsingPrepare(GateWithRegisters):
         # 1. PREPARE†
         yield cirq.inverse(prepare_op)
         # 2. MultiControlled Z, controlled on |000..00> state.
-        phase_control = merge_qubits(self.selection_registers, **state_prep_selection_regs)
+        phase_control = np.array(
+            merge_qubits(self.selection_registers, **state_prep_selection_regs)
+        )
         yield cirq.X(phase_target) if not self.control_val else []
         yield MultiControlPauli([0] * len(phase_control), target_gate=cirq.Z).on_registers(
-            controls=phase_control, target=phase_target
+            controls=phase_control.reshape(phase_control.shape + (1,)), target=phase_target
         )
         yield cirq.X(phase_target) if not self.control_val else []
         # 3. PREPARE

--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -186,8 +186,8 @@ def _t_complexity_for_gate_or_op(
 ) -> Optional[TComplexity]:
     strategies = [
         _has_t_complexity,
-        _is_clifford_or_t,
         _from_bloq_build_call_graph,
+        _is_clifford_or_t,
         _from_cirq_decomposition,
     ]
     return _t_complexity_from_strategies(gate_or_op, fail_quietly, strategies)


### PR DESCRIPTION
This PR makes a bunch of improvements to `MultiControlPauli`, some of which are pulled out from https://github.com/quantumlib/Qualtran/pull/765

Specifically

1. `MultiControlPauli` learns classical simulation when target is an X gate
2. A more efficient tensor contraction which doesn't default to decomposing the Bloq; which is more expensive since it uses a bunch of ancilla qubits
3. Change the signature to accept a list of qubits instead of a single n-bit register as control