### PR TITLE
Remove unitary validation check when constructing `GateWithRegisters.controlled()`

### DIFF
--- a/qualtran/_infra/gate_with_registers_test.py
+++ b/qualtran/_infra/gate_with_registers_test.py
@@ -147,6 +147,11 @@ t: ───t───────────────────Y───
     )
 
 
+def test_non_unitary_controlled():
+    bloq = BloqWithDecompose()
+    assert bloq.controlled(control_values=[0]) == Controlled(bloq, CtrlSpec(cvs=0))
+
+
 @pytest.mark.notebook
 def test_notebook():
     execute_notebook('gate_with_registers')


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Qualtran/issues/885

For now, I've mainly copied the logic from `cirq.ControlledGate` to construct `AbstractControlValues` object from parameters `num_controls`, `control_values` and `control_qid_shape` but we should eventually get rid of these arguments or at least move this to a different place instead of on `GateWithRegisters`. For example - we could add a new `GWROperation` for cirq-style API and delegate to underlying gate's `gwr.controlled(ctrl_spec)`. Right now, `cirq.GateOperation().controlled_by()` delegates to `gwr.controlled` but with the cirq-style API (`num_control`, `control_values`, `control_qid_shape`). 


cc @anurudhp 