### PR TITLE
Add `__str__` to data types and use it in diagrams

### DIFF
--- a/qualtran/_infra/data_types.py
+++ b/qualtran/_infra/data_types.py
@@ -103,6 +103,9 @@ class QDType(metaclass=abc.ABCMeta):
         for val in val_array.reshape(-1):
             self.assert_valid_classical_val(val)
 
+    def __str__(self):
+        return f'{self.__class__.__name__}({self.num_qubits})'
+
 
 @attrs.frozen
 class QBit(QDType):
@@ -390,6 +393,9 @@ class BoundedQUInt(QDType):
         if np.any(val_array >= self.iteration_length):
             raise ValueError(f"Too-large classical values encountered in {debug_str}")
 
+    def __str__(self):
+        return f'{self.__class__.__name__}({self.bitsize}, {self.iteration_length})'
+
 
 @attrs.frozen
 class QFxp(QDType):
@@ -470,6 +476,12 @@ class QFxp(QDType):
         # TODO: Asserting a valid value here opens a can of worms because classical data, except integers,
         # is currently not propagated correctly through Bloqs
         pass
+
+    def __str__(self):
+        if self.signed:
+            return f'QFxp({self.bitsize}, {self.num_frac}, True)'
+        else:
+            return f'QFxp({self.bitsize}, {self.num_frac})'
 
 
 @attrs.frozen

--- a/qualtran/_infra/data_types.py
+++ b/qualtran/_infra/data_types.py
@@ -136,6 +136,9 @@ class QBit(QDType):
         if not np.all((val_array == 0) | (val_array == 1)):
             raise ValueError(f"Bad {self} value array in {debug_str}")
 
+    def __str__(self):
+        return f'QBit()'
+
 
 @attrs.frozen
 class QAny(QDType):

--- a/qualtran/_infra/data_types.py
+++ b/qualtran/_infra/data_types.py
@@ -137,7 +137,7 @@ class QBit(QDType):
             raise ValueError(f"Bad {self} value array in {debug_str}")
 
     def __str__(self):
-        return f'QBit()'
+        return 'QBit()'
 
 
 @attrs.frozen

--- a/qualtran/_infra/data_types_test.py
+++ b/qualtran/_infra/data_types_test.py
@@ -34,13 +34,16 @@ from .data_types import (
 def test_qint():
     qint_8 = QInt(8)
     assert qint_8.num_qubits == 8
+    assert str(qint_8) == 'QInt(8)'
     n = sympy.symbols('x')
     qint_8 = QInt(n)
     assert qint_8.num_qubits == n
+    assert str(qint_8) == 'QInt(x)'
 
 
 def test_qint_ones():
     qint_8 = QIntOnesComp(8)
+    assert str(qint_8) == 'QIntOnesComp(8)'
     assert qint_8.num_qubits == 8
     with pytest.raises(ValueError, match="num_qubits must be > 1."):
         QIntOnesComp(1)
@@ -51,6 +54,8 @@ def test_qint_ones():
 
 def test_quint():
     qint_8 = QUInt(8)
+    assert str(qint_8) == 'QUInt(8)'
+
     assert qint_8.num_qubits == 8
     # works
     QUInt(1)
@@ -61,6 +66,8 @@ def test_quint():
 
 def test_bounded_quint():
     qint_3 = BoundedQUInt(2, 3)
+    assert str(qint_3) == 'BoundedQUInt(2, 3)'
+
     assert qint_3.bitsize == 2
     assert qint_3.iteration_length == 3
     with pytest.raises(ValueError, match="BoundedQUInt iteration length.*"):
@@ -74,10 +81,12 @@ def test_bounded_quint():
 
 def test_qfxp():
     qfp_16 = QFxp(16, 15)
+    assert str(qfp_16) == 'QFxp(16, 15)'
     assert qfp_16.num_qubits == 16
     assert qfp_16.num_int == 1
     assert qfp_16.fxp_dtype_str == 'fxp-u16/15'
     qfp_16 = QFxp(16, 15, signed=True)
+    assert str(qfp_16) == 'QFxp(16, 15, True)'
     assert qfp_16.num_qubits == 16
     assert qfp_16.num_int == 0
     assert qfp_16.fxp_dtype_str == 'fxp-s16/15'
@@ -100,6 +109,7 @@ def test_qfxp():
 
 def test_qmontgomeryuint():
     qmontgomeryuint_8 = QMontgomeryUInt(8)
+    assert str(qmontgomeryuint_8) == 'QMontgomeryUInt(8)'
     assert qmontgomeryuint_8.num_qubits == 8
     # works
     QMontgomeryUInt(1)

--- a/qualtran/_infra/data_types_test.py
+++ b/qualtran/_infra/data_types_test.py
@@ -211,6 +211,7 @@ def test_type_errors_matrix(qdtype_a, qdtype_b):
 
 
 def test_single_qubit_consistency():
+    assert str(QBit()) == 'QBit()'
     assert check_dtypes_consistent(QBit(), QBit())
     assert check_dtypes_consistent(QBit(), QInt(1))
     assert check_dtypes_consistent(QInt(1), QBit())

--- a/qualtran/drawing/graphviz.py
+++ b/qualtran/drawing/graphviz.py
@@ -405,8 +405,7 @@ class PrettyGraphDrawer(GraphDrawer):
 class TypedGraphDrawer(PrettyGraphDrawer):
     @staticmethod
     def _fmt_dtype(dtype: QDType):
-        label = f'{dtype.__class__.__name__}({dtype.num_qubits})'
-        return label
+        return str(dtype)
 
     def cxn_label(self, cxn: Connection) -> str:
         """Overridable method to return labels for connections."""


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Qualtran/issues/855 and keeps up with the philosophy of https://github.com/quantumlib/Qualtran/issues/791 to use `__str__` for pretty and informative names