### PR TITLE
First pass of type checking in Qualtran

### DIFF
--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -2,6 +2,10 @@
 show_error_codes = true
 plugins = duet.typing, numpy.typing.mypy_plugin
 allow_redefinition = true
+# Disabling function override checking
+# Qualtran has many places where kwargs are used
+# with the intention to override in subclasses in ways mypy does not like
+disable_error_code = override
 
 [mypy-__main__]
 follow_imports = silent
@@ -15,7 +19,7 @@ follow_imports = silent
 ignore_missing_imports = true
 
 # Non-Google
-[mypy-sympy.*,matplotlib.*,proto.*,pandas.*,scipy.*,freezegun.*,mpl_toolkits.*,networkx.*,ply.*,astroid.*,pytest.*,_pytest.*,pylint.*,setuptools.*,qiskit.*,quimb.*,pylatex.*,filelock.*,sortedcontainers.*,tqdm.*]
+[mypy-sympy.*,matplotlib.*,proto.*,pandas.*,scipy.*,freezegun.*,mpl_toolkits.*,networkx.*,ply.*,astroid.*,pytest.*,_pytest.*,pylint.*,setuptools.*,qiskit.*,quimb.*,pylatex.*,filelock.*,sortedcontainers.*,tqdm.*,plotly.*,dash.*,tensorflow_docs.*,fxpmath.*,ipywidgets.*,cachetools.*,pydot.*]
 follow_imports = silent
 ignore_missing_imports = true
 

--- a/dev_tools/qualtran_dev_tools/clean_notebooks.py
+++ b/dev_tools/qualtran_dev_tools/clean_notebooks.py
@@ -15,7 +15,7 @@ import os
 import subprocess
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import List
+from typing import Any, List
 
 import nbformat
 from nbconvert.preprocessors import ClearMetadataPreprocessor, ClearOutputPreprocessor
@@ -46,7 +46,7 @@ def clean_notebook(nb_path: Path, do_clean: bool = True):
 
     pp1 = ClearOutputPreprocessor()
     pp2 = ClearMetadataPreprocessor(preserve_cell_metadata_mask={'cq.autogen'})
-    resources = {}
+    resources: dict[str, Any] = {}
     nb, resources = pp1.preprocess(nb, resources=resources)
     nb, resources = pp2.preprocess(nb, resources=resources)
 

--- a/dev_tools/qualtran_dev_tools/notebook_execution.py
+++ b/dev_tools/qualtran_dev_tools/notebook_execution.py
@@ -176,6 +176,8 @@ def execute_and_export_notebook(paths: _NBInOutPaths) -> Optional[Exception]:
         with paths.html_out.open('w') as f:
             f.write(html)
 
+    return None
+
 
 class _NotebookRunClosure:
     """Used to run notebook execution logic in subprocesses."""

--- a/dev_tools/qualtran_dev_tools/reference_docs.py
+++ b/dev_tools/qualtran_dev_tools/reference_docs.py
@@ -94,11 +94,11 @@ def mixin_custom_template(template_name: str) -> Type:
     return _CustomTemplateMixin
 
 
-class MyModulePageBuilder(mixin_custom_template('module'), ModulePageBuilder):
+class MyModulePageBuilder(mixin_custom_template('module'), ModulePageBuilder):  # type: ignore[misc]
     """Use a custom template for module pages."""
 
 
-class MyClassPageBuilder(mixin_custom_template('class'), ClassPageBuilder):
+class MyClassPageBuilder(mixin_custom_template('class'), ClassPageBuilder):  # type: ignore[misc]
     """Use a custom template for class pages.
 
     Additionally, this will re-sort the class members (i.e. methods) to match
@@ -120,11 +120,11 @@ class MyClassPageBuilder(mixin_custom_template('class'), ClassPageBuilder):
         )
 
 
-class MyFunctionPageBuilder(mixin_custom_template('function'), FunctionPageBuilder):
+class MyFunctionPageBuilder(mixin_custom_template('function'), FunctionPageBuilder):  # type: ignore[misc]
     """Use a custom template for function pages."""
 
 
-class MyTypeAliasPageBuilder(mixin_custom_template('type_alias'), TypeAliasPageBuilder):
+class MyTypeAliasPageBuilder(mixin_custom_template('type_alias'), TypeAliasPageBuilder):  # type: ignore[misc]
     """Use a custom template for type alias pages."""
 
 

--- a/dev_tools/requirements/deps/mypy.txt
+++ b/dev_tools/requirements/deps/mypy.txt
@@ -1,3 +1,3 @@
 # the mypy dependency file
-mypy~=0.991.0
+mypy
 mypy-protobuf

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -335,7 +335,7 @@ more-itertools==10.2.0
     #   jaraco-functools
 mpmath==1.3.0
     # via sympy
-mypy==0.991
+mypy==1.9.0
     # via -r deps/mypy.txt
 mypy-extensions==1.0.0
     # via

--- a/qualtran/_infra/adjoint_test.py
+++ b/qualtran/_infra/adjoint_test.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
+from typing import Dict, TYPE_CHECKING
 
 import pytest
 import sympy
@@ -25,6 +26,9 @@ from qualtran.bloqs.for_testing.with_call_graph import TestBloqWithCallGraph
 from qualtran.bloqs.for_testing.with_decomposition import TestParallelCombo, TestSerialCombo
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import LarrowTextBox, RarrowTextBox
+
+if TYPE_CHECKING:
+    from qualtran import BloqBuilder, SoquetT
 
 
 def test_serial_combo_adjoint():
@@ -179,7 +183,7 @@ class DecomposesIntoTAcceptsAdjoint(Bloq):
     def signature(self) -> Signature:
         return Signature.build(q=1)
 
-    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT'):
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
         soqs = bb.add_d(TAcceptsAdjoint(), **soqs)
         return soqs
 

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -16,7 +16,7 @@
 """Contains the main interface for defining `Bloq`s."""
 
 import abc
-from typing import Any, Dict, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import Any, Dict, Optional, Sequence, Set, Tuple, Type, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     import cirq
@@ -297,7 +297,7 @@ class Bloq(metaclass=abc.ABCMeta):
     def call_graph(
         self,
         generalizer: Optional[Union['GeneralizerT', Sequence['GeneralizerT']]] = None,
-        keep: Optional[Sequence['Bloq']] = None,
+        keep: Callable[['Bloq'], bool] = None,
         max_depth: Optional[int] = None,
     ) -> Tuple['nx.DiGraph', Dict['Bloq', Union[int, 'sympy.Expr']]]:
         """Get the bloq call graph and call totals.
@@ -480,7 +480,7 @@ class Bloq(metaclass=abc.ABCMeta):
         return cirq.Gate.on(BloqAsCirqGate(bloq=self), *qubits)
 
     def on_registers(
-        self, **qubit_regs: Union['cirq.Qid', Sequence['cirq.Qid'], 'NDArray[cirq.Qid]']
+        self, **qubit_regs: Union['cirq.Qid', Sequence['cirq.Qid'], 'NDArray[cirq.Qid]']  # type: ignore[type-var]
     ) -> 'cirq.Operation':
         """A `cirq.Operation` of this bloq operating on the given qubit registers.
 

--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -27,6 +27,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Type,
     TYPE_CHECKING,
     Union,
 )
@@ -911,7 +912,7 @@ class BloqBuilder:
         binst = BloqInstance(bloq, i=self._new_binst_i())
         return dict(self._add_binst(binst, in_soqs=in_soqs))
 
-    def add(self, bloq: Bloq, **in_soqs: SoquetInT) -> Union[None, SoquetT, Tuple[SoquetT, ...]]:
+    def add(self, bloq: Bloq, **in_soqs: SoquetInT):
         """Add a new bloq instance to the compute graph.
 
         This is the primary method for building a composite bloq. Each call to `add` adds a

