### PR TITLE
More improvements to the Controlled infrastructure

### DIFF
--- a/qualtran/_infra/adjoint.py
+++ b/qualtran/_infra/adjoint.py
@@ -150,6 +150,13 @@ class Adjoint(GateWithRegisters):
             return cirq.inverse(self.subbloq.decompose_from_registers(context=context, **quregs))
         return super().decompose_from_registers(context=context, **quregs)
 
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'):
+        sub_info = cirq.circuit_diagram_info(self.subbloq, args, default=NotImplemented)
+        if sub_info is NotImplemented:
+            return NotImplemented
+        sub_info.exponent *= -1
+        return sub_info
+
     def supports_decompose_bloq(self) -> bool:
         """Delegate to `subbloq.supports_decompose_bloq()`"""
         return self.subbloq.supports_decompose_bloq()

--- a/qualtran/_infra/adjoint.py
+++ b/qualtran/_infra/adjoint.py
@@ -150,7 +150,9 @@ class Adjoint(GateWithRegisters):
             return cirq.inverse(self.subbloq.decompose_from_registers(context=context, **quregs))
         return super().decompose_from_registers(context=context, **quregs)
 
-    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'):
+    def _circuit_diagram_info_(
+        self, args: 'cirq.CircuitDiagramInfoArgs'
+    ) -> cirq.CircuitDiagramInfo:
         sub_info = cirq.circuit_diagram_info(self.subbloq, args, default=NotImplemented)
         if sub_info is NotImplemented:
             return NotImplemented

--- a/qualtran/_infra/controlled.py
+++ b/qualtran/_infra/controlled.py
@@ -34,7 +34,7 @@ from numpy.typing import NDArray
 
 from .bloq import Bloq
 from .data_types import QBit, QDType
-from .gate_with_registers import GateWithRegisters, merge_qubits
+from .gate_with_registers import GateWithRegisters
 from .registers import Register, Side, Signature
 
 if TYPE_CHECKING:

--- a/qualtran/_infra/controlled.py
+++ b/qualtran/_infra/controlled.py
@@ -418,7 +418,8 @@ class Controlled(GateWithRegisters):
                 cirq.ControlledGate(self.subbloq, control_values=self.ctrl_spec.to_cirq_cv())
             )
         if all(reg.side == Side.THRU for reg in self.subbloq.signature):
-            # subbloq has only THRU registers, so the unitary is well defined.
+            # subbloq has only THRU registers, so the tensor contraction corresponds
+            # to a unitary matrix.
             return self.tensor_contract()
         # Unable to determine the unitary effect.
         return NotImplemented

--- a/qualtran/_infra/controlled.py
+++ b/qualtran/_infra/controlled.py
@@ -34,6 +34,7 @@ from numpy.typing import NDArray
 
 from .bloq import Bloq
 from .data_types import QBit, QDType
+from .gate_with_registers import GateWithRegisters, merge_qubits
 from .registers import Register, Side, Signature
 
 if TYPE_CHECKING:
@@ -278,7 +279,7 @@ def _get_nice_ctrl_reg_names(reg_names: List[str], n: int) -> Tuple[str, ...]:
 
 
 @attrs.frozen
