### PR TITLE
Added optional params `sub_bit_prec` and `epsilon` to `preprocess_lcu_coefficients_for_reversible_sampling`

### DIFF
--- a/qualtran/bloqs/chemistry/thc/prepare_test.py
+++ b/qualtran/bloqs/chemistry/thc/prepare_test.py
@@ -54,7 +54,7 @@ def test_prepare_alt_keep_vals(num_mu, num_spat, mu):
     flat_data = np.abs(np.concatenate([zeta[triu_indices], t_l]))
     eps = 2**-mu / len(flat_data)
     alternates, keep_numers, mu = preprocess_lcu_coefficients_for_reversible_sampling(
-        flat_data, eps
+        flat_data, epsilon = eps
     )
     keep_denom = 2**mu
     data_len = len(flat_data)

--- a/qualtran/bloqs/chemistry/writing_algorithms.ipynb
+++ b/qualtran/bloqs/chemistry/writing_algorithms.ipynb
@@ -441,7 +441,7 @@
     "    # Get some random hamiltonian matrix elements\n",
     "    lcu_coeffs = np.concatenate((tpq.ravel(), eris.ravel()))\n",
     "    alt, keep, mu = preprocess_lcu_coefficients_for_reversible_sampling(\n",
-    "        np.abs(lcu_coeffs), 2**-num_bits_state_prep / len(lcu_coeffs)\n",
+    "        np.abs(lcu_coeffs), epsilon=2**-num_bits_state_prep / len(lcu_coeffs)\n",
     "    )\n",
     "    # our alt value will be between 0 and len(lcu_coeffs), we need to map these\n",
     "    # back to p, q, and p, q, r, s indices\n",
@@ -586,7 +586,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/qualtran/linalg/lcu_util.py
+++ b/qualtran/linalg/lcu_util.py
@@ -147,7 +147,7 @@ def _preprocess_for_efficient_roulette_selection(discretized_probabilities):
 
 
 def preprocess_lcu_coefficients_for_reversible_sampling(
-    lcu_coefficients: Sequence[float], epsilon: float
+    lcu_coefficients: Sequence[float], **precision: float
 ):
     """Prepares data used to perform efficient reversible roulette selection.
 
@@ -168,7 +168,9 @@ def preprocess_lcu_coefficients_for_reversible_sampling(
         lcu_coefficients: A list of non-negative floats, with the i'th float
             corresponding to the i'th coefficient of an LCU decomposition
             of the Hamiltonian (in an ordering determined by the caller).
-        epsilon: Absolute error tolerance.
+        epsilon/sub_bit_prec: keyword arguments, exactly one of them must be
+            provided. Epsilon is the absolute error tolerance, whereas
+            sub_bit_prec is the bits of precision.
 
     Returns:
         alternates (list[int]): A python list of ints indicating alternative
@@ -182,6 +184,10 @@ def preprocess_lcu_coefficients_for_reversible_sampling(
             denominator to divide the items in keep_numers by in order to get
             a probability. The actual denominator is 2**sub_bit_precision.
     """
+    eps_provided = "epsilon" in precision.keys()
+    bit_prec_provided = "sub_bit_prec" in precision.keys()
+    assert eps_provided ^ bit_prec_provided == 1, "epsilon or sub_bit_prec must be provided"
+    epsilon = precision["epsilon"] if eps_provided else 1/2**precision["sub_bit_prec"]
     numers, denom, sub_bit_precision = _discretize_probability_distribution(
         lcu_coefficients, epsilon
     )

--- a/qualtran/linalg/lcu_util_test.py
+++ b/qualtran/linalg/lcu_util_test.py
@@ -127,7 +127,7 @@ class PreprocessForEfficientRouletteSelectionTest(unittest.TestCase):
 class PreprocessLCUCoefficientsForReversibleSamplingTest(unittest.TestCase):
     def assertPreprocess(self, lcu_coefs, epsilon):
         alternates, keep_numers, mu = preprocess_lcu_coefficients_for_reversible_sampling(
-            lcu_coefs, epsilon
+            lcu_coefs, epsilon=epsilon
         )
 
         n = len(lcu_coefs)


### PR DESCRIPTION
This PR solves issue #799. Now `preprocess_lcu_coefficients_for_reversible_sampling` accepts either a tolerance `epsilon` or a number of bits of precision `sub_bit_prec`, related as $\epsilon = 2^{-n_b}$.