### PR TITLE
Bugfix in `CtrlSpec` serialization

### DIFF
--- a/qualtran/protos/ctrl_spec.proto
+++ b/qualtran/protos/ctrl_spec.proto
@@ -22,6 +22,6 @@ import "qualtran/protos/args.proto";
 package qualtran;
 
 message CtrlSpec {
-  repeated QDataType qdtype = 1;
+  repeated QDataType qdtypes = 1;
   repeated NDArray cvs = 2;
 }

--- a/qualtran/protos/ctrl_spec_pb2.py
+++ b/qualtran/protos/ctrl_spec_pb2.py
@@ -16,7 +16,7 @@ from qualtran.protos import data_types_pb2 as qualtran_dot_protos_dot_data__type
 from qualtran.protos import args_pb2 as qualtran_dot_protos_dot_args__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1fqualtran/protos/ctrl_spec.proto\x12\x08qualtran\x1a qualtran/protos/data_types.proto\x1a\x1aqualtran/protos/args.proto\"O\n\x08\x43trlSpec\x12#\n\x06qdtype\x18\x01 \x03(\x0b\x32\x13.qualtran.QDataType\x12\x1e\n\x03\x63vs\x18\x02 \x03(\x0b\x32\x11.qualtran.NDArrayb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1fqualtran/protos/ctrl_spec.proto\x12\x08qualtran\x1a qualtran/protos/data_types.proto\x1a\x1aqualtran/protos/args.proto\"P\n\x08\x43trlSpec\x12$\n\x07qdtypes\x18\x01 \x03(\x0b\x32\x13.qualtran.QDataType\x12\x1e\n\x03\x63vs\x18\x02 \x03(\x0b\x32\x11.qualtran.NDArrayb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -24,5 +24,5 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'qualtran.protos.ctrl_spec_p
 if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
   _globals['_CTRLSPEC']._serialized_start=107
-  _globals['_CTRLSPEC']._serialized_end=186
+  _globals['_CTRLSPEC']._serialized_end=187
 # @@protoc_insertion_point(module_scope)

--- a/qualtran/protos/ctrl_spec_pb2.pyi
+++ b/qualtran/protos/ctrl_spec_pb2.pyi
@@ -36,18 +36,18 @@ DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 class CtrlSpec(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-    QDTYPE_FIELD_NUMBER: builtins.int
+    QDTYPES_FIELD_NUMBER: builtins.int
     CVS_FIELD_NUMBER: builtins.int
     @property
-    def qdtype(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[qualtran.protos.data_types_pb2.QDataType]: ...
+    def qdtypes(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[qualtran.protos.data_types_pb2.QDataType]: ...
     @property
     def cvs(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[qualtran.protos.args_pb2.NDArray]: ...
     def __init__(
         self,
         *,
-        qdtype: collections.abc.Iterable[qualtran.protos.data_types_pb2.QDataType] | None = ...,
+        qdtypes: collections.abc.Iterable[qualtran.protos.data_types_pb2.QDataType] | None = ...,
         cvs: collections.abc.Iterable[qualtran.protos.args_pb2.NDArray] | None = ...,
     ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["cvs", b"cvs", "qdtype", b"qdtype"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["cvs", b"cvs", "qdtypes", b"qdtypes"]) -> None: ...
 
 global___CtrlSpec = CtrlSpec

--- a/qualtran/serialization/ctrl_spec.py
+++ b/qualtran/serialization/ctrl_spec.py
@@ -19,13 +19,13 @@ from qualtran.serialization import args, data_types
 
 def ctrl_spec_from_proto(spec: ctrl_spec_pb2.CtrlSpec) -> CtrlSpec:
     return CtrlSpec(
-        qdtype=[data_types.data_type_from_proto(dtype) for dtype in spec.qdtype],
+        qdtypes=[data_types.data_type_from_proto(dtype) for dtype in spec.qdtypes],
         cvs=[args.ndarray_from_proto(cvs) for cvs in spec.cvs],
     )
 
 
 def ctrl_spec_to_proto(spec: CtrlSpec) -> ctrl_spec_pb2.CtrlSpec:
     return ctrl_spec_pb2.CtrlSpec(
-        qdtype=[data_types.data_type_to_proto(dtype) for dtype in spec.qdtype],
+        qdtypes=[data_types.data_type_to_proto(dtype) for dtype in spec.qdtypes],
         cvs=[args.ndarray_to_proto(cvs) for cvs in spec.cvs],
     )

--- a/qualtran/serialization/ctrl_spec_test.py
+++ b/qualtran/serialization/ctrl_spec_test.py
@@ -1,0 +1,34 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from qualtran import CtrlSpec, QBit, QUInt
+from qualtran.serialization.ctrl_spec import ctrl_spec_from_proto, ctrl_spec_to_proto
+
+
+@pytest.mark.parametrize(
+    "ctrl_spec",
+    [
+        CtrlSpec(),
+        CtrlSpec(cvs=0),
+        CtrlSpec(qdtypes=QUInt(4), cvs=0b0110),
+        CtrlSpec(cvs=[0, 1, 1, 0]),
+        CtrlSpec(qdtypes=[QBit(), QBit()], cvs=[[0, 1], [1, 0]]),
+    ],
+)
+def test_ctrl_spec_to_proto_roundtrip(ctrl_spec: CtrlSpec):
+    ctrl_spec_proto = ctrl_spec_to_proto(ctrl_spec)
+    ctrl_spec_roundtrip = ctrl_spec_from_proto(ctrl_spec_proto)
+    assert ctrl_spec == ctrl_spec_roundtrip


### PR DESCRIPTION
We had updated `qdtype -> qdtypes` in `CtrlSpec` class but the change didn't propagate to the proto. This PR fixes that and adds tests.