-class Controlled(Bloq):
+class Controlled(GateWithRegisters):
     """A controlled version of `subbloq`.
 
     This meta-bloq is part of the 'controlled' protocol. As a default fallback,
@@ -410,6 +411,18 @@ class Controlled(Bloq):
         # Add the data to the tensor network.
         tn.add(qtn.Tensor(data=data, inds=out_ind + in_ind, tags=[self.short_name(), tag]))
 
+    def _unitary_(self):
+        if isinstance(self.subbloq, GateWithRegisters):
+            # subbloq is a cirq gate, use the cirq-style API to derive a unitary.
+            return cirq.unitary(
+                cirq.ControlledGate(self.subbloq, control_values=self.ctrl_spec.to_cirq_cv())
+            )
+        if all(reg.side == Side.THRU for reg in self.subbloq.signature):
+            # subbloq has only THRU registers, so the unitary is well defined.
+            return self.tensor_contract()
+        # Unable to determine the unitary effect.
+        return NotImplemented
+
     def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
         if soq.reg.name not in self.ctrl_reg_names:
             # Delegate to subbloq
@@ -418,6 +431,9 @@ class Controlled(Bloq):
         # Otherwise, it's part of the control register.
         i = self.ctrl_reg_names.index(soq.reg.name)
         return self.ctrl_spec.wire_symbol(i, soq)
+
+    def adjoint(self) -> 'Bloq':
+        return self.subbloq.adjoint().controlled(self.ctrl_spec)
 
     def pretty_name(self) -> str:
         return f'C[{self.subbloq.pretty_name()}]'

--- a/qualtran/_infra/controlled_test.py
+++ b/qualtran/_infra/controlled_test.py
@@ -322,7 +322,7 @@ def test_notebook():
 
 def _verify_ctrl_tensor_for_unitary(ctrl_spec: CtrlSpec, bloq: Bloq, gate: cirq.Gate):
     cbloq = Controlled(bloq, ctrl_spec)
-    cgate = gate.controlled(control_values=ctrl_spec.to_cirq_cv())
+    cgate = cirq.ControlledGate(gate, control_values=ctrl_spec.to_cirq_cv())
     np.testing.assert_array_equal(cbloq.tensor_contract(), cirq.unitary(cgate))
 
 

--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -356,7 +356,24 @@ class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
         >>>         # Use ctrl_spec to construct a controlled version of `self`.
 
         Args:
-            num_controls:
+            num_controls: Cirq style API to specify control specification -
+                Total number of control qubits.
+            control_values: Cirq style API to specify control specification -
+                Which control computational basis state to apply the
+                sub gate.  A sequence of length `num_controls` where each
+                entry is an integer (or set of integers) corresponding to the
+                computational basis state (or set of possible values) where that
+                control is enabled.  When all controls are enabled, the sub gate is
+                applied.  If unspecified, control values default to 1.
+            control_qid_shape: Cirq style API to specify control specification -
+                The qid shape of the controls.  A tuple of the
+                expected dimension of each control qid.  Defaults to
+                `(2,) * num_controls`.  Specify this argument when using qudits.
+            ctrl_spec: Bloq style API to specify a control specification -
+                An optional keyword argument `CtrlSpec`, which specifies how to control
+                the bloq. The default spec means the bloq will be active when one control qubit is
+                in the |1> state. See the CtrlSpec documentation for more possibilities including
+                negative controls, integer-equality control, and ndarrays of control values.
         """
         from qualtran._infra.controlled import CtrlSpec
 

--- a/qualtran/_infra/gate_with_registers_test.py
+++ b/qualtran/_infra/gate_with_registers_test.py
@@ -18,8 +18,19 @@ import cirq
 import numpy as np
 import pytest
 
-from qualtran import GateWithRegisters, QAny, QBit, Register, Side, Signature, SoquetT
+from qualtran import (
+    Controlled,
+    CtrlSpec,
+    GateWithRegisters,
+    QAny,
+    QBit,
+    Register,
+    Side,
+    Signature,
+    SoquetT,
+)
 from qualtran.bloqs.basic_gates import XGate, YGate, ZGate
+from qualtran.bloqs.util_bloqs import Power
 from qualtran.testing import execute_notebook
 
 
@@ -50,6 +61,38 @@ def test_gate_with_registers():
     assert op1 == op2
 
     np.testing.assert_allclose(cirq.unitary(tg), tg.tensor_contract())
+
+    # Test GWR.controlled() works correctly with Bloq and Cirq style API
+    ctrl = cirq.q('ctrl')
+    cop1 = tg.controlled().on(ctrl, *qubits[:5], *qubits[6:], qubits[5])
+    cop2 = tg.controlled().on_registers(ctrl=ctrl, r1=qubits[:5], r2=qubits[6:], r3=qubits[5])
+    cop3 = op1.controlled_by(ctrl)
+    cop4 = op2.controlled_by(ctrl)
+    assert cop1 == cop2 == cop3 == cop4
+    assert cop1.gate == cop2.gate == cop3.gate == cop4.gate == Controlled(tg, CtrlSpec())
+
+    assert (
+        tg.controlled(num_controls=1, control_values=[0])
+        == tg.controlled(control_values=[0], control_qid_shape=(2,))
+        == tg.controlled(CtrlSpec(cvs=0))
+        == tg.controlled(ctrl_spec=CtrlSpec(cvs=0))
+    )
+
+    # Test GWR.controlled() raises with incorrect invocation.
+    with pytest.raises(ValueError):
+        tg.controlled(control_values=[0], ctrl_spec=CtrlSpec())
+
+    with pytest.raises(ValueError):
+        tg.controlled(CtrlSpec(), control_values=[0])
+
+    with pytest.raises(ValueError):
+        tg.controlled(CtrlSpec(), ctrl_spec=CtrlSpec())
+
+    # Test GWR**pow
+    assert tg**-1 == tg.adjoint()
+    assert tg**1 is tg
+    assert tg**-10 == Power(tg.adjoint(), 10)
+    assert tg**10 == Power(tg, 10)
 
 
 class _TestGateAtomic(GateWithRegisters):

