### PR TITLE
Update stale notebooks.

### DIFF
--- a/qualtran/bloqs/chemistry/thc/thc.ipynb
+++ b/qualtran/bloqs/chemistry/thc/thc.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "from qualtran import Bloq, CompositeBloq, BloqBuilder, Signature, Register\n",
     "from qualtran import QBit, QInt, QUInt, QAny\n",
-    "from qualtran.drawing import show_bloq, show_call_graph, show_counts_sigma, show_flame_graph\n",
+    "from qualtran.drawing import show_bloq, show_call_graph, show_counts_sigma\n",
     "from typing import *\n",
     "import numpy as np\n",
     "import sympy\n",

--- a/qualtran/bloqs/chemistry/thc/thc.ipynb
+++ b/qualtran/bloqs/chemistry/thc/thc.ipynb
@@ -393,6 +393,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from qualtran.drawing import flame_graph\n",
     "show_flame_graph(thc_prep)"
    ]
   },

--- a/qualtran/bloqs/chemistry/thc/thc.ipynb
+++ b/qualtran/bloqs/chemistry/thc/thc.ipynb
@@ -170,6 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from qualtran.drawing import show_flame_graph\n",
     "show_flame_graph(thc_uni)"
    ]
   },
@@ -393,7 +394,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qualtran.drawing import flame_graph\n",
+    "from qualtran.drawing import show_flame_graph\n",
     "show_flame_graph(thc_prep)"
    ]
   },
@@ -596,6 +597,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from qualtran.drawing import show_flame_graph\n",
     "show_flame_graph(thc_sel)"
    ]
   },

--- a/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp.ipynb
+++ b/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp.ipynb
@@ -80,7 +80,13 @@
     "This therefore block-encodes $e^{-iHt}$ in the block where the signal qubit and selection registers are all $|0\\rangle$.\n",
     "\n",
     "#### References\n",
-    " - [Generalized Quantum Signal Processing](https://arxiv.org/abs/2308.01501).     Motlagh and Wiebe. (2023). Theorem 7, Corollary 8.\n"
+    " - [Generalized Quantum Signal Processing](https://arxiv.org/abs/2308.01501).     Motlagh and Wiebe. (2023). Theorem 7, Corollary 8. \n",
+    "\n",
+    "#### Parameters\n",
+    " - `walk_operator`: qubitization walk operator of $H$ constructed from SELECT and PREPARE oracles.\n",
+    " - `t`: time to simulate the Hamiltonian, i.e. $e^{-iHt}$\n",
+    " - `alpha`: the $1$-norm of the coefficients of the unitaries comprising the Hamiltonian $H$.\n",
+    " - `precision`: the precision $\\epsilon$ to approximate $e^{it\\cos\\theta}$ to a polynomial.\n"
    ]
   },
   {

--- a/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.ipynb
+++ b/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.ipynb
@@ -164,7 +164,12 @@
     "Implements multi-control, single-target C^{n}P gate.\n",
     "\n",
     "Implements $C^{n}P = (1 - |1^{n}><1^{n}|) I + |1^{n}><1^{n}| P^{n}$ using $n-1$\n",
-    "clean ancillas using a multi-controlled `AND` gate.\n",
+    "clean ancillas using a multi-controlled `AND` gate. Uses the Toffoli ladder\n",
+    "construction described in \"n−2 Ancilla Bits\" section of Ref[1] but uses an\n",
+    "$\\text{AND} / \\text{AND}^\\dagger$ ladder instead for computing / uncomputing\n",
+    "using clean ancillas instead of the Toffoli ladder. The measurement based\n",
+    "uncomputation of $\\text{AND}$ does not consume any magic states and thus has\n",
+    "better constant factors.\n",
     "\n",
     "#### References\n",
     " - [Constructing Large Controlled Nots](https://algassert.com/circuits/2015/06/05/Constructing-Large-Controlled-Nots.html). \n"


### PR DESCRIPTION
Rerunning the autogen script results in this diff. I added flame graph imports directly above the call sites as the autogen function will just erase the import where was before. Maybe we should add an import for the flame_graph to the autodoc in the future?