### PR TITLE
[wip] Quimb Controlled

### DIFF
--- a/qualtran/Controlled.ipynb
+++ b/qualtran/Controlled.ipynb
@@ -57,8 +57,8 @@
     "from qualtran import CtrlSpec\n",
     "\n",
     "ctrl_spec = CtrlSpec(cvs=[0, 1, 0, 1])\n",
-    "cx = x.controlled(ctrl_spec=ctrl_spec)\n",
-    "show_bloq(cx, type='musical_score')"
+    "cnx = x.controlled(ctrl_spec=ctrl_spec)\n",
+    "show_bloq(cnx, type='musical_score')"
    ]
   },
   {
@@ -190,6 +190,44 @@
     "ccx3 = OnEach(n=3, gate=x).controlled(CtrlSpec(cvs=(1,1)))\n",
     "show_bloq(ccx3.decompose_bloq(), type='musical_score')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3920e60-d4dc-418e-9d21-64758b8a32d2",
+   "metadata": {},
+   "source": [
+    "## Tensor Simulation\n",
+    "\n",
+    "The `Controlled` bloq has special support for tensor network simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a812c87-bf07-4479-ba0f-b585c9b5ebdd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cnx.tensor_contract()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4eed1f45-3024-4472-ab9f-6801dc77e23f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%debug"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b910b59-b4d9-406b-9bea-25dfe735044a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -208,7 +246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/qualtran/simulation/tensor.ipynb
+++ b/qualtran/simulation/tensor.ipynb
@@ -122,6 +122,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6118273-8db0-4096-8162-5396d70dc0f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.basic_gates import TwoBitSwap\n",
+    "\n",
+    "bloq = TwoBitSwap()\n",
+    "cbloq = bloq.as_composite_bloq()\n",
+    "#cbloq = bloq.decompose_bloq()\n",
+    "show_bloq(cbloq)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "2dd02b3b",
    "metadata": {},
@@ -136,10 +151,85 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qualtran.simulation.tensor import cbloq_to_quimb\n",
+    "from qualtran.simulation.tensor import cbloq_to_quimb, cbloq_as_contracted_tensor\n",
     "\n",
     "tn, fix = cbloq_to_quimb(cbloq)\n",
-    "tn.draw(show_inds=False)"
+    "tn.draw()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59eed5d2-4372-4536-a24f-3d4067a2d984",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def my_active(a, b):\n",
+    "    return a == b\n",
+    "\n",
+    "from qualtran.simulation.tensor._controlled import _get_ctrl_tensor_data\n",
+    "\n",
+    "ctrl = _get_ctrl_tensor_data(n_ctrl=2, is_active_func=my_active)\n",
+    "ctrl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "364d2812-4d3c-4b0c-a4fc-fb741bc242a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qualtran import LeftDangle, RightDangle\n",
+    "\n",
+    "left_inds = [soq for soq in tn.outer_inds() if soq.binst is LeftDangle]\n",
+    "right_inds = [soq for soq in tn.outer_inds() if soq.binst is RightDangle]\n",
+    "\n",
+    "print(left_inds)\n",
+    "print(right_inds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5e9f202-1b40-4666-8b22-4255795ec35a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = cbloq_as_contracted_tensor(cbloq, {'x': 'ix', 'y': 'iy'}, {'x': 'ox', 'y': 'oy'}, [])\n",
+    "linds = [soq for soq in a.inds if soq.startswith('i')]\n",
+    "rinds = [soq for soq in a.inds if soq.startswith('o')]\n",
+    "print(linds)\n",
+    "print(rinds)\n",
+    "a.new_ind_with_identity('asdf', linds, rinds)\n",
+    "a.draw()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0f19497-2404-447a-87b6-ef907f5bbe4f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aa = a.to_dense(['asdf'], linds, rinds)\n",
+    "aa[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ad9822c-4a7f-4c5e-be0b-428a58483876",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inds = ('c1i', 'c2i', 'c1o', 'c20', 'asdf')\n",
+    "\n",
+    "import quimb.tensor as qtn\n",
+    "btn = qtn.TensorNetwork()\n",
+    "btn.add(qtn.Tensor(data=ctrl, inds=inds))\n",
+    "btn.add(a)\n",
+    "btn.draw()"
    ]
   },
   {
@@ -148,16 +238,6 @@
    "metadata": {},
    "source": [
     "The entire suite of Quimb tools are now available."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8365af84",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tn.contraction_info()"
    ]
   },
   {
@@ -326,7 +406,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/qualtran/simulation/tensor/_controlled.py
+++ b/qualtran/simulation/tensor/_controlled.py
@@ -1,0 +1,112 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import itertools
+from typing import Any, Callable, Dict, List, Sequence, Hashable
+
+import numpy as np
+import quimb.tensor as qtn
+from numpy.typing import NDArray
+
+from qualtran import Bloq, LeftDangle, RightDangle, SoquetT
+
+from ._quimb import cbloq_as_contracted_tensor, cbloq_to_quimb
+
+
+def _get_ctrl_tensor_data(n_ctrl: int, is_active_func: Callable[[Any, ...], bool]) -> NDArray:
+    """Get an ndarray for a factorized control tensor.
+
+    This tensor copies `n_ctrl` input legs to their same output values and activates the
+    orthogonal `internal_ctrl_ind` leg where the control values are active (relative to the provided
+    activation function).
+
+    NOTE! the `is_active` leg is *active low* to correspond to
+    `qtn.Tensor.new_ind_with_identity()`. A `True` return from `is_active_func` corresponds
+    to the index value 0.
+
+    The ndarray has indices ordered:
+    (ctrl1_in, ... cntrln_in, ctrl1_out, ... cntrln_out, internal_ctrl_ind).
+    """
+    # TODO: this must use the ctrl_spec data types and shapes.
+
+    # Each ctrl line has an input and output
+    # plus the orthogonal activation leg.
+    n_dim = 2 * n_ctrl + 1
+
+    ctrl_tensor = np.zeros((2,) * n_dim, dtype=np.complex128)
+    for ctrl_vals in itertools.product([0, 1], repeat=n_ctrl):
+        is_active = 1 - int(is_active_func(*ctrl_vals))
+        ctrl_tensor[ctrl_vals + ctrl_vals + (is_active,)] = 1.0
+
+    return ctrl_tensor
+
+
+def _get_ctrl_tensor(
+    ctrl_reg_names: Sequence[str],
+    is_active_func: Callable[[Any, ...], bool],
+    incoming: Dict[str, Hashable],
+    outgoing: Dict[str, Hashable],
+    internal_ctrl_ind: str,
+) -> qtn.Tensor:
+    """Produce a factorized control tensor.
+
+    This needs to be joined with an appropriate bloq tensor along `internal_ctrl_ind` to
+    represent a full gate.
+
+    Args:
+        ctrl_reg_names: The register names that correspond to the control registers. Used
+            to index into `incoming` and `outgoing.`
+        is_active_func: A predicate that reports whether a given set of control values
+            correspond to an activated bloq.
+        incoming: A superset of incoming indices by register name. We'll select out those
+            that correspond to controls using `ctrl_reg_names`.
+        outgoing: A superset of outgoing indices by register name. We'll select out those
+            that correspond to controls using `ctrl_reg_names`.
+        internal_ctrl_ind: The name of the additional (internal) index. This index is active low!
+            An index value of 0 corresponds to an activated tensor.
+    """
+    # i_ctrls = tuple(itertools.chain.from_iterable(incoming[creg_name].reshape(-1) for creg_name in ctrl_reg_names))
+    # o_ctrls = tuple(itertools.chain.from_iterable(outgoing[creg_name].reshape(-1) for creg_name in ctrl_reg_names))
+    i_ctrls = tuple(incoming[creg_name] for creg_name in ctrl_reg_names)
+    o_ctrls = tuple(outgoing[creg_name] for creg_name in ctrl_reg_names)
+    ctrl_tensor = _get_ctrl_tensor_data(n_ctrl=len(i_ctrls), is_active_func=is_active_func)
+    return qtn.Tensor(data=ctrl_tensor, inds=i_ctrls + o_ctrls + (internal_ctrl_ind,))
+
+
+def _get_ctrled_tensor_for_bloq(
+    bloq: 'Bloq',
+    incoming: Dict[str, 'SoquetT'],
+    outgoing: Dict[str, 'SoquetT'],
+    internal_ctrl_ind: str,
+) -> qtn.Tensor:
+    """Get a tensor for a bloq with one additional control-like index.
+
+    This needs to be joined with an appropriate control tensor along `internal_ctrl_ind` to
+    represent a full gate.
+
+    Args:
+        bloq: The bloq to contract and control.
+        incoming: A superset of incoming indices by register name. We'll select out the
+            indices for the (uncontrolled) `bloq`.
+        outgoing: A superset of outgoing indices by register name. We'll select out the
+            indices for the (uncontrolled) `bloq`.
+        internal_ctrl_ind: The name of the additional (internal) index. This index is active low!
+            An index value of 0 corresponds to an activated tensor.
+    """
+    tensor = cbloq_as_contracted_tensor(
+        bloq.as_composite_bloq(), incoming=incoming, outgoing=outgoing
+    )
+    left_inds = [soq for soq in tensor.inds if soq.binst is LeftDangle]
+    right_inds = [soq for soq in tensor.inds if soq.binst is RightDangle]
+    tensor.new_ind_with_identity(name=internal_ctrl_ind, left_inds=left_inds, right_inds=right_inds)
+    return tensor

--- a/qualtran/simulation/tensor/_controlled_test.py
+++ b/qualtran/simulation/tensor/_controlled_test.py
@@ -1,0 +1,107 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import quimb.tensor as qtn
+
+from qualtran.simulation.tensor._controlled import _get_ctrl_tensor, _get_ctrled_tensor_for_bloq, \
+    _get_ctrl_tensor_data
+import numpy as np
+from numpy.typing import NDArray
+
+_PAULI_X = np.array([[0,1], [1,0]])
+_PAULI_X = np.array([[0.1,0.2], [0.3,0.4]])
+
+def test_get_ctrl_data():
+    def _is_active_1(cv: int):
+        return bool(cv)
+    td = _get_ctrl_tensor_data(n_ctrl=1, is_active_func=_is_active_1)
+    print()
+    for cv, not_active in np.where(td):
+        if cv:
+            assert not_active == 0
+        else:
+            assert not_active == 1
+    print(np.where(td))
+    print()
+
+def test_ctrl():
+    incoming = {
+        'c1': 'c1i',
+        'c2': 'c2i',
+        'x': 'xi',
+    }
+    outgoing = {
+        'c1': 'c1o',
+        'c2': 'c2o',
+        'x': 'xo',
+    }
+    ctrl_reg_names = ['c1', 'c2']
+
+    def _is_active(c1:int, c2: int) -> bool:
+        return (c1 == 0 and c2 == 0)
+
+    internal_ctrl_ind = qtn.rand_uuid()
+    ctrl_tensor = _get_ctrl_tensor(
+        ctrl_reg_names,
+        is_active_func=_is_active,
+        incoming=incoming,
+        outgoing=outgoing,
+        internal_ctrl_ind=internal_ctrl_ind,
+    )
+
+    left_inds = ['xi']
+    right_inds = ['xo']
+    tensor = qtn.Tensor(data=_PAULI_X, inds=right_inds+left_inds)
+    tensor.new_ind_with_identity(name=internal_ctrl_ind, left_inds=left_inds, right_inds=right_inds)
+
+    res = ctrl_tensor & tensor
+    mat = res.to_dense(('c1o', 'c2o', 'xo'), ('c1i', 'c2i', 'xi'))
+    print()
+    print(mat.astype(float))
+    print()
+
+
+def test_ctrl_shaped():
+    incoming = {
+        'cc': np.array([['c00i', 'c01i'],['c10i', 'c11i']]),
+        'x': 'xi',
+    }
+    outgoing = {
+        'cc': np.array([['c00o', 'c01o'],['c10o', 'c11o']]),
+        'x': 'xo',
+    }
+    ctrl_reg_names = ['cc']
+
+    def _is_active(cc: NDArray[int]) -> bool:
+        return np.all(cc)
+
+    internal_ctrl_ind = qtn.rand_uuid()
+    ctrl_tensor = _get_ctrl_tensor(
+        ctrl_reg_names,
+        is_active_func=_is_active,
+        incoming=incoming,
+        outgoing=outgoing,
+        internal_ctrl_ind=internal_ctrl_ind,
+    )
+
+    left_inds = ['xi']
+    right_inds = ['xo']
+    tensor = qtn.Tensor(data=_PAULI_X, inds=right_inds+left_inds)
+    tensor.new_ind_with_identity(name=internal_ctrl_ind, left_inds=left_inds, right_inds=right_inds)
+
+    res = ctrl_tensor & tensor
+    mat = res.to_dense(('c00i', 'c01i', 'c10i', 'c11i', 'xi'), ('c00o', 'c01o', 'c10o', 'c11o', 'xo'))
+    print()
+    print(mat.astype(float))
+    print()


### PR DESCRIPTION
@tanujkhattar this is what I've got so far for quimb support for tensor contraction of controlled bloqs. This is how I'd like it to be structured (i.e. `_get_ctrled_tensor_for_bloq` and `_get_ctrl_tensor`); but the implementation of `get_ctrl_tensor` needs to actually support CtrlSpec dtypes and shapes and all that jazz. 