--- a/qualtran/bloqs/phase_estimation/lp_resource_state.py
+++ b/qualtran/bloqs/phase_estimation/lp_resource_state.py
@@ -64,7 +64,7 @@ class LPRSInterimPrep(GateWithRegisters):
         yield [OnEach(self.bitsize, Hadamard()).on(*q), Hadamard().on(*anc)]
         for i in range(self.bitsize):
             rz_angle = -2 * np.pi * (2**i) / (2**self.bitsize + 1)
-            yield cirq.Rz(rads=rz_angle).controlled().on(q[i], *anc)
+            yield Rz(angle=rz_angle).controlled().on(q[i], *anc)
         yield Rz(angle=-2 * np.pi / (2**self.bitsize + 1)).on(*anc)
         yield Hadamard().on(*anc)
 
@@ -72,11 +72,9 @@ class LPRSInterimPrep(GateWithRegisters):
         rz_angle = -2 * pi(self.bitsize) / (2**self.bitsize + 1)
         ret = {(Rz(angle=rz_angle), 1), (Hadamard(), 2 + self.bitsize)}
         if is_symbolic(self.bitsize):
-            ret |= {(Rz(angle=rz_angle).controlled().bloq, self.bitsize)}
+            ret |= {(Rz(angle=rz_angle).controlled(), self.bitsize)}
         else:
-            ret |= {
-                (Rz(angle=rz_angle * (2**i)).controlled().bloq, 1) for i in range(self.bitsize)
-            }
+            ret |= {(Rz(angle=rz_angle * (2**i)).controlled(), 1) for i in range(self.bitsize)}
         return ret
 
     def _t_complexity_(self) -> 'TComplexity':

--- a/qualtran/bloqs/phase_estimation/text_book_qpe.py
+++ b/qualtran/bloqs/phase_estimation/text_book_qpe.py
@@ -12,16 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Sequence, Set, Tuple
+from typing import Set, Tuple
 
 import attrs
 import cirq
 
 from qualtran import Bloq, bloq_example, BloqDocSpec, GateWithRegisters, QFxp, Register, Signature
-from qualtran._infra.gate_with_registers import merge_qubits
 from qualtran.bloqs.basic_gates import Hadamard, OnEach
 from qualtran.bloqs.qft.qft_text_book import QFTTextBook
-from qualtran.bloqs.util_bloqs import Power
 from qualtran.resource_counting.symbolic_counting_utils import (
     ceil,
     is_symbolic,
@@ -222,14 +220,13 @@ class TextbookQPE(GateWithRegisters):
         self, context: cirq.DecompositionContext, **quregs
     ) -> cirq.OP_TREE:
         target_quregs = {reg.name: quregs[reg.name] for reg in self.target_registers}
-        target_qubits = merge_qubits(self.target_registers, **target_quregs)
+        unitary_op = self.unitary.on_registers(**target_quregs)
 
-        phase_qubits: Sequence[cirq.Qid] = quregs['qpe_reg'].flatten()
+        phase_qubits = quregs['qpe_reg']
 
         yield self.ctrl_state_prep.on(*phase_qubits)
         for i, qbit in enumerate(phase_qubits[::-1]):
-            yield Power(self.unitary.controlled(), 2**i).on(qbit, *target_qubits)
-            # yield cirq.pow(unitary_op.controlled_by(qbit), 2**i)
+            yield cirq.pow(unitary_op.controlled_by(qbit), 2**i)
         yield self.qft_inv.on(*phase_qubits)
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:

--- a/qualtran/bloqs/qsp/generalized_qsp.py
+++ b/qualtran/bloqs/qsp/generalized_qsp.py
@@ -20,16 +20,8 @@ from attrs import field, frozen
 from numpy.polynomial import Polynomial
 from numpy.typing import NDArray
 
