### PR TITLE
Unary iteration: nth_operation_callgraph for more subclasses

### DIFF
--- a/qualtran/bloqs/multiplexers/apply_gate_to_lth_target.py
+++ b/qualtran/bloqs/multiplexers/apply_gate_to_lth_target.py
@@ -14,7 +14,7 @@
 
 import itertools
 from functools import cached_property
-from typing import Callable, Sequence, Tuple
+from typing import Callable, Sequence, Set, Tuple
 
 import attrs
 import cirq
@@ -23,6 +23,8 @@ import numpy as np
 from qualtran import bloq_example, BloqDocSpec, BoundedQUInt, QAny, QBit, Register, Signature
 from qualtran._infra.gate_with_registers import total_bits
 from qualtran.bloqs.multiplexers.unary_iteration_bloq import UnaryIterationGate
+from qualtran.cirq_interop._cirq_to_bloq import _cirq_gate_to_bloq
+from qualtran.resource_counting import BloqCountT
 
 
 @attrs.frozen
@@ -103,6 +105,10 @@ class ApplyGateToLthQubit(UnaryIterationGate):
         selection_idx = tuple(selection_indices[reg.name] for reg in self.selection_regs)
         target_idx = int(np.ravel_multi_index(selection_idx, selection_shape))
         return self.nth_gate(*selection_idx).on(target[target_idx]).controlled_by(control)
+
+    def nth_operation_callgraph(self, **selection_regs_name_to_val) -> Set['BloqCountT']:
+        selection_idx = tuple(selection_regs_name_to_val[reg.name] for reg in self.selection_regs)
+        return {(_cirq_gate_to_bloq(self.nth_gate(*selection_idx)), 1)}
 
 
 @bloq_example

--- a/qualtran/bloqs/multiplexers/selected_majorana_fermion.py
+++ b/qualtran/bloqs/multiplexers/selected_majorana_fermion.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Sequence, Tuple, Union
+from typing import Sequence, Set, Tuple, Union
 
 import attrs
 import cirq
@@ -23,7 +23,9 @@ from numpy.typing import NDArray
 from qualtran import QAny, QBit, Register
 from qualtran._infra.data_types import BoundedQUInt
 from qualtran._infra.gate_with_registers import total_bits
+from qualtran.bloqs.basic_gates import CNOT, CZPowGate
 from qualtran.bloqs.multiplexers.unary_iteration_bloq import UnaryIterationGate
+from qualtran.cirq_interop._cirq_to_bloq import _cirq_gate_to_bloq
 
 
 @attrs.frozen
@@ -120,3 +122,6 @@ class SelectedMajoranaFermion(UnaryIterationGate):
         yield cirq.CNOT(control, *accumulator)
         yield self.target_gate(target[target_idx]).controlled_by(control)
         yield cirq.CZ(*accumulator, target[target_idx])
+
+    def nth_operation_callgraph(self, **selection_regs_name_to_val) -> Set['BloqCountT']:
+        return {(CNOT(), 1), (_cirq_gate_to_bloq(self.target_gate), 1), (CZPowGate(), 1)}


### PR DESCRIPTION
This speeds up gate counting from a couple seconds to a couple hundred milliseconds on the hubbard model example. 