### PR TITLE
`GateWithRegisters.controlled()` now returns `BloqAsCirqGate(Controlled())` instead of `cirq.Controlled` gate.

### DIFF
--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -318,7 +318,6 @@ class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
         control_values=None,
         control_qid_shape: Optional[Tuple[int, ...]] = None,
     ) -> 'cirq.Gate':
-        # Multiple inheritance: use the `cirq.Gate` method.
         from qualtran.cirq_interop import BloqAsCirqGate
 
         controlled_gate = cirq.ControlledGate(

--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -21,6 +21,7 @@ from numpy.typing import NDArray
 
 from qualtran._infra.bloq import Bloq, DecomposeNotImplementedError, DecomposeTypeError
 from qualtran._infra.composite_bloq import CompositeBloq
+from qualtran._infra.controlled import Controlled, CtrlSpec
 from qualtran._infra.quantum_graph import Soquet
 from qualtran._infra.registers import Register, Side
 
@@ -318,12 +319,42 @@ class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
         control_qid_shape: Optional[Tuple[int, ...]] = None,
     ) -> 'cirq.Gate':
         # Multiple inheritance: use the `cirq.Gate` method.
-        return cirq.Gate.controlled(
+        from qualtran.cirq_interop import BloqAsCirqGate
+
+        controlled_gate = cirq.ControlledGate(
             self,
             num_controls=num_controls,
             control_values=control_values,
             control_qid_shape=control_qid_shape,
         )
+        ctrl_spec = CtrlSpec.from_cirq_cv(controlled_gate.control_values)
+        return BloqAsCirqGate(Controlled(self, ctrl_spec))
+
+    def _unitary_(self):
+        return NotImplemented
+
+    def add_my_tensors(
+        self,
+        tn: 'qtn.TensorNetwork',
+        tag: 'Any',
+        *,
+        incoming: Dict[str, 'SoquetT'],
+        outgoing: Dict[str, 'SoquetT'],
+    ):
+        if not self._unitary_.__qualname__.startswith('GateWithRegisters.'):
+            from qualtran.cirq_interop._cirq_to_bloq import _add_my_tensors_from_gate
+
+            _add_my_tensors_from_gate(
+                self,
+                self.signature,
+                self.short_name(),
+                tn,
+                tag,
+                incoming=incoming,
+                outgoing=outgoing,
+            )
+        else:
+            return super().add_my_tensors(tn, tag, incoming=incoming, outgoing=outgoing)
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
         """Default diagram info that uses register names to name the boxes in multi-qubit gates.

--- a/qualtran/_infra/gate_with_registers_test.py
+++ b/qualtran/_infra/gate_with_registers_test.py
@@ -15,6 +15,7 @@
 from typing import Dict
 
 import cirq
+import numpy as np
 import pytest
 
 from qualtran import GateWithRegisters, QAny, QBit, Register, Side, Signature, SoquetT
@@ -47,6 +48,22 @@ def test_gate_with_registers():
     op1 = tg.on_registers(r1=qubits[:5], r2=qubits[6:], r3=qubits[5])
     op2 = tg.on(*qubits[:5], *qubits[6:], qubits[5])
     assert op1 == op2
+
+    np.testing.assert_allclose(cirq.unitary(tg), tg.tensor_contract())
+
+
+class _TestGateAtomic(GateWithRegisters):
+    @property
+    def signature(self) -> Signature:
+        return Signature.build(q=4)
+
+    def _unitary_(self) -> cirq.OP_TREE:
+        return cirq.unitary(cirq.Circuit(cirq.H.on_each(cirq.LineQubit.range(4))))
+
+
+def test_gate_with_registers_uses_unitary_for_tensor_contraction():
+    tg = _TestGateAtomic()
+    np.testing.assert_allclose(cirq.unitary(tg), tg.tensor_contract())
 
 
 class BloqWithDecompose(GateWithRegisters):

--- a/qualtran/bloqs/generalized_qsp_test.py
+++ b/qualtran/bloqs/generalized_qsp_test.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Any, Dict, Sequence, Tuple, Union
+from typing import Sequence, Tuple, Union
 
 import cirq
 import numpy as np

--- a/qualtran/bloqs/generalized_qsp_test.py
+++ b/qualtran/bloqs/generalized_qsp_test.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Sequence, Union
+from typing import Any, Dict, Sequence, Tuple, Union
 
 import cirq
 import numpy as np
@@ -113,19 +113,19 @@ def test_real_polynomial_has_real_complementary_polynomial(degree: int):
 @frozen
 class RandomGate(GateWithRegisters):
     bitsize: int
-    matrix: NDArray
+    matrix: Tuple[Tuple[int, ...], ...]
 
     @staticmethod
     def create(bitsize: int, *, random_state=None) -> 'RandomGate':
         matrix = random_unitary(2**bitsize, random_state=random_state)
-        return RandomGate(bitsize, matrix)
+        return RandomGate(bitsize, tuple(tuple(x) for x in matrix.tolist()))
 
     @property
     def signature(self) -> Signature:
         return Signature.build(q=self.bitsize)
 
     def _unitary_(self):
-        return self.matrix
+        return np.array(self.matrix)
 
 
 def evaluate_polynomial_of_matrix(P: Sequence[complex], U: NDArray) -> NDArray:

--- a/qualtran/bloqs/util_bloqs.py
+++ b/qualtran/bloqs/util_bloqs.py
@@ -37,6 +37,7 @@ from qualtran import (
 )
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import directional_text_box, WireSymbol
+from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
 from qualtran.simulation.classical_sim import bits_to_ints, ints_to_bits
 
 if TYPE_CHECKING:
@@ -488,12 +489,13 @@ class Power(Bloq):
     """
 
     bloq: Bloq
-    power: int
+    power: SymbolicInt
 
     def __attrs_post_init__(self):
         if any(reg.side != Side.THRU for reg in self.bloq.signature):
             raise ValueError('Bloq to repeat must have only THRU registers')
-        assert self.power >= 1
+        if self.power < 1:
+            raise ValueError(f'{self.power=} must be a positive integer.')
 
     def adjoint(self) -> 'Bloq':
         return Power(self.bloq.adjoint(), self.power)

--- a/qualtran/bloqs/util_bloqs_test.py
+++ b/qualtran/bloqs/util_bloqs_test.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 from functools import cached_property
 from typing import Dict, Type
 
@@ -24,7 +23,7 @@ from qualtran import Bloq, BloqBuilder, QAny, QFxp, QInt, Register, Side, Signat
 from qualtran._infra.gate_with_registers import get_named_qubits
 from qualtran.bloqs.basic_gates import CNOT, XGate
 from qualtran.bloqs.for_testing import TestCastToFrom, TestMultiRegister
-from qualtran.bloqs.util_bloqs import Allocate, Cast, Free, Join, Partition, Split
+from qualtran.bloqs.util_bloqs import Allocate, Cast, Free, Join, Partition, Power, Split
 from qualtran.simulation.classical_sim import call_cbloq_classically
 from qualtran.simulation.tensor import bloq_to_dense, cbloq_to_quimb
 from qualtran.testing import assert_valid_bloq_decomposition, execute_notebook
@@ -216,6 +215,22 @@ def test_cast_classical_sim():
     (a, b) = bloq.call_classically(a=7, b=2)
     assert a == 7
     assert b == 9
+
+
+def test_power():
+    with pytest.raises(ValueError, match="THRU"):
+        from qualtran.bloqs.mcmt import And
+
+        _ = Power(And(), 2)
+
+    bloq = TestMultiRegister()
+    with pytest.raises(ValueError, match="positive"):
+        _ = Power(bloq, -2)
+
+    bloq_raised_to_power = Power(bloq, 10)
+    assert bloq_raised_to_power.signature == bloq.signature
+    cbloq = bloq_raised_to_power.decompose_bloq()
+    assert [binst.bloq for binst, _, _ in cbloq.iter_bloqnections()] == [bloq] * 10
 
 
 @pytest.mark.notebook

--- a/qualtran/cirq_interop/cirq_interop.ipynb
+++ b/qualtran/cirq_interop/cirq_interop.ipynb
@@ -457,55 +457,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "896e0392-3f1f-4965-bb13-0a541581ec25",
-   "metadata": {},
-   "source": [
-    "## Test `Cirq -> Bloqs -> Cirq` roundtrip using `QROM`\n",
-    "\n",
-    "Another example is to import the data loading oracle QROM from Cirq into Qualtran by wrapping it into a `CirqGateAsBloq`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "978141e4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from qualtran.bloqs.data_loading.qrom import QROM\n",
-    "from qualtran._infra.gate_with_registers import get_named_qubits\n",
-    "from qualtran.drawing import get_musical_score_data, draw_musical_score\n",
-    "# Ensure no information is lost in Cirq -> Bloqs -> Cirq conversion.\n",
-    "cirq_qrom = QROM.build([10, 20, 30], num_controls=1)\n",
-    "quregs = get_named_qubits(cirq_qrom.signature)\n",
-    "circuit = cirq.Circuit(cirq.decompose_once(cirq_qrom.on_registers(**quregs)))\n",
-    "print(circuit)\n",
-    "qrom_gate_via_bloq = BloqAsCirqGate(CirqGateAsBloq(cirq_qrom))\n",
-    "circuit_roundrip = cirq.Circuit(cirq.decompose_once(qrom_gate_via_bloq.on_registers(**quregs)))\n",
-    "print(circuit_roundrip)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "52765449-acc2-4673-b7f4-f2add2b83c66",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# The same decomposition can be obtained by directly decomposing the corresponding Bloq.\n",
-    "# 1. Decompose wrapped Bloq directly to obtain the Composite Bloq for QROM.\n",
-    "bloq = CirqGateAsBloq(cirq_qrom)\n",
-    "cbloq = bloq.decompose_bloq()\n",
-    "fig, ax = draw_musical_score(get_musical_score_data(cbloq))\n",
-    "fig.set_size_inches(16, 5)\n",
-    "# 2. Convert Cirq decomposed circuit to composite Bloq.\n",
-    "cbloq = cirq_optree_to_cbloq(circuit, signature=bloq.signature, in_quregs=quregs, out_quregs=quregs)\n",
-    "fig, ax = draw_musical_score(get_musical_score_data(cbloq))\n",
-    "fig.set_size_inches(16, 5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "8ec19639-ae2d-4a66-91eb-8cd4d10068ef",
    "metadata": {},
    "source": [
@@ -521,6 +472,7 @@
    "source": [
     "from qualtran.bloqs.factoring.mod_exp import ModExp\n",
     "from qualtran.drawing import show_bloq\n",
+    "from qualtran.drawing import get_musical_score_data, draw_musical_score\n",
     "N = 13*17\n",
     "n = int(np.ceil(np.log2(N)))\n",
     "g = 8\n",
@@ -582,7 +534,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/qualtran/serialization/resolver_dict.py
+++ b/qualtran/serialization/resolver_dict.py
@@ -318,6 +318,7 @@ RESOLVER_DICT = {
     "qualtran.bloqs.util_bloqs.Free": qualtran.bloqs.util_bloqs.Free,
     "qualtran.bloqs.util_bloqs.Join": qualtran.bloqs.util_bloqs.Join,
     "qualtran.bloqs.util_bloqs.Partition": qualtran.bloqs.util_bloqs.Partition,
+    "qualtran.bloqs.util_bloqs.Power": qualtran.bloqs.util_bloqs.Power,
     "qualtran.bloqs.util_bloqs.Split": qualtran.bloqs.util_bloqs.Split,
 }
 


### PR DESCRIPTION
This is a step towards using the new `Controlled` bloq instead of `cirq.Controlled` gate throghout the library. Eventually, we'd to update all the call sites so that `GateWithRegisters.controlled` follows the same api as `Bloq.controlled` but as a step towards this direction; this PR ensures that we move away from using `cirq.Controlled` gate and always stay in Qualtran land. 


Note: This further regressed the CI time from ~17m to ~19m due to https://github.com/quantumlib/Qualtran/issues/793 and the fact that `Controlled` bloq is not a `GateWithRegisters`, it cannot use the underlying unitary even when it wraps a `GateWithRegisters` bloq, when doing cirq style simulations. Using the `Controlled` bloq in cirq-style simulations forces us to go via tensor contraction. Making it a `GateWithRegisters` would circumvent this but this can be addressed in follow-up PRs if needed. cc @mpharrigan 