-from qualtran import (
-    bloq_example,
-    BloqDocSpec,
-    Controlled,
-    CtrlSpec,
-    GateWithRegisters,
-    QBit,
-    Register,
-    Signature,
-)
+from qualtran import bloq_example, BloqDocSpec, GateWithRegisters, QBit, Register, Signature
+from qualtran._infra.gate_with_registers import merge_qubits
 from qualtran.bloqs.basic_gates.su2_rotation import SU2RotationGate
 
 if TYPE_CHECKING:
@@ -382,14 +374,15 @@ class GeneralizedQSP(GateWithRegisters):
         num_inverse_applications = self.negative_power
 
         yield self.signal_rotations[0].on(signal_qubit)
+        flat_qubits_for_u = merge_qubits(self.U.signature, **quregs)
         for signal_rotation in self.signal_rotations[1:]:
             if num_inverse_applications > 0:
                 # apply C-U^\dagger
-                yield self.U.adjoint().on_registers(**quregs).controlled_by(signal_qubit)
+                yield self.U.adjoint().controlled().on(signal_qubit, *flat_qubits_for_u)
                 num_inverse_applications -= 1
             else:
                 # apply C[0]-U
-                yield self.U.on_registers(**quregs).controlled_by(signal_qubit, control_values=[0])
+                yield self.U.controlled(control_values=[0]).on(signal_qubit, *flat_qubits_for_u)
             yield signal_rotation.on(signal_qubit)
 
         for _ in range(num_inverse_applications):
@@ -401,12 +394,12 @@ class GeneralizedQSP(GateWithRegisters):
         counts = set(Counter(self.signal_rotations).items())
 
         if degree > self.negative_power:
-            counts.add((Controlled(self.U, CtrlSpec(cvs=0)), degree - self.negative_power))
+            counts.add((self.U.controlled(control_values=[0]), degree - self.negative_power))
         elif self.negative_power > degree:
             counts.add((self.U.adjoint(), self.negative_power - degree))
 
         if self.negative_power > 0:
-            counts.add((Controlled(self.U.adjoint(), CtrlSpec()), min(degree, self.negative_power)))
+            counts.add((self.U.adjoint().controlled(), min(degree, self.negative_power)))
 
         return counts
 

--- a/qualtran/bloqs/qsp/generalized_qsp.py
+++ b/qualtran/bloqs/qsp/generalized_qsp.py
@@ -21,7 +21,6 @@ from numpy.polynomial import Polynomial
 from numpy.typing import NDArray
 
 from qualtran import bloq_example, BloqDocSpec, GateWithRegisters, QBit, Register, Signature
-from qualtran._infra.gate_with_registers import merge_qubits
 from qualtran.bloqs.basic_gates.su2_rotation import SU2RotationGate
 
 if TYPE_CHECKING:
@@ -374,15 +373,14 @@ class GeneralizedQSP(GateWithRegisters):
         num_inverse_applications = self.negative_power
 
         yield self.signal_rotations[0].on(signal_qubit)
-        flat_qubits_for_u = merge_qubits(self.U.signature, **quregs)
         for signal_rotation in self.signal_rotations[1:]:
             if num_inverse_applications > 0:
                 # apply C-U^\dagger
-                yield self.U.adjoint().controlled().on(signal_qubit, *flat_qubits_for_u)
+                yield self.U.adjoint().on_registers(**quregs).controlled_by(signal_qubit)
                 num_inverse_applications -= 1
             else:
                 # apply C[0]-U
-                yield self.U.controlled(control_values=[0]).on(signal_qubit, *flat_qubits_for_u)
+                yield self.U.on_registers(**quregs).controlled_by(signal_qubit, control_values=[0])
             yield signal_rotation.on(signal_qubit)
 
         for _ in range(num_inverse_applications):

--- a/qualtran/bloqs/qubitization_walk_operator_test.py
+++ b/qualtran/bloqs/qubitization_walk_operator_test.py
@@ -16,6 +16,7 @@ import cirq
 import numpy as np
 import pytest
 
+from qualtran import Adjoint
 from qualtran._infra.gate_with_registers import get_named_qubits, total_bits
 from qualtran.bloqs.chemistry.ising import get_1d_ising_hamiltonian
 from qualtran.bloqs.mcmt.multi_control_multi_target_pauli import MultiControlPauli
