### PR TITLE
Fix bug in `TGate.as_cirq_op` when `is_adjoint=True`

### DIFF
--- a/qualtran/bloqs/basic_gates/t_gate.py
+++ b/qualtran/bloqs/basic_gates/t_gate.py
@@ -104,7 +104,8 @@ class TGate(Bloq):
         import cirq
 
         (q,) = q
-        return cirq.T(q), {'q': np.array([q])}
+        pow = -1 if self.is_adjoint else 1
+        return cirq.T(q) ** pow, {'q': np.array([q])}
 
     def pretty_name(self) -> str:
         maybe_dag = '†' if self.is_adjoint else ''

--- a/qualtran/bloqs/basic_gates/t_gate.py
+++ b/qualtran/bloqs/basic_gates/t_gate.py
@@ -104,8 +104,8 @@ class TGate(Bloq):
         import cirq
 
         (q,) = q
-        pow = -1 if self.is_adjoint else 1
-        return cirq.T(q) ** pow, {'q': np.array([q])}
+        p = -1 if self.is_adjoint else 1
+        return cirq.T(q) ** p, {'q': np.array([q])}
 
     def pretty_name(self) -> str:
         maybe_dag = '†' if self.is_adjoint else ''

--- a/qualtran/bloqs/basic_gates/t_gate_test.py
+++ b/qualtran/bloqs/basic_gates/t_gate_test.py
@@ -35,9 +35,10 @@ def test_to_cirq():
     bb = BloqBuilder()
     q = bb.add(PlusState())
     q = bb.add(TGate(), q=q)
+    q = bb.add(TGate(is_adjoint=True), q=q)
     cbloq = bb.finalize(q=q)
     circuit, _ = cbloq.to_cirq_circuit()
-    cirq.testing.assert_has_diagram(circuit, "_c(0): ───H───T───")
+    cirq.testing.assert_has_diagram(circuit, "_c(0): ───H───T───T^-1───")
 
 
 def test_tensors():


### PR DESCRIPTION
`TGate(is_adjoint=True).as_cirq_op` should return `cirq.T ** -1` but currently returns `cirq.T`. This is bad an was discovered when playing with https://github.com/quantumlib/Qualtran/pull/803