--- a/qualtran/_infra/controlled.py
+++ b/qualtran/_infra/controlled.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 
 def _cvs_convert(
     cvs: Union[int, Sequence[int], Sequence[Sequence[int]]]
-) -> Tuple[NDArray[int], ...]:
+) -> Tuple[NDArray[np.integer], ...]:
     if isinstance(cvs, (int, np.integer)):
         return (np.array(cvs),)
     if isinstance(cvs, np.ndarray):
@@ -103,7 +103,7 @@ class CtrlSpec:
     qdtypes: Tuple[QDType, ...] = attrs.field(
         default=QBit(), converter=lambda qt: (qt,) if isinstance(qt, QDType) else tuple(qt)
     )
-    cvs: Tuple[NDArray[int], ...] = attrs.field(default=1, converter=_cvs_convert)
+    cvs: Tuple[NDArray[np.integer], ...] = attrs.field(default=1, converter=_cvs_convert)
 
     def __attrs_post_init__(self):
         assert len(self.qdtypes) == len(self.cvs)

--- a/qualtran/_infra/controlled_test.py
+++ b/qualtran/_infra/controlled_test.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, TYPE_CHECKING
 
 import attrs
 import cirq
@@ -48,6 +48,9 @@ from qualtran.bloqs.mcmt import And
 from qualtran.cirq_interop.testing import GateHelper
 from qualtran.drawing import get_musical_score_data
 from qualtran.drawing.musical_score import Circle, SoqData, TextBox
+
+if TYPE_CHECKING:
+    from qualtran import SoquetT
 
 
 def test_ctrl_spec():
@@ -374,7 +377,7 @@ class TestCtrlStatePrepAnd(Bloq):
         and_ctrl = [bb.add(one_or_zero[cv]) for cv in self.and_ctrl]
 
         ctrl_soqs = bb.add_d(cbloq, **ctrl_soqs, ctrl=and_ctrl)
-        out_soqs = [*ctrl_soqs.pop('ctrl'), ctrl_soqs.pop('target')]
+        out_soqs = np.asarray([*ctrl_soqs.pop('ctrl'), ctrl_soqs.pop('target')])
 
         for reg, cvs in zip(cbloq.ctrl_regs, self.ctrl_spec.cvs):
             for idx in reg.all_idxs():

--- a/qualtran/_infra/data_types.py
+++ b/qualtran/_infra/data_types.py
@@ -50,7 +50,7 @@ respectively.
 
 import abc
 from enum import Enum
-from typing import Any, Iterable, List, Sequence, Union
+from typing import Any, cast, Iterable, List, Sequence, Union
 
 import attrs
 import numpy as np
@@ -133,7 +133,9 @@ class QBit(QDType):
         assert len(bits) == 1
         return bits[0]
 
-    def assert_valid_classical_val_array(self, val_array: NDArray[int], debug_str: str = 'val'):
+    def assert_valid_classical_val_array(
+        self, val_array: NDArray[np.integer], debug_str: str = 'val'
+    ):
         if not np.all((val_array == 0) | (val_array == 1)):
             raise ValueError(f"Bad {self} value array in {debug_str}")
 
@@ -192,7 +194,7 @@ class QInt(QDType):
     def to_bits(self, x: int) -> List[int]:
         """Yields individual bits corresponding to binary representation of x"""
         self.assert_valid_classical_val(x)
-        mask = (1 << self.bitsize) - 1
+        mask = (1 << cast(int, self.bitsize)) - 1
         return QUInt(self.bitsize).to_bits(int(x) & mask)
 
     def from_bits(self, bits: Sequence[int]) -> int:
@@ -209,7 +211,9 @@ class QInt(QDType):
         if val >= 2 ** (self.bitsize - 1):
             raise ValueError(f"Too-large classical {self}: {val} encountered in {debug_str}")
 
-    def assert_valid_classical_val_array(self, val_array: NDArray[int], debug_str: str = 'val'):
+    def assert_valid_classical_val_array(
+        self, val_array: NDArray[np.integer], debug_str: str = 'val'
+    ):
         if np.any(val_array < -(2 ** (self.bitsize - 1))):
             raise ValueError(f"Too-small classical {self}s encountered in {debug_str}")
         if np.any(val_array >= 2 ** (self.bitsize - 1)):
@@ -298,7 +302,9 @@ class QUInt(QDType):
         if val >= 2**self.bitsize:
             raise ValueError(f"Too-large classical value encountered in {debug_str}")
 
-    def assert_valid_classical_val_array(self, val_array: NDArray[int], debug_str: str = 'val'):
+    def assert_valid_classical_val_array(
+        self, val_array: NDArray[np.integer], debug_str: str = 'val'
+    ):
         if np.any(val_array < 0):
             raise ValueError(f"Negative classical values encountered in {debug_str}")
         if np.any(val_array >= 2**self.bitsize):
@@ -391,7 +397,9 @@ class BoundedQUInt(QDType):
         """Combine individual bits to form x"""
         return QUInt(self.bitsize).from_bits(bits)
 
-    def assert_valid_classical_val_array(self, val_array: NDArray[int], debug_str: str = 'val'):
+    def assert_valid_classical_val_array(
+        self, val_array: NDArray[np.integer], debug_str: str = 'val'
+    ):
         if np.any(val_array < 0):
             raise ValueError(f"Negative classical values encountered in {debug_str}")
         if np.any(val_array >= self.iteration_length):
@@ -539,7 +547,9 @@ class QMontgomeryUInt(QDType):
         if val >= 2**self.bitsize:
             raise ValueError(f"Too-large classical value encountered in {debug_str}")
 
-    def assert_valid_classical_val_array(self, val_array: NDArray[int], debug_str: str = 'val'):
+    def assert_valid_classical_val_array(
+        self, val_array: NDArray[np.integer], debug_str: str = 'val'
+    ):
         if np.any(val_array < 0):
             raise ValueError(f"Negative classical values encountered in {debug_str}")
         if np.any(val_array >= 2**self.bitsize):

--- a/qualtran/_infra/gate_with_registers_test.py
+++ b/qualtran/_infra/gate_with_registers_test.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
 
 import cirq
 import numpy as np
