### PR TITLE
Return default None for gates that do not have a diagram info from CirqGateAsBloq

### DIFF
--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -131,7 +131,7 @@ class CirqGateAsBloqBase(GateWithRegisters, metaclass=abc.ABCMeta):
         return cirq.unitary(self.cirq_gate, default=None)
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
-        return cirq.circuit_diagram_info(self.cirq_gate)
+        return cirq.circuit_diagram_info(self.cirq_gate, default=None)
 
     def __str__(self):
         return str(self.cirq_gate)

--- a/qualtran/cirq_interop/_cirq_to_bloq_test.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq_test.py
@@ -32,7 +32,7 @@ from qualtran import (
     Signature,
 )
 from qualtran._infra.gate_with_registers import get_named_qubits
-from qualtran.bloqs.basic_gates import CNOT, OneState
+from qualtran.bloqs.basic_gates import CNOT, GlobalPhase, OneState
 from qualtran.bloqs.mcmt.and_bloq import And
 from qualtran.bloqs.util_bloqs import Allocate, Free, Join, Split
 from qualtran.cirq_interop import cirq_optree_to_cbloq, CirqGateAsBloq, CirqQuregT
@@ -224,3 +224,7 @@ def test_cirq_gate_as_bloq_decompose_raises():
     bloq = CirqGateAsBloq(cirq.X)
     with pytest.raises(DecomposeNotImplementedError, match="does not declare a decomposition"):
         _ = bloq.decompose_bloq()
+
+
+def test_cirq_gate_as_bloq_diagram_info():
+    assert cirq.circuit_diagram_info(GlobalPhase(1j)) is None


### PR DESCRIPTION
Trying to print a `cirq.Circuit()` that contains a `GlobalPhase.on()` bloq-as-op currently raises an error because `cirq.GlobalPhaseGate` does not defined a circuit diagram info. This PR fixes the bug so we use a default fallback of `None`, to indicate that we don't know how to draw this operation, when `self.cirq_gate` does not have a diagram info. 