### PR TITLE
QDTypes learn `to_bits` and `from_bits`

### DIFF
--- a/qualtran/_infra/data_types.py
+++ b/qualtran/_infra/data_types.py
@@ -190,7 +190,7 @@ class QInt(QDType):
         self.assert_valid_classical_val(x)
         return iter_bits_twos_complement(x, self.bitsize)
 
-    def from_bits(self, *bits: int):
+    def from_bits(self, *bits: int) -> int:
         """Combine individual bits to form x"""
         sign = bits[0]
         x = QUInt(self.bitsize - 1).from_bits(*[1 - x if sign else x for x in bits[1:]])
@@ -245,7 +245,7 @@ class QIntOnesComp(QDType):
             ret[i] ^= ret[0]
         return ret
 
-    def from_bits(self, *bits: int):
+    def from_bits(self, *bits: int) -> int:
         """Combine individual bits to form x"""
         x = QUInt(self.bitsize).from_bits(*[x ^ bits[0] for x in bits[1:]])
         return (-1) ** bits[0] * x
@@ -287,7 +287,7 @@ class QUInt(QDType):
         self.assert_valid_classical_val(x)
         return iter_bits(x, self.bitsize)
 
-    def from_bits(self, *bits: int):
+    def from_bits(self, *bits: int) -> int:
         """Combine individual bits to form x"""
         return int("".join(str(x) for x in bits), 2)
 
@@ -390,7 +390,7 @@ class BoundedQUInt(QDType):
         self.assert_valid_classical_val(x)
         return iter_bits(x, self.bitsize, signed=False)
 
-    def from_bits(self, *bits: int):
+    def from_bits(self, *bits: int) -> int:
         """Combine individual bits to form x"""
         return QUInt(self.bitsize).from_bits(*bits)
 
@@ -508,10 +508,10 @@ class QMontgomeryUInt(QDType):
     def get_classical_domain(self) -> Iterable[Any]:
         return range(2 ** (self.bitsize))
 
-    def to_bits(self, n: int) -> Iterable[Any]:
+    def to_bits(self, x: int) -> Iterable[int]:
         raise NotImplementedError(f"to_bits not implemented for {self}")
 
-    def from_bits(self, n: int) -> Iterable[Any]:
+    def from_bits(self, *bits: int) -> int:
         raise NotImplementedError(f"from_bits not implemented for {self}")
 
     def assert_valid_classical_val(self, val: int, debug_str: str = 'val'):

--- a/qualtran/_infra/data_types_test.py
+++ b/qualtran/_infra/data_types_test.py
@@ -213,22 +213,25 @@ def test_to_and_from_bits():
     # QInt
     qint4 = QInt(4)
     for x in range(-8, 8):
-        assert qint4.from_bits(*qint4.to_bits(x)) == x
+        assert qint4.from_bits(qint4.to_bits(x)) == x
     assert list(qint4.to_bits(-2)) == [1, 1, 1, 0]
     assert list(QInt(4).to_bits(2)) == [0, 0, 1, 0]
-    assert qint4.from_bits(*qint4.to_bits(-2)) == -2
-    assert qint4.from_bits(*qint4.to_bits(2)) == 2
+    assert qint4.from_bits(qint4.to_bits(-2)) == -2
+    assert qint4.from_bits(qint4.to_bits(2)) == 2
     with pytest.raises(ValueError):
         QInt(4).to_bits(10)
 
     # QUInt
     quint4 = QUInt(4)
     assert list(quint4.to_bits(10)) == [1, 0, 1, 0]
-    assert quint4.from_bits(*quint4.to_bits(10)) == 10
+    assert quint4.from_bits(quint4.to_bits(10)) == 10
     for x in range(16):
-        assert quint4.from_bits(*quint4.to_bits(x)) == x
+        assert quint4.from_bits(quint4.to_bits(x)) == x
     with pytest.raises(ValueError):
         quint4.to_bits(16)
+
+    with pytest.raises(ValueError):
+        quint4.to_bits(-1)
 
     # BoundedQUInt
     bquint4 = BoundedQUInt(4, 12)
@@ -250,19 +253,34 @@ def test_to_and_from_bits():
     assert list(qintones4.to_bits(-2)) == [1, 1, 0, 1]
     assert list(qintones4.to_bits(2)) == [0, 0, 1, 0]
     for x in range(-7, 8):
-        assert qintones4.from_bits(*qintones4.to_bits(x)) == x
+        assert qintones4.from_bits(qintones4.to_bits(x)) == x
+    with pytest.raises(ValueError):
+        qintones4.to_bits(8)
+    with pytest.raises(ValueError):
+        qintones4.to_bits(-8)
 
     # QFxp: Negative numbers are stored as ones complement
     qfxp_4_3 = QFxp(4, 3, True)
     assert list(qfxp_4_3.to_bits(0.5)) == [0, 1, 0, 0]
-    assert qfxp_4_3.from_bits(*qfxp_4_3.to_bits(0.5)).get_val() == 0.5
+    assert qfxp_4_3.from_bits(qfxp_4_3.to_bits(0.5)).get_val() == 0.5
     assert list(qfxp_4_3.to_bits(-0.5)) == [1, 1, 0, 0]
