### PR TITLE
Mark tests slow

### DIFF
--- a/qualtran/bloqs/reflection_using_prepare_test.py
+++ b/qualtran/bloqs/reflection_using_prepare_test.py
@@ -85,9 +85,9 @@ def get_3q_uniform_dirac_notation(signs, global_phase: complex = 1):
     return ret
 
 
-@pytest.mark.parametrize('num_ones', [*range(5, 9)])
+@pytest.mark.parametrize('num_ones', [5])
 @pytest.mark.parametrize('eps', [0.01])
-@pytest.mark.parametrize('global_phase', [+1, -1, 1j, -1j])
+@pytest.mark.parametrize('global_phase', [+1, -1j])
 def test_reflection_using_prepare(num_ones, eps, global_phase):
     data = [1] * num_ones
     prepare_gate = StatePreparationAliasSampling.from_lcu_probs(data, probability_epsilon=eps)
@@ -100,7 +100,7 @@ def test_reflection_using_prepare(num_ones, eps, global_phase):
     initial_state_prep = cirq.Circuit(cirq.H.on_each(*g.quregs['selection']))
     initial_state = cirq.dirac_notation(initial_state_prep.final_state_vector())
     assert initial_state == get_3q_uniform_dirac_notation('++++++++')
-    result = cirq.Simulator(dtype=np.complex128).simulate(
+    result = cirq.Simulator(dtype=np.complex64).simulate(
         initial_state_prep + decomposed_circuit, qubit_order=qubit_order
     )
     selection = g.quregs['selection']

--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling_test.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling_test.py
@@ -29,7 +29,7 @@ def test_state_prep_alias_sampling_autotest(bloq_autotester):
     bloq_autotester(_state_prep_alias)
 
 
-def assert_state_preparation_valid_for_coefficient(lcu_coefficients: float, epsilon: float):
+def assert_state_preparation_valid_for_coefficient(lcu_coefficients: np.ndarray, epsilon: float):
     gate = StatePreparationAliasSampling.from_lcu_probs(
         lcu_probabilities=lcu_coefficients.tolist(), probability_epsilon=epsilon
     )
@@ -58,6 +58,13 @@ def assert_state_preparation_valid_for_coefficient(lcu_coefficients: float, epsi
     np.testing.assert_allclose(lcu_coefficients, abs(prepared_state) ** 2, atol=epsilon)
 
 
+def test_state_preparation_via_coherent_alias_sampling_quick():
+    num_sites, epsilon = 2, 1e-2
+    lcu_coefficients = get_1d_ising_lcu_coeffs(num_sites)
+    assert_state_preparation_valid_for_coefficient(lcu_coefficients, epsilon)
+
+
+@pytest.mark.slow
 @pytest.mark.parametrize("num_sites, epsilon", [[2, 3e-3], [3, 3.0e-3], [4, 5.0e-3], [7, 8.0e-3]])
 def test_state_preparation_via_coherent_alias_sampling(num_sites, epsilon):
     lcu_coefficients = get_1d_ising_lcu_coeffs(num_sites)


### PR DESCRIPTION
Mark tests as slow for state prep alias sampling and add a quick version. For reflection using prepare, reduce the range of tests. 