### PR TITLE
bug fix for format_duration function

### DIFF
--- a/qualtran/surface_code/ui.py
+++ b/qualtran/surface_code/ui.py
@@ -403,21 +403,21 @@ def format_duration(duration: Sequence[float]) -> Tuple[str, Sequence[float]]:
     Finds the best unit to report `duration` and assumes that `duration` is initially in us.
     """
     unit = 'us'
-    if duration[0] > 1000:
+    if duration[0] > 86400_000_000:
+        duration = [d / 86400_000_000 for d in duration]
+        unit = 'days'
+    elif duration[0] > 3600_000_000:
+        duration = [d / 3600_000_000 for d in duration]
+        unit = 'hours'
+    elif duration[0] > 60_000_000:
+        duration = [d / 60_000_000 for d in duration]
+        unit = 'min'
+    elif duration[0] > 1000_000:
+        duration = [d / 1000_000 for d in duration]
+        unit = 's'
+    elif duration[0] > 1000:
         duration = [d / 1000 for d in duration]
         unit = 'ms'
-    if duration[0] > 1000:
-        duration = [d / 1000 for d in duration]
-        unit = 's'
-    if duration[0] > 60:
-        duration = [d / 60 for d in duration]
-        unit = 'min'
-    if duration[0] > 60:
-        duration = [d / 60 for d in duration]
-        unit = 'hours'
-    if duration[0] > 24:
-        duration = [d / 24 for d in duration]
-        unit = 'days'
     return unit, duration
 
 


### PR DESCRIPTION
The `format_duration` function in `ui.py` converts the input incorrectly, I have rewritten the function so that it (should) convert the input correctly.

As an example: in the original `format_duration`, an input of 25 ms gives the output as 1.04166666667 **days**, which is obviously incorrect.  