-    assert qfxp_4_3.from_bits(*qfxp_4_3.to_bits(-0.5)).get_val() == -0.5
+    assert qfxp_4_3.from_bits(qfxp_4_3.to_bits(-0.5)).get_val() == -0.5
     assert list(qfxp_4_3.to_bits(0.625)) == [0, 1, 0, 1]
-    assert qfxp_4_3.from_bits(*qfxp_4_3.to_bits(+0.625)).get_val() == +0.625
-    assert qfxp_4_3.from_bits(*qfxp_4_3.to_bits(-0.625)).get_val() == -0.625
+    assert qfxp_4_3.from_bits(qfxp_4_3.to_bits(+0.625)).get_val() == +0.625
+    assert qfxp_4_3.from_bits(qfxp_4_3.to_bits(-0.625)).get_val() == -0.625
     assert list(QFxp(4, 3, True).to_bits(-(1 - 0.625))) == [1, 1, 0, 1]
-    assert qfxp_4_3.from_bits(*qfxp_4_3.to_bits(0.375)).get_val() == 0.375
-    assert qfxp_4_3.from_bits(*qfxp_4_3.to_bits(-0.375)).get_val() == -0.375
+    assert qfxp_4_3.from_bits(qfxp_4_3.to_bits(0.375)).get_val() == 0.375
+    assert qfxp_4_3.from_bits(qfxp_4_3.to_bits(-0.375)).get_val() == -0.375
+    with pytest.raises(ValueError):
+        _ = qfxp_4_3.to_bits(0.1)
+
+    with pytest.raises(ValueError):
+        _ = qfxp_4_3.to_bits(1.5)
+
+    assert qfxp_4_3.from_bits(qfxp_4_3.to_bits(1 / 2 + 1 / 4 + 1 / 8)) == 1 / 2 + 1 / 4 + 1 / 8
+    assert qfxp_4_3.from_bits(qfxp_4_3.to_bits(-1 / 2 - 1 / 4 - 1 / 8)) == -1 / 2 - 1 / 4 - 1 / 8
+    with pytest.raises(ValueError):
+        _ = qfxp_4_3.to_bits(1 / 2 + 1 / 4 + 1 / 8 + 1 / 16)
+
     assert list(QFxp(7, 3, True).to_bits(-4.375)) == [1] + [0, 1, 1] + [1, 0, 1]
     assert list(QFxp(7, 3, True).to_bits(+4.625)) == [0] + [1, 0, 0] + [1, 0, 1]

--- a/qualtran/_infra/data_types_test.py
+++ b/qualtran/_infra/data_types_test.py
@@ -212,6 +212,7 @@ def test_single_qubit_consistency():
 def test_to_and_from_bits():
     # QInt
     qint4 = QInt(4)
+    assert [*qint4.get_classical_domain()] == [*range(-8, 8)]
     for x in range(-8, 8):
         assert qint4.from_bits(qint4.to_bits(x)) == x
     assert list(qint4.to_bits(-2)) == [1, 1, 1, 0]
@@ -223,6 +224,7 @@ def test_to_and_from_bits():
 
     # QUInt
     quint4 = QUInt(4)
+    assert [*quint4.get_classical_domain()] == [*range(0, 16)]
     assert list(quint4.to_bits(10)) == [1, 0, 1, 0]
     assert quint4.from_bits(quint4.to_bits(10)) == 10
     for x in range(16):
@@ -235,6 +237,7 @@ def test_to_and_from_bits():
 
     # BoundedQUInt
     bquint4 = BoundedQUInt(4, 12)
+    assert [*bquint4.get_classical_domain()] == [*range(0, 12)]
     assert list(bquint4.to_bits(10)) == [1, 0, 1, 0]
     with pytest.raises(ValueError):
         BoundedQUInt(4, 12).to_bits(13)
@@ -252,6 +255,7 @@ def test_to_and_from_bits():
     qintones4 = QIntOnesComp(4)
     assert list(qintones4.to_bits(-2)) == [1, 1, 0, 1]
     assert list(qintones4.to_bits(2)) == [0, 0, 1, 0]
+    assert [*qintones4.get_classical_domain()] == [*range(-7, 8)]
     for x in range(-7, 8):
         assert qintones4.from_bits(qintones4.to_bits(x)) == x
     with pytest.raises(ValueError):
@@ -281,6 +285,10 @@ def test_to_and_from_bits():
     assert qfxp_4_3.from_bits(qfxp_4_3.to_bits(-1 / 2 - 1 / 4 - 1 / 8)) == -1 / 2 - 1 / 4 - 1 / 8
     with pytest.raises(ValueError):
         _ = qfxp_4_3.to_bits(1 / 2 + 1 / 4 + 1 / 8 + 1 / 16)
+
+    for qfxp in [QFxp(4, 3, True), QFxp(3, 3, False), QFxp(7, 3, False), QFxp(7, 3, True)]:
+        for x in qfxp.get_classical_domain():
+            assert qfxp.from_bits(qfxp.to_bits(x)) == x
 
     assert list(QFxp(7, 3, True).to_bits(-4.375)) == [1] + [0, 1, 1] + [1, 0, 1]
     assert list(QFxp(7, 3, True).to_bits(+4.625)) == [0] + [1, 0, 0] + [1, 0, 1]


### PR DESCRIPTION
This is useful to support classical and tensor simulations and support conversion of control values to Cirq. I'll demonstrate usage in follow-up PRs. 

cc @fdmalone 