@@ -32,6 +32,9 @@ from qualtran import (
 from qualtran.bloqs.basic_gates import XGate, YGate, ZGate
 from qualtran.bloqs.util_bloqs import Power
 from qualtran.testing import execute_notebook
+
+if TYPE_CHECKING:
+    from qualtran import BloqBuilder
 
 
 class _TestGate(GateWithRegisters):

--- a/qualtran/_infra/quantum_graph.py
+++ b/qualtran/_infra/quantum_graph.py
@@ -16,6 +16,7 @@
 
 from typing import Tuple, TYPE_CHECKING, Union
 
+import numpy as np
 from attrs import field, frozen
 
 if TYPE_CHECKING:
@@ -79,7 +80,7 @@ def _to_tuple(x: Union[int, Tuple[int, ...]]) -> Tuple[int, ...]:
 
 
 @frozen
-class Soquet:
+class Soquet(np.generic):
     """One half of a connection.
 
     Users should not construct these directly. They should be marshalled

--- a/qualtran/_infra/registers.py
+++ b/qualtran/_infra/registers.py
@@ -16,10 +16,11 @@
 import enum
 import itertools
 from collections import defaultdict
-from typing import Dict, Iterable, Iterator, List, overload, Tuple
+from typing import Dict, Iterable, Iterator, List, overload, Tuple, Union
 
 import attrs
 import numpy as np
+import sympy
 from attrs import field, frozen
 
 from .data_types import QAny, QBit, QDType
@@ -128,7 +129,7 @@ class Signature:
         self._rights = _dedupe((reg.name, reg) for reg in self._registers if reg.side & Side.RIGHT)
 
     @classmethod
-    def build(cls, **registers: int) -> 'Signature':
+    def build(cls, **registers: Union[int, sympy.Expr]) -> 'Signature':
         """Construct a Signature comprised of simple thru registers given the register bitsizes.
 
         Args:

--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -195,7 +195,7 @@ class Add(Bloq):
             yield from self._right_building_block(inp, out, anc, depth - 1)
 
     def decompose_from_registers(
-        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         # reverse the order of qubits for big endian-ness.
         input_bits = quregs['a'][::-1]

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -45,6 +45,7 @@ from qualtran.drawing import WireSymbol
 from qualtran.drawing.musical_score import TextBox
 
 if TYPE_CHECKING:
+    from qualtran import BloqBuilder
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
@@ -87,7 +88,7 @@ class LessThanConstant(GateWithRegisters, cirq.ArithmeticGate):
         return NotImplemented  # pragma: no cover
 
     def decompose_from_registers(
-        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         """Decomposes the gate into 4N And and And† operations for a T complexity of 4N.
 

--- a/qualtran/bloqs/arithmetic/hamming_weight.py
+++ b/qualtran/bloqs/arithmetic/hamming_weight.py
@@ -93,7 +93,7 @@ class HammingWeightCompute(GateWithRegisters):
             x = [*y]
 
     def decompose_from_registers(
-        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         # Qubit order needs to be reversed because the registers store Big Endian representation
         # of integers.

--- a/qualtran/bloqs/arithmetic/multiplication.py
+++ b/qualtran/bloqs/arithmetic/multiplication.py
@@ -34,6 +34,8 @@ from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.resource_counting.symbolic_counting_utils import smax
 
 if TYPE_CHECKING:
+    import quimb.tensor as qtn
+
     from qualtran import SoquetT
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT

--- a/qualtran/bloqs/basic_gates/cnot.py
+++ b/qualtran/bloqs/basic_gates/cnot.py
@@ -123,8 +123,8 @@ class CNOT(Bloq):
         return super().get_ctrl_system(ctrl_spec=ctrl_spec)
 
     def as_cirq_op(
-        self, qubit_manager: 'cirq.QubitManager', ctrl: 'CirqQuregT', target: 'CirqQuregT'
-    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
+        self, qubit_manager: 'cirq.QubitManager', ctrl: 'CirqQuregT', target: 'CirqQuregT'  # type: ignore[type-var]
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:  # type: ignore[type-var]
         import cirq
 
         (ctrl,) = ctrl

--- a/qualtran/bloqs/basic_gates/hadamard.py
+++ b/qualtran/bloqs/basic_gates/hadamard.py
@@ -82,8 +82,8 @@ class Hadamard(Bloq):
         )
 
     def as_cirq_op(
-        self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'
-    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
+        self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'  # type: ignore[type-var]
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:  # type: ignore[type-var]
         import cirq
 
         (q,) = q

--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -13,10 +13,11 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Protocol
+from typing import Protocol, Union
 
 import cirq
 import numpy as np
+import sympy
 from attrs import frozen
 
 from qualtran import bloq_example, BloqDocSpec, CompositeBloq, DecomposeTypeError
@@ -263,7 +264,7 @@ class Rz(CirqGateAsBloqBase):
         of z-rotations](https://arxiv.org/pdf/1403.2975.pdf).
     """
 
-    angle: float
+    angle: Union[sympy.expr, float]
     eps: float = 1e-11
 
     def decompose_bloq(self) -> 'CompositeBloq':
@@ -276,7 +277,7 @@ class Rz(CirqGateAsBloqBase):
 
 @frozen
 class Rx(CirqGateAsBloqBase):
-    angle: float
+    angle: Union[sympy.expr, float]
     eps: float = 1e-11
 
     def decompose_bloq(self) -> 'CompositeBloq':

--- a/qualtran/bloqs/basic_gates/s_gate.py
+++ b/qualtran/bloqs/basic_gates/s_gate.py
@@ -75,8 +75,8 @@ class SGate(Bloq):
         )
 
     def as_cirq_op(
-        self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'
-    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
+        self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'  # type:ignore[type-var]
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:  # type:ignore[type-var]
         import cirq
 
         (q,) = q

--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -42,6 +42,7 @@ from qualtran.resource_counting.generalizers import ignore_split_join
 from .t_gate import TGate
 
 if TYPE_CHECKING:
+    from qualtran import CompositeBloq
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
@@ -74,8 +75,8 @@ class TwoBitSwap(Bloq):
         return Signature.build(x=1, y=1)
 
     def as_cirq_op(
-        self, qubit_manager: 'cirq.QubitManager', x: 'CirqQuregT', y: 'CirqQuregT'
-    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
+        self, qubit_manager: 'cirq.QubitManager', x: 'CirqQuregT', y: 'CirqQuregT'  # type: ignore[type-var]
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:  # type: ignore[type-var]
         (x,) = x
         (y,) = y
         return cirq.SWAP.on(x, y), {'x': [x], 'y': [y]}
@@ -129,9 +130,9 @@ class TwoBitCSwap(Bloq):
         self,
         *,
         context: cirq.DecompositionContext,
-        ctrl: NDArray[cirq.Qid],
-        x: NDArray[cirq.Qid],
-        y: NDArray[cirq.Qid],
+        ctrl: NDArray[cirq.Qid],  # type: ignore[type-var]
+        x: NDArray[cirq.Qid],  # type: ignore[type-var]
+        y: NDArray[cirq.Qid],  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         (ctrl,) = ctrl
         (x,) = x

--- a/qualtran/bloqs/basic_gates/swap_test.py
+++ b/qualtran/bloqs/basic_gates/swap_test.py
@@ -116,8 +116,8 @@ def _set_ctrl_swap(ctrl_bit, bloq: CSwap):
 
     bb = BloqBuilder()
     q0 = bb.add(states[ctrl_bit])
-    q1 = bb.add_register('q1', bloq.bitsize)
-    q2 = bb.add_register('q2', bloq.bitsize)
+    q1 = bb.add_register('q1', int(bloq.bitsize))
+    q2 = bb.add_register('q2', int(bloq.bitsize))
     q0, q1, q2 = bb.add(bloq, ctrl=q0, x=q1, y=q2)
     bb.add(effs[ctrl_bit], q=q0)
     return bb.finalize(q1=q1, q2=q2)

--- a/qualtran/bloqs/basic_gates/t_gate.py
+++ b/qualtran/bloqs/basic_gates/t_gate.py
@@ -95,8 +95,8 @@ class TGate(Bloq):
         return attrs.evolve(self, is_adjoint=not self.is_adjoint)
 
     def as_cirq_op(
-        self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'
-    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
+        self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'  # type: ignore[type-var]
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:  # type: ignore[type-var]
         import cirq
 
         (q,) = q

--- a/qualtran/bloqs/basic_gates/toffoli.py
+++ b/qualtran/bloqs/basic_gates/toffoli.py
@@ -105,8 +105,8 @@ class Toffoli(Bloq):
         return {'ctrl': ctrl, 'target': target}
 
     def as_cirq_op(
-        self, qubit_manager: 'cirq.QubitManager', ctrl: 'CirqQuregT', target: 'CirqQuregT'
-    ) -> Tuple[Union['cirq.Operation', None], Dict[str, 'CirqQuregT']]:
+        self, qubit_manager: 'cirq.QubitManager', ctrl: 'CirqQuregT', target: 'CirqQuregT'  # type: ignore[type-var]
+    ) -> Tuple[Union['cirq.Operation', None], Dict[str, 'CirqQuregT']]:  # type: ignore[type-var]
         import cirq
 
         (trg,) = target

--- a/qualtran/bloqs/basic_gates/x_basis.py
+++ b/qualtran/bloqs/basic_gates/x_basis.py
@@ -89,8 +89,8 @@ class _XVector(Bloq):
         )
 
     def as_cirq_op(
-        self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'
-    ) -> Tuple[Union['cirq.Operation', None], Dict[str, 'CirqQuregT']]:
+        self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'  # type: ignore[type-var]
+    ) -> Tuple[Union['cirq.Operation', None], Dict[str, 'CirqQuregT']]:  # type: ignore[type-var]
         if not self.state:
             raise ValueError(f"There is no Cirq equivalent for {self}")
 
@@ -234,7 +234,7 @@ class XGate(Bloq):
         from qualtran.bloqs.basic_gates import CNOT, Toffoli
 
         if ctrl_spec is None or ctrl_spec == CtrlSpec():
-            bloq = CNOT()
+            bloq: 'Bloq' = CNOT()
         elif ctrl_spec == CtrlSpec(cvs=(1, 1)):
             bloq = Toffoli()
         else:
@@ -256,7 +256,7 @@ class XGate(Bloq):
         return {'q': (q + 1) % 2}
 
     def as_cirq_op(
-        self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'
+        self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'
     ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
         import cirq
 

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -112,8 +112,8 @@ class _ZVector(Bloq):
         return {}
 
     def as_cirq_op(
-        self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'
-    ) -> Tuple[Union['cirq.Operation', None], Dict[str, 'CirqQuregT']]:
+        self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'  # type: ignore[type-var]
+    ) -> Tuple[Union['cirq.Operation', None], Dict[str, 'CirqQuregT']]:  # type: ignore[type-var]
         if not self.state:
             raise ValueError(f"There is no Cirq equivalent for {self}")
 

--- a/qualtran/bloqs/chemistry/chem_tutorials.py
+++ b/qualtran/bloqs/chemistry/chem_tutorials.py
@@ -37,20 +37,20 @@ def linear(x: NDArray[np.float64], a: float, c: float) -> NDArray[np.float64]:
 def fit_linear(x: NDArray[np.float64], y: NDArray[np.float64]) -> Tuple[float, float]:
     """Fit a line given x and y values.
 
-    Args
+    Args:
         x: the independent variable (x value) for the linear fit.
         y: the dependent (y) for the linear fit.
 
-    Returns
+    Returns:
         slope: The slope of the linear fit.
         intercept: the intercept of the linear fit.
+
+    Raises:
+        np.linalg.LinAlgError: if fitting fails.
     """
-    try:
-        # pylint: disable-next=unbalanced-tuple-unpacking
-        popt, _ = scipy.optimize.curve_fit(linear, x, y)
-        return popt
-    except np.linalg.LinAlgError:
-        return None
+    # pylint: disable-next=unbalanced-tuple-unpacking
+    popt, _ = scipy.optimize.curve_fit(linear, x, y)
+    return popt
 
 
 def gen_random_chem_ham(num_spin_orb: int):

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/select_and_prepare.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/select_and_prepare.py
@@ -40,6 +40,7 @@ from qualtran.bloqs.swap_network import MultiplexedCSwap
 from qualtran.drawing import TextBox, WireSymbol
 
 if TYPE_CHECKING:
+    from qualtran import Soquet
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 
 

--- a/qualtran/bloqs/chemistry/thc/notebook_utils.py
+++ b/qualtran/bloqs/chemistry/thc/notebook_utils.py
@@ -53,7 +53,7 @@ def custom_qroam_repr(self) -> str:
 
 
 # TODO: better way of customizing label
-SelectSwapQROM.__repr__ = custom_qroam_repr
+SelectSwapQROM.__repr__ = custom_qroam_repr  # type: ignore[assignment]
 
 
 def custom_qrom_repr(self) -> str:
@@ -62,7 +62,8 @@ def custom_qrom_repr(self) -> str:
     return f"QROM(selection_bitsizes={selection_repr}, target_bitsizes={target_repr})"
 
 
-QROM.__repr__ = custom_qrom_repr
+# TODO: better way of customizing label
+QROM.__repr__ = custom_qrom_repr  # type: ignore[assignment]
 
 
 def custom_generalizations(bloq: Bloq) -> Optional[Bloq]:

--- a/qualtran/bloqs/factoring/mod_add.py
+++ b/qualtran/bloqs/factoring/mod_add.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Set, Union
+from typing import Dict, Set, TYPE_CHECKING, Union
 
 import numpy as np
 import sympy
@@ -26,6 +26,9 @@ from qualtran.bloqs.basic_gates import TGate, XGate
 from qualtran.drawing import Circle, TextBox, WireSymbol
 from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 from qualtran.simulation.classical_sim import ClassicalValT
+
+if TYPE_CHECKING:
+    from qualtran import BloqBuilder, Soquet
 
 
 @frozen

--- a/qualtran/bloqs/factoring/mod_exp_test.py
+++ b/qualtran/bloqs/factoring/mod_exp_test.py
@@ -77,7 +77,7 @@ def test_mod_exp_consistent_counts():
             return attrs.evolve(b, k=my_k)
         if isinstance(b, (Split, Join)):
             # Ignore these
-            return
+            return None
         return b
 
     counts2 = bloq.decompose_bloq().bloq_counts(generalizer=generalize)

--- a/qualtran/bloqs/factoring/mod_mul_test.py
+++ b/qualtran/bloqs/factoring/mod_mul_test.py
@@ -118,7 +118,7 @@ def test_consistent_counts():
             return attrs.evolve(b, k=my_k)
 
         if isinstance(b, (Free, Allocate)):
-            return
+            return None
         return b
 
     counts2 = bloq.decompose_bloq().bloq_counts(generalizer=generalize)

--- a/qualtran/bloqs/factoring/mod_sub.py
+++ b/qualtran/bloqs/factoring/mod_sub.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
 
 from attrs import frozen
 
@@ -22,6 +22,10 @@ from qualtran.bloqs.arithmetic.addition import SimpleAddConstant
 from qualtran.bloqs.basic_gates import CNOT, XGate
 from qualtran.bloqs.factoring.mod_add import MontgomeryModAdd
 from qualtran.bloqs.mcmt.multi_control_multi_target_pauli import MultiControlX
+
+if TYPE_CHECKING:
+    from qualtran import BloqBuilder
+    from qualtran.simulation.classical_sim import ClassicalValT
 
 
 @frozen

--- a/qualtran/bloqs/for_testing/qubitization_walk_test.py
+++ b/qualtran/bloqs/for_testing/qubitization_walk_test.py
@@ -42,7 +42,7 @@ class PrepareUniformSuperpositionTest(PrepareOracle):
         return Signature.build()
 
     def decompose_from_registers(
-        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         yield PrepareUniformSuperposition(self.n, self.cvs).on_registers(target=quregs['selection'])
 

--- a/qualtran/bloqs/for_testing/with_decomposition.py
+++ b/qualtran/bloqs/for_testing/with_decomposition.py
@@ -13,12 +13,16 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict
+from typing import Any, Dict, TYPE_CHECKING, Union
 
 from attrs import frozen
+from numpy.typing import NDArray
 
 from qualtran import Bloq, BloqBuilder, Signature, Soquet
 from qualtran.bloqs.for_testing.atom import TestAtom
+
+if TYPE_CHECKING:
+    from qualtran import SoquetT
 
 
 @frozen
@@ -29,7 +33,7 @@ class TestSerialCombo(Bloq):
     def signature(self) -> Signature:
         return Signature.build(reg=1)
 
-    def build_composite_bloq(self, bb: 'BloqBuilder', reg: 'SoquetT') -> Dict[str, 'Soquet']:
+    def build_composite_bloq(self, bb: 'BloqBuilder', reg: 'SoquetT') -> Dict[str, 'SoquetT']:
         for i in range(3):
             reg = bb.add(TestAtom(tag=f'atom{i}'), q=reg)
         return {'reg': reg}
@@ -43,7 +47,8 @@ class TestParallelCombo(Bloq):
     def signature(self) -> Signature:
         return Signature.build(reg=3)
 
-    def build_composite_bloq(self, bb: 'BloqBuilder', reg: 'SoquetT') -> Dict[str, 'Soquet']:
+    def build_composite_bloq(self, bb: 'BloqBuilder', reg: 'SoquetT') -> Dict[str, 'SoquetT']:
+        assert isinstance(Soquet, reg)
         reg = bb.split(reg)
         for i in range(len(reg)):
             reg[i] = bb.add(TestAtom(), q=reg[i])
@@ -59,7 +64,7 @@ class TestIndependentParallelCombo(Bloq):
     def signature(self) -> Signature:
         return Signature.build()
 
-    def build_composite_bloq(self, bb: 'BloqBuilder') -> Dict[str, 'Soquet']:
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
         for _ in range(3):
             reg = bb.allocate(1)
             reg = bb.add(TestAtom(), q=reg)

--- a/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp.py
+++ b/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Dict, Set, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
 
 import numpy as np
 from attrs import field, frozen

--- a/qualtran/bloqs/mcmt/and_bloq.py
+++ b/qualtran/bloqs/mcmt/and_bloq.py
@@ -167,7 +167,7 @@ class And(GateWithRegisters):
         return Circle(filled)
 
     def decompose_from_registers(
-        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         """Decomposes a single `And` gate on 2 controls and 1 target in terms of Clifford+T gates.
 

--- a/qualtran/bloqs/mcmt/and_bloq_test.py
+++ b/qualtran/bloqs/mcmt/and_bloq_test.py
@@ -22,7 +22,7 @@ import pytest
 from attrs import frozen
 
 import qualtran.testing as qlt_testing
-from qualtran import Bloq, BloqBuilder, Signature, SoquetT
+from qualtran import Bloq, BloqBuilder, Signature, Soquet, SoquetT
 from qualtran.bloqs.basic_gates import OneEffect, OneState, ZeroEffect, ZeroState
 from qualtran.bloqs.mcmt.and_bloq import _and_bloq, _multi_and, And, MultiAnd
 from qualtran.drawing import Circle, get_musical_score_data
@@ -186,6 +186,8 @@ class AndIdentity(Bloq):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', q0: 'SoquetT', q1: 'SoquetT'
     ) -> Dict[str, 'SoquetT']:
+        assert isinstance(q0, Soquet)
+        assert isinstance(q1, Soquet)
         qs, trg = bb.add(And(), ctrl=[q0, q1])
         q0, q1 = bb.add(And(uncompute=True), ctrl=qs, target=trg)
         return {'q0': q0, 'q1': q1}

--- a/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
+++ b/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
@@ -36,7 +36,10 @@ from qualtran.bloqs.basic_gates import CNOT, Toffoli, XGate
 from qualtran.bloqs.mcmt.and_bloq import And, MultiAnd
 
 if TYPE_CHECKING:
+    import quimb.tensor as qtn
+
     from qualtran.resource_counting.bloq_counts import BloqCountT, SympySymbolAllocator
+    from qualtran.simulation.classical_sim import ClassicalValT
 
 
 @frozen
@@ -64,7 +67,7 @@ class MultiTargetCNOT(GateWithRegisters):
         control: NDArray[cirq.Qid],
         targets: NDArray[cirq.Qid],
     ):
-        def cnots_for_depth_i(i: int, q: NDArray[cirq.Qid]) -> cirq.OP_TREE:
+        def cnots_for_depth_i(i: int, q: NDArray[cirq.Qid]) -> cirq.OP_TREE:  # type: ignore[type-var]
             for c, t in zip(q[: 2**i], q[2**i : min(len(q), 2 ** (i + 1))]):
                 yield cirq.CNOT(c, t)
 

--- a/qualtran/bloqs/phase_estimation/lp_resource_state.py
+++ b/qualtran/bloqs/phase_estimation/lp_resource_state.py
@@ -58,7 +58,7 @@ class LPRSInterimPrep(GateWithRegisters):
         return 'LPRS'
 
     def decompose_from_registers(
-        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         q, anc = quregs['m'].tolist()[::-1], quregs['anc']
         yield [OnEach(self.bitsize, Hadamard()).on(*q), Hadamard().on(*anc)]

--- a/qualtran/bloqs/phase_estimation/qubitization_qpe.py
+++ b/qualtran/bloqs/phase_estimation/qubitization_qpe.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Set, Tuple
+from typing import Set, Tuple, TYPE_CHECKING
 
 import attrs
 import cirq
@@ -29,6 +29,9 @@ from qualtran.resource_counting.symbolic_counting_utils import (
     SymbolicFloat,
     SymbolicInt,
 )
+
+if TYPE_CHECKING:
+    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 
 
 @attrs.frozen

--- a/qualtran/bloqs/phase_estimation/text_book_qpe.py
+++ b/qualtran/bloqs/phase_estimation/text_book_qpe.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Set, Tuple
+from typing import Set, Tuple, TYPE_CHECKING
 
 import attrs
 import cirq
@@ -28,6 +28,9 @@ from qualtran.resource_counting.symbolic_counting_utils import (
     SymbolicFloat,
     SymbolicInt,
 )
+
+if TYPE_CHECKING:
+    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 
 
 @attrs.frozen

--- a/qualtran/bloqs/qft/approximate_qft.py
+++ b/qualtran/bloqs/qft/approximate_qft.py
@@ -113,7 +113,7 @@ class ApproximateQFT(GateWithRegisters):
         )
 
     def decompose_from_registers(
-        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         if self.bitsize == 1:
             yield cirq.H(*quregs['q'])

--- a/qualtran/bloqs/qft/qft_phase_gradient.py
+++ b/qualtran/bloqs/qft/qft_phase_gradient.py
@@ -59,7 +59,7 @@ class QFTPhaseGradient(GateWithRegisters):
         )
 
     def decompose_from_registers(
-        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         if self.bitsize == 1:
             yield cirq.H(*quregs['q'])

--- a/qualtran/bloqs/qft/qft_text_book.py
+++ b/qualtran/bloqs/qft/qft_text_book.py
@@ -43,7 +43,7 @@ class QFTTextBook(GateWithRegisters):
         return Signature.build_from_dtypes(q=QUInt(self.bitsize))
 
     def decompose_from_registers(
-        self, *, context: cirq.DecompositionContext, q: NDArray[cirq.Qid]
+        self, *, context: cirq.DecompositionContext, q: NDArray[cirq.Qid]  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         yield cirq.H(q[0])
         for i in range(1, len(q)):

--- a/qualtran/bloqs/qsp/generalized_qsp.py
+++ b/qualtran/bloqs/qsp/generalized_qsp.py
@@ -357,7 +357,7 @@ class GeneralizedQSP(GateWithRegisters):
         return self._qsp_phases[2]
 
     @cached_property
-    def signal_rotations(self) -> NDArray[SU2RotationGate]:
+    def signal_rotations(self) -> NDArray[SU2RotationGate]:  # type: ignore[type-var]
         return np.array(
             [
                 SU2RotationGate(theta, phi, self._lambda if i == 0 else 0)
@@ -366,7 +366,7 @@ class GeneralizedQSP(GateWithRegisters):
         )
 
     def decompose_from_registers(
-        self, *, context: 'cirq.DecompositionContext', signal, **quregs: NDArray['cirq.Qid']
+        self, *, context: 'cirq.DecompositionContext', signal, **quregs: NDArray['cirq.Qid']  # type: ignore[type-var]
     ) -> 'cirq.OP_TREE':
         (signal_qubit,) = signal
 

--- a/qualtran/bloqs/reflection.py
+++ b/qualtran/bloqs/reflection.py
@@ -42,7 +42,7 @@ class Reflection(Bloq):
         cvs: The control values for each register.
     """
     bitsizes: Tuple[int, ...] = attrs.field(converter=tuple)
-    cvs: Tuple[int] = attrs.field(converter=tuple)
+    cvs: Tuple[int, ...] = attrs.field(converter=tuple)
 
     def __attrs_post_init__(self):
         if len(self.bitsizes) != len(self.cvs):

--- a/qualtran/bloqs/rotations/phase_gradient.py
+++ b/qualtran/bloqs/rotations/phase_gradient.py
@@ -29,7 +29,12 @@ from qualtran.bloqs.basic_gates.rotation import CZPowGate, ZPowGate
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 
 if TYPE_CHECKING:
+    import quimb.tensor as qtn
+
+    from qualtran import Bloq, SoquetT
+    from qualtran.resource_counting import SympySymbolAllocator
     from qualtran.resource_counting.bloq_counts import BloqCountT
+    from qualtran.simulation.classical_sim import ClassicalValT
 
 
 @attrs.frozen
@@ -66,7 +71,7 @@ class PhaseGradientUnitary(GateWithRegisters):
         )
 
     def decompose_from_registers(
-        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         ctrl = quregs.get('ctrl', ())
         gate = CZPowGate if self.controlled else ZPowGate

--- a/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
+++ b/qualtran/bloqs/rotations/phasing_via_cost_function_test.py
@@ -59,9 +59,13 @@ class TestHammingWeightPhasing(GateWithRegisters):
         )
 
     @property
+    def phase_gradient_oracle(self) -> QvrPhaseGradient:
+        return QvrPhaseGradient(self.cost_reg, self.exponent / 2, self.eps)
+
+    @property
     def phase_oracle(self) -> QvrInterface:
         if self.use_phase_gradient:
-            return QvrPhaseGradient(self.cost_reg, self.exponent / 2, self.eps)
+            return self.phase_gradient_oracle
         else:
             return QvrZPow(self.cost_reg, self.exponent / 2, self.eps)
 
@@ -71,11 +75,11 @@ class TestHammingWeightPhasing(GateWithRegisters):
 
     def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
         if self.use_phase_gradient:
-            soqs['phase_grad'] = bb.add(PhaseGradientState(self.phase_oracle.b_grad))
+            soqs['phase_grad'] = bb.add(PhaseGradientState(self.phase_gradient_oracle.b_grad))
         soqs = bb.add_d(PhasingViaCostFunction(self.cost_eval_oracle, self.phase_oracle), **soqs)
         if self.use_phase_gradient:
             bb.add(
-                PhaseGradientState(self.phase_oracle.b_grad).adjoint(),
+                PhaseGradientState(self.phase_gradient_oracle.b_grad).adjoint(),
                 phase_grad=soqs.pop('phase_grad'),
             )
         return soqs
@@ -132,9 +136,13 @@ class TestSquarePhasing(GateWithRegisters):
         )
 
     @property
+    def phase_gradient_oracle(self) -> QvrPhaseGradient:
+        return QvrPhaseGradient(self.cost_reg, self.gamma, self.eps)
+
+    @property
     def phase_oracle(self) -> QvrInterface:
         if self.use_phase_gradient:
-            return QvrPhaseGradient(self.cost_reg, self.gamma, self.eps)
+            return self.phase_gradient_oracle
         else:
             return QvrZPow(self.cost_reg, self.gamma, self.eps)
 
@@ -144,11 +152,11 @@ class TestSquarePhasing(GateWithRegisters):
 
     def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
         if self.use_phase_gradient:
-            soqs['phase_grad'] = bb.add(PhaseGradientState(self.phase_oracle.b_grad))
+            soqs['phase_grad'] = bb.add(PhaseGradientState(self.phase_gradient_oracle.b_grad))
         soqs = bb.add_d(PhasingViaCostFunction(self.cost_eval_oracle, self.phase_oracle), **soqs)
         if self.use_phase_gradient:
             bb.add(
-                PhaseGradientState(self.phase_oracle.b_grad).adjoint(),
+                PhaseGradientState(self.phase_gradient_oracle.b_grad).adjoint(),
                 phase_grad=soqs.pop('phase_grad'),
             )
         return soqs

--- a/qualtran/bloqs/rotations/quantum_variable_rotation.py
+++ b/qualtran/bloqs/rotations/quantum_variable_rotation.py
@@ -84,6 +84,7 @@ from qualtran.resource_counting.symbolic_counting_utils import (
 
 if TYPE_CHECKING:
     from qualtran import SoquetT
+    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 
 
 class QvrInterface(GateWithRegisters, metaclass=abc.ABCMeta):

--- a/qualtran/bloqs/state_preparation/state_preparation_via_rotation_test.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_via_rotation_test.py
@@ -64,8 +64,9 @@ def test_state_prep_via_rotation(bloq_autotester):
     ],
 )
 def test_exact_state_prep_via_rotation_(phase_bitsize: int, state_coefs: Tuple[complex, ...]):
+    # https://github.com/python/mypy/issues/5313
     qsp = StatePreparationViaRotations(
-        phase_bitsize=phase_bitsize, state_coefficients=tuple(state_coefs)
+        phase_bitsize=phase_bitsize, state_coefficients=state_coefs  # type: ignore[arg-type]
     )
     assert_valid_bloq_decomposition(qsp)
     bb = BloqBuilder()
@@ -102,11 +103,12 @@ def test_exact_state_prep_via_rotation_(phase_bitsize: int, state_coefs: Tuple[c
 def test_state_prep_via_rotation_adjoint(
     phase_bitsize: int, state_coefs: Tuple[complex, ...]
 ) -> None:
+    # https://github.com/python/mypy/issues/5313
     qsp = StatePreparationViaRotations(
-        phase_bitsize=phase_bitsize, state_coefficients=tuple(state_coefs)
+        phase_bitsize=phase_bitsize, state_coefficients=state_coefs  # type: ignore[arg-type]
     )
     qsp_adj = StatePreparationViaRotations(
-        phase_bitsize=phase_bitsize, state_coefficients=tuple(state_coefs), uncompute=True
+        phase_bitsize=phase_bitsize, state_coefficients=state_coefs, uncompute=True  # type: ignore[arg-type]
     )
 
     bb = BloqBuilder()
@@ -145,7 +147,7 @@ def test_state_prep_via_rotation_adjoint(
 )
 def test_approximate_state_prep_via_rotation(phase_bitsize: int, state_coefs: Tuple[complex, ...]):
     qsp = StatePreparationViaRotations(
-        phase_bitsize=phase_bitsize, state_coefficients=tuple(state_coefs)
+        phase_bitsize=phase_bitsize, state_coefficients=state_coefs  # type: ignore[arg-type]
     )
     assert_valid_bloq_decomposition(qsp)
     bb = BloqBuilder()
@@ -176,7 +178,7 @@ def test_controlled_state_preparation_via_rotation_do_not_prepare(
     phase_bitsize: int, state_coefs: Tuple[complex, ...]
 ):
     qsp = StatePreparationViaRotations(
-        phase_bitsize=phase_bitsize, state_coefficients=tuple(state_coefs), control_bitsize=1
+        phase_bitsize=phase_bitsize, state_coefficients=state_coefs, control_bitsize=1  # type: ignore[arg-type]
     )
     assert_valid_bloq_decomposition(qsp)
     bb = BloqBuilder()
@@ -200,7 +202,7 @@ def test_state_preparation_via_rotation_superposition_ctrl(
     phase_bitsize: int, state_coefs: Tuple[complex, ...]
 ):
     qsp = StatePreparationViaRotations(
-        phase_bitsize=phase_bitsize, state_coefficients=tuple(state_coefs), control_bitsize=1
+        phase_bitsize=phase_bitsize, state_coefficients=state_coefs, control_bitsize=1  # type: ignore[arg-type]
     )
     assert_valid_bloq_decomposition(qsp)
     bb = BloqBuilder()
@@ -227,7 +229,7 @@ def test_state_preparation_via_rotation_multi_qubit_ctrl(
     phase_bitsize: int, state_coefs: Tuple[complex, ...]
 ):
     qsp = StatePreparationViaRotations(
-        phase_bitsize=phase_bitsize, state_coefficients=tuple(state_coefs), control_bitsize=2
+        phase_bitsize=phase_bitsize, state_coefficients=state_coefs, control_bitsize=2  # type: ignore[arg-type]
     )
     state_bitsize = (len(state_coefs) - 1).bit_length()
     assert_valid_bloq_decomposition(qsp)

--- a/qualtran/bloqs/swap_network/cswap_approx.py
+++ b/qualtran/bloqs/swap_network/cswap_approx.py
@@ -66,7 +66,7 @@ class CSwapApprox(GateWithRegisters):
         return Signature.build(ctrl=1, x=self.bitsize, y=self.bitsize)
 
     def decompose_from_registers(
-        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         ctrl, target_x, target_y = quregs['ctrl'], quregs['x'], quregs['y']
 

--- a/qualtran/bloqs/util_bloqs.py
+++ b/qualtran/bloqs/util_bloqs.py
@@ -44,8 +44,9 @@ from qualtran.simulation.classical_sim import bits_to_ints, ints_to_bits
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from qualtran import AbstractCtrlSpec, AddControlledT
+    from qualtran import AddControlledT
     from qualtran.cirq_interop import CirqQuregT
+    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -98,9 +99,7 @@ class Split(Bloq):
             )
         )
 
-    def get_ctrl_system(
-        self, ctrl_spec: Optional['AbstractCtrlSpec'] = None
-    ) -> Tuple['Bloq', 'AddControlledT']:
+    def get_ctrl_system(self, ctrl_spec=None) -> Tuple['Bloq', 'AddControlledT']:
         def add_controlled(
             bb: 'BloqBuilder', ctrl_soqs: Sequence['SoquetT'], in_soqs: Dict[str, 'SoquetT']
         ) -> Tuple[Iterable['SoquetT'], Iterable['SoquetT']]:
@@ -166,9 +165,7 @@ class Join(Bloq):
     def on_classical_vals(self, reg: 'NDArray[np.uint8]') -> Dict[str, int]:
         return {'reg': bits_to_ints(reg)[0]}
 
-    def get_ctrl_system(
-        self, ctrl_spec: Optional['AbstractCtrlSpec'] = None
-    ) -> Tuple['Bloq', 'AddControlledT']:
+    def get_ctrl_system(self, ctrl_spec=None) -> Tuple['Bloq', 'AddControlledT']:
         def add_controlled(
             bb: 'BloqBuilder', ctrl_soqs: Sequence['SoquetT'], in_soqs: Dict[str, 'SoquetT']
         ) -> Tuple[Iterable['SoquetT'], Iterable['SoquetT']]:

--- a/qualtran/cirq_interop/_bloq_to_cirq.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq.py
@@ -99,8 +99,8 @@ class BloqAsCirqGate(cirq.Gate):
 
     @classmethod
     def bloq_on(
-        cls, bloq: Bloq, cirq_quregs: Dict[str, 'CirqQuregT'], qubit_manager: cirq.QubitManager
-    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:
+        cls, bloq: Bloq, cirq_quregs: Dict[str, 'CirqQuregT'], qubit_manager: cirq.QubitManager  # type: ignore[type-var]
+    ) -> Tuple['cirq.Operation', Dict[str, 'CirqQuregT']]:  # type: ignore[type-var]
         """Shim `bloq` into a cirq gate and call it on `cirq_quregs`.
 
         This is used as a default implementation for `Bloq.as_cirq_op` if a native
@@ -157,7 +157,7 @@ class BloqAsCirqGate(cirq.Gate):
         return NotImplemented
 
     def on_registers(
-        self, **qubit_regs: Union[cirq.Qid, Sequence[cirq.Qid], NDArray[cirq.Qid]]
+        self, **qubit_regs: Union[cirq.Qid, Sequence[cirq.Qid], NDArray[cirq.Qid]]  # type: ignore[type-var]
     ) -> cirq.Operation:
         return self.on(*merge_qubits(self.signature, **qubit_regs))
 

--- a/qualtran/cirq_interop/_bloq_to_cirq_test.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq_test.py
@@ -82,7 +82,7 @@ class SwapTest(Bloq):
         return Signature.build(x=self.n, y=self.n)
 
     def build_composite_bloq(
-        self, bb: 'BloqBuilder', *, x: Soquet, y: Soquet
+        self, bb: 'BloqBuilder', x: Soquet, y: Soquet, **kwargs
     ) -> Dict[str, SoquetT]:
         xs = bb.split(x)
         ys = bb.split(y)

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -56,8 +56,8 @@ from qualtran.simulation.tensor._tensor_data_manipulation import (
 if TYPE_CHECKING:
     from qualtran.drawing import WireSymbol
 
-CirqQuregT = NDArray[cirq.Qid]
-CirqQuregInT = Union[NDArray[cirq.Qid], Sequence[cirq.Qid]]
+CirqQuregT = NDArray[cirq.Qid]  # type: ignore[type-var]
+CirqQuregInT = Union[NDArray[cirq.Qid], Sequence[cirq.Qid]]  # type: ignore[type-var]
 
 
 def _get_cirq_quregs(signature: Signature, qm: InteropQubitManager):

--- a/qualtran/linalg/jacobi_anger_approximations.py
+++ b/qualtran/linalg/jacobi_anger_approximations.py
@@ -54,7 +54,7 @@ def degree_jacobi_anger_approximation(t: SymbolicFloat, *, precision: SymbolicFl
         return sympy.O(t + sympy.log(precision) / sympy.log(sympy.log(precision)))
 
     def term_too_small(n: int) -> bool:
-        return np.isclose(scipy.special.jv(n, t), 0, atol=precision)
+        return bool(np.isclose(scipy.special.jv(n, t), 0, atol=float(precision)))
 
     d = 1
     while not term_too_small(d):

--- a/qualtran/linalg/jacobi_anger_approximations_test.py
+++ b/qualtran/linalg/jacobi_anger_approximations_test.py
@@ -28,6 +28,7 @@ def test_exp_cos_approximation(t: float, precision: float):
     random_state = np.random.RandomState(42 + int(t))
 
     degree = degree_jacobi_anger_approximation(t, precision=precision)
+    assert isinstance(degree, int)
     P = np.polynomial.Polynomial(approx_exp_cos_by_jacobi_anger(t, degree=degree))
     theta = 2 * np.pi * random_state.random(1000)
     e_itheta = np.exp(1j * theta)
@@ -42,6 +43,7 @@ def test_exp_sin_approximation(t: float, precision: float):
     random_state = np.random.RandomState(42 + int(t))
 
     degree = degree_jacobi_anger_approximation(t, precision=precision)
+    assert isinstance(degree, int)
     P = np.polynomial.Polynomial(approx_exp_sin_by_jacobi_anger(t, degree=degree))
     theta = 2 * np.pi * random_state.random(1000)
     e_itheta = np.exp(1j * theta)

--- a/qualtran/resource_counting/classify_bloqs_test.py
+++ b/qualtran/resource_counting/classify_bloqs_test.py
@@ -59,7 +59,8 @@ class TestBundleOfBloqs(Bloq):
         (((Add(QInt(8)), 4),), 'arithmetic'),
         (((QROM.build([4, 10, 11, 34]), 8),), 'data_loading'),
         (((And(), 4),), 'multi_control_pauli'),
-        (((Reflection((3, 3, 2), (0, 0, 1)), 100),), 'reflection'),
+        # https://github.com/python/mypy/issues/5313
+        (((Reflection((3, 3, 2), (0, 0, 1)), 100),), 'reflection'),  # type: ignore[arg-type]
         (((LessThanConstant(8, 3), 10),), 'arithmetic'),
     ),
 )
@@ -77,7 +78,8 @@ def test_default_classification(bloq_count, classification):
         (Add(QInt(8)), 'arithmetic'),
         (QROM.build([4, 10, 11, 34]), 'data_loading'),
         (And(), 'multi_control_pauli'),
-        (Reflection((3, 3, 2), (0, 0, 1)), 'reflection'),
+        # https://github.com/python/mypy/issues/5313
+        (Reflection((3, 3, 2), (0, 0, 1)), 'reflection'),  # type: ignore[arg-type]
         (LessThanConstant(8, 3).adjoint(), 'arithmetic'),
     ),
 )

--- a/qualtran/serialization/bloq_test.py
+++ b/qualtran/serialization/bloq_test.py
@@ -89,7 +89,7 @@ def test_cbloq_to_proto_two_cnot():
 
 @attrs.frozen
 class TestCSwap(Bloq):
-    bitsize: Union[int, sympy.Expr]
+    bitsize: int
 
     @property
     def signature(self) -> 'Signature':

--- a/qualtran/simulation/classical_sim.py
+++ b/qualtran/simulation/classical_sim.py
@@ -34,7 +34,7 @@ from qualtran import (
 )
 from qualtran._infra.composite_bloq import _binst_to_cxns
 
-ClassicalValT = Union[int, NDArray[int]]
+ClassicalValT = Union[int, NDArray[np.integer]]
 
 
 def bits_to_ints(bitstrings: Union[Sequence[int], NDArray[np.uint]]) -> NDArray[np.uint]:

--- a/qualtran/surface_code/ui.py
+++ b/qualtran/surface_code/ui.py
@@ -363,7 +363,7 @@ def create_qubit_pie_chart(
     if estimation_model == _GIDNEY_FOWLER_MODEL:
         res, factory, _ = get_ccz2t_costs_from_grid_search(
             n_magic=needed_magic,
-            n_algo_qubits=algorithm.algorithm_qubits,
+            n_algo_qubits=int(algorithm.algorithm_qubits),
             phys_err=physical_error_rate,
             error_budget=error_budget,
             factory_iter=[MultiFactory(f, int(magic_count)) for f in iter_ccz2t_factories()],
@@ -380,15 +380,15 @@ def create_qubit_pie_chart(
         fig.update_traces(textinfo='value')
         return fig
     else:
-        factory = MultiFactory(magic_factory, int(magic_count))
+        multi_factory = MultiFactory(magic_factory, int(magic_count))
         memory_footprint = pd.DataFrame(columns=['source', 'qubits'])
         memory_footprint['source'] = [
             'logical qubits + routing overhead',
             'Magic State Distillation',
         ]
         memory_footprint['qubits'] = [
-            FastDataBlock.grid_size(algorithm.algorithm_qubits),
-            factory.footprint(),
+            FastDataBlock.grid_size(int(algorithm.algorithm_qubits)),
+            multi_factory.footprint(),
         ]
         fig = px.pie(
             memory_footprint, values='qubits', names='source', title='Physical Qubit Utilization'
@@ -466,7 +466,8 @@ def create_runtime_plot(
     unit, duration = format_duration(duration)
     duration_name = f'Duration ({unit})'
     num_qubits = (
-        FastDataBlock.grid_size(algorithm.algorithm_qubits) + factory.footprint() * magic_counts
+        FastDataBlock.grid_size(int(algorithm.algorithm_qubits))
+        + factory.footprint() * magic_counts
     )
     df = pd.DataFrame(
         {
@@ -561,9 +562,9 @@ def total_magic(estimation_model: str, needed_magic: MagicCount) -> Tuple[Tuple[
     total_t = needed_magic.n_t + 4 * needed_magic.n_ccz
     total_ccz = total_t / 4
     if estimation_model == _GIDNEY_FOWLER_MODEL:
-        return ['Total Number of Toffoli gates'], f'{total_ccz:g}'
+        return ('Total Number of Toffoli gates',), f'{total_ccz:g}'
     else:
-        return ['Total Number of T gates'], f'{total_t:g}'
+        return ('Total Number of T gates',), f'{total_t:g}'
 
 
 def min_num_factories(
@@ -601,7 +602,7 @@ def compute_duration(
     if estimation_model == _GIDNEY_FOWLER_MODEL:
         res, _, _ = get_ccz2t_costs_from_grid_search(
             n_magic=needed_magic,
-            n_algo_qubits=algorithm.algorithm_qubits,
+            n_algo_qubits=int(algorithm.algorithm_qubits),
             phys_err=physical_error_rate,
             error_budget=error_budget,
             factory_iter=[MultiFactory(f, magic_count) for f in iter_ccz2t_factories()],

--- a/qualtran/testing.py
+++ b/qualtran/testing.py
@@ -16,7 +16,9 @@ import itertools
 import traceback
 from enum import Enum
 from pathlib import Path
-from typing import List, Tuple
+from typing import Dict, List, Tuple, Union
+
+import sympy
 
 from qualtran import (
     Bloq,
@@ -429,8 +431,8 @@ def assert_equivalent_bloq_example_counts(bloq_ex: BloqExample) -> None:
 
     has_manual_counts: bool
     has_decomp_counts: bool
-    manual_counts = None
-    decomp_counts = None
+    manual_counts: Dict['Bloq', Union[int, 'sympy.Expr']] = {}
+    decomp_counts: Dict['Bloq', Union[int, 'sympy.Expr']] = {}
 
     # Notable implementation detail: since `bloq.build_call_graph` has a default fallback
     # that uses the decomposition, we could accidentally be comparing two identical code paths


### PR DESCRIPTION
- Fixes many mypy issues in Qualtran.

Some highlights:
- Disable override type checking since overrides or variable kwargs are not appreciated by mypy
- Remove return type for BloqBuilder.add since many places assume it returns a tuple.
- Make Soquet a np.generic so NDArray[Soquet] works
- Ignore NDArray[cirq.Qid] type issues