@@ -161,8 +162,8 @@ target3: ──────SelectPauliLCU─────────
 
     def keep(op):
         ret = op in gateset_to_keep
-        if op.gate is not None and isinstance(op.gate, cirq.ops.raw_types._InverseCompositeGate):
-            ret |= op.gate._original in gateset_to_keep
+        if op.gate is not None and isinstance(op.gate, Adjoint):
+            ret |= op.gate.subbloq in gateset_to_keep
         return ret
 
     greedy_mm = cirq.GreedyQubitManager(prefix="ancilla", maximize_reuse=True)

--- a/qualtran/bloqs/util_bloqs.py
+++ b/qualtran/bloqs/util_bloqs.py
@@ -26,6 +26,7 @@ from sympy import Expr
 from qualtran import (
     Bloq,
     BloqBuilder,
+    GateWithRegisters,
     QAny,
     QBit,
     QDType,
@@ -478,7 +479,7 @@ class Cast(Bloq):
 
 
 @frozen
-class Power(Bloq):
+class Power(GateWithRegisters):
     """Wrapper that repeats the given `bloq` `power` times.
 
     `Bloq` must have only THRU registers.

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -28,6 +28,8 @@ from qualtran import (
     Bloq,
     BloqBuilder,
     CompositeBloq,
+    Controlled,
+    CtrlSpec,
     DecomposeNotImplementedError,
     DecomposeTypeError,
     GateWithRegisters,
@@ -349,6 +351,11 @@ def _cirq_gate_to_bloq(gate: cirq.Gate) -> Bloq:
     if isinstance(gate, cirq.ops.raw_types._InverseCompositeGate):
         # Inverse of a cirq gate, delegate to Adjoint
         return Adjoint(_cirq_gate_to_bloq(gate._original))
+
+    if isinstance(gate, cirq.ControlledGate):
+        return Controlled(
+            _cirq_gate_to_bloq(gate.sub_gate), CtrlSpec.from_cirq_cv(gate.control_values)
+        )
 
     # Check specific basic gates instances.
     CIRQ_GATE_TO_BLOQ_MAP = {

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -47,7 +47,6 @@ from qualtran._infra.gate_with_registers import (
     get_named_qubits,
     split_qubits,
 )
-from qualtran.bloqs.util_bloqs import Cast
 from qualtran.cirq_interop._interop_qubit_manager import InteropQubitManager
 from qualtran.cirq_interop.t_complexity_protocol import t_complexity, TComplexity
 from qualtran.simulation.tensor._tensor_data_manipulation import (
@@ -247,6 +246,8 @@ def _ensure_in_reg_exists(
     bb: BloqBuilder, in_reg: _QReg, qreg_to_qvar: Dict[_QReg, Soquet]
 ) -> None:
     """Takes care of qubit allocations, split and joins to ensure `qreg_to_qvar[in_reg]` exists."""
+    from qualtran.bloqs.util_bloqs import Cast
+
     all_mapped_qubits = {q for qreg in qreg_to_qvar for q in qreg.qubits}
     qubits_to_allocate: List[cirq.Qid] = [q for q in in_reg.qubits if q not in all_mapped_qubits]
     if qubits_to_allocate:


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Qualtran/issues/865
Fixes https://github.com/quantumlib/Qualtran/issues/686

The improvements are -

- `GateWithRegisters.controlled()` now returns `Controlled` bloq
- `cirq_gate_to_bloq` now maps a `cirq.Controlled` gates to `Controlled` bloq.
- `Controlled` bloq is now a `GateWithRegisters`. This is required because we want to support cirq style simulations for circuits containing `Controlled(Rx())` bloqs and `BloqAsCirqGate(Controlled())` is not sufficient because we need special logic to derive the unitary matrix for controlled bloqs (eg: when subbloq is a GateWithRegisters but doesn't have only THRU registers). 


After this PR, we should never need to invoke the `cirq.Controlled` gates in either cirq-style or bloq-style API in Qualtran and we should always use `Controlled` bloq in all cases. All existing uses of `cirq.Controlled` gates would be updated to `Controlled` bloq when invoking the bloq-style API using the `cirq_gate_to_bloq` mapping. 


This is the final PR in my series of PRs to improve the controlled infrastructure. cc @mpharrigan 