### PR TITLE
Rename `RandomGate` -> `MatrixGate`

### DIFF
--- a/qualtran/bloqs/for_testing/matrix_gate.py
+++ b/qualtran/bloqs/for_testing/matrix_gate.py
@@ -15,14 +15,13 @@ from typing import Tuple
 
 import numpy as np
 from attrs import field, frozen
-from cirq.testing import random_unitary
 
 from qualtran import GateWithRegisters, Signature
 
 
 @frozen
-class RandomGate(GateWithRegisters):
-    """Gate with a uniformly random unitary action
+class MatrixGate(GateWithRegisters):
+    """A unitary n-qubit defined entirely by its numpy matrix.
 
     Args:
         bitsize: number of qubits $n$
@@ -48,18 +47,15 @@ class RandomGate(GateWithRegisters):
         return Signature.build(q=self.bitsize)
 
     @classmethod
-    def create(cls, bitsize: int, *, random_state=None) -> 'RandomGate':
+    def random(cls, bitsize: int, *, random_state=None) -> 'MatrixGate':
         """generate a uniformly random unitary on `bitsize` qubits"""
+        from cirq.testing import random_unitary
+
         matrix = random_unitary(2**bitsize, random_state=random_state)
         return cls(bitsize, matrix)
 
     def _unitary_(self):
         return np.array(self.matrix)
 
-    def adjoint(self) -> 'RandomGate':
-        return RandomGate(self.bitsize, np.conj(self.matrix).T)
-
-    def __pow__(self, power):
-        if power == -1:
-            return self.adjoint()
-        return NotImplemented
+    def adjoint(self) -> 'MatrixGate':
+        return MatrixGate(self.bitsize, np.conj(self.matrix).T)

--- a/qualtran/bloqs/for_testing/matrix_gate_test.py
+++ b/qualtran/bloqs/for_testing/matrix_gate_test.py
@@ -15,13 +15,13 @@ import cirq
 import numpy as np
 import pytest
 
-from .random_gate import RandomGate
+from .matrix_gate import MatrixGate
 
 
 @pytest.mark.parametrize("bitsize", [1, 2, 3])
 def test_create_and_unitary(bitsize: int):
     random_state = np.random.RandomState(42)
     for _ in range(5):
-        gate = RandomGate.create(bitsize, random_state=random_state)
+        gate = MatrixGate.random(bitsize, random_state=random_state)
         np.testing.assert_allclose(cirq.unitary(gate), gate.matrix)
         np.testing.assert_allclose(cirq.unitary(gate**-1), np.conj(gate.matrix).T)

--- a/qualtran/bloqs/for_testing/random_select_and_prepare.py
+++ b/qualtran/bloqs/for_testing/random_select_and_prepare.py
@@ -21,14 +21,14 @@ from attrs import frozen
 from numpy.typing import NDArray
 
 from qualtran import BloqBuilder, BoundedQUInt, QBit, Register, SoquetT
-from qualtran.bloqs.for_testing.random_gate import RandomGate
+from qualtran.bloqs.for_testing.matrix_gate import MatrixGate
 from qualtran.bloqs.qubitization_walk_operator import QubitizationWalkOperator
 from qualtran.bloqs.select_and_prepare import PrepareOracle, SelectOracle
 
 
 @frozen
-class RandomPrepareOracle(PrepareOracle):
-    r"""Gate that prepares a randomly chosen state with real amplitudes.
+class TestPrepareOracle(PrepareOracle):
+    r"""Gate that prepares a fixed state with real amplitudes using a MatrixGate.
 
     It is an $n$-qubit unitary $U$ such that
 
@@ -39,13 +39,13 @@ class RandomPrepareOracle(PrepareOracle):
     where $\alpha_x \ge 0$ such that $\sum_x \alpha_x = 1$.
 
     Args:
-        U: A `RandomGate` whose matrix is the unitary of the oracle.
+        U: A `MatrixGate` whose matrix is the unitary of the oracle.
 
     Registers:
         selection: $n$-qubit register
     """
 
-    U: RandomGate
+    U: MatrixGate
 
     def __attrs_post_init__(self):
         # check that first column is all reals
@@ -57,24 +57,20 @@ class RandomPrepareOracle(PrepareOracle):
         return (Register('selection', BoundedQUInt(bitsize=self.U.bitsize)),)
 
     @classmethod
-    def create(cls, bitsize: int, *, random_state: np.random.RandomState):
-        matrix = RandomGate.create(bitsize, random_state=random_state).matrix
+    def random(cls, bitsize: int, *, random_state: np.random.RandomState):
+        """Generate a random unitary s.t. the first column has all real amplitudes"""
+        matrix = MatrixGate.random(bitsize, random_state=random_state).matrix
         matrix = np.array(matrix)
 
         # make the first column (weights \sqrt{alpha_i}) all reals
         column = matrix[:, 0]
         matrix = matrix * (column.conj() / np.abs(column))[:, None]
 
-        return cls(RandomGate(bitsize, matrix))
+        return cls(MatrixGate(bitsize, matrix))
 
     def build_composite_bloq(self, bb: BloqBuilder, selection: SoquetT) -> dict[str, SoquetT]:
         selection = bb.add(self.U, q=selection)
         return {'selection': selection}
-
-    def __pow__(self, power):
-        if power == -1:
-            return self.U.adjoint()
-        return NotImplemented
 
     @cached_property
     def alphas(self):
@@ -82,7 +78,7 @@ class RandomPrepareOracle(PrepareOracle):
 
 
 @frozen
-class PauliSelectOracle(SelectOracle):
+class TestPauliSelectOracle(SelectOracle):
     r"""Paulis acting on $m$ qubits, controlled by an $n$-qubit register.
 
     Given $2^n$ multi-qubit-Paulis (acting on $m$ qubits) $U_j$,
@@ -113,7 +109,7 @@ class PauliSelectOracle(SelectOracle):
     @classmethod
     def random(
         cls, select_bitsize: int, target_bitsize: int, *, random_state: np.random.RandomState
-    ) -> 'PauliSelectOracle':
+    ) -> 'TestPauliSelectOracle':
         dps = tuple(
             cirq.DensePauliString(random_state.randint(0, 4, size=target_bitsize))
             for _ in range(2**select_bitsize)
@@ -197,8 +193,8 @@ def random_qubitization_walk_operator(
     Returns:
         WalkOperator for $H$, and the Hamiltonian $H$.
     """
-    prepare = RandomPrepareOracle.create(select_bitsize, random_state=random_state)
-    select = PauliSelectOracle.random(select_bitsize, target_bitsize, random_state=random_state)
+    prepare = TestPrepareOracle.random(select_bitsize, random_state=random_state)
+    select = TestPauliSelectOracle.random(select_bitsize, target_bitsize, random_state=random_state)
 
     np.testing.assert_allclose(np.linalg.norm(prepare.alphas, 1), 1)
 

--- a/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp_test.py
+++ b/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp_test.py
@@ -18,7 +18,7 @@ import pytest
 import scipy
 from numpy.typing import NDArray
 
-from qualtran.bloqs.for_testing.random_gate import RandomGate
+from qualtran.bloqs.for_testing.matrix_gate import MatrixGate
 from qualtran.bloqs.for_testing.random_select_and_prepare import random_qubitization_walk_operator
 from qualtran.bloqs.qsp.generalized_qsp_test import (
     assert_matrices_almost_equal,
@@ -54,7 +54,7 @@ def test_generalized_qsp_with_exp_cos_approx_on_random_unitaries(
     random_state = np.random.RandomState(42)
 
     for _ in range(5):
-        U = RandomGate.create(bitsize, random_state=random_state)
+        U = MatrixGate.random(bitsize, random_state=random_state)
         gqsp = HamiltonianSimulationByGQSP(_walk_op, t=t, alpha=1, precision=precision).gqsp
         P, Q = gqsp.P, gqsp.Q
 

--- a/qualtran/bloqs/qsp/generalized_qsp_test.py
+++ b/qualtran/bloqs/qsp/generalized_qsp_test.py
@@ -25,7 +25,7 @@ from numpy.typing import NDArray
 from qualtran import Bloq, bloq_example, Controlled, CtrlSpec, GateWithRegisters
 from qualtran.bloqs.basic_gates.su2_rotation import SU2RotationGate
 from qualtran.bloqs.for_testing.atom import TestGWRAtom
-from qualtran.bloqs.for_testing.random_gate import RandomGate
+from qualtran.bloqs.for_testing.matrix_gate import MatrixGate
 from qualtran.bloqs.qubitization_walk_operator_test import get_walk_operator_for_1d_ising_model
 from qualtran.resource_counting import SympySymbolAllocator
 from qualtran.resource_counting.symbolic_counting_utils import Shaped
@@ -170,7 +170,7 @@ def test_generalized_qsp_with_real_poly_on_random_unitaries(bitsize: int, degree
     random_state = np.random.RandomState(42)
 
     for _ in range(10):
-        U = RandomGate.create(bitsize, random_state=random_state)
+        U = MatrixGate.random(bitsize, random_state=random_state)
         P = random_qsp_polynomial(degree, random_state=random_state, only_real_coeffs=True)
         verify_generalized_qsp(U, P)
 
@@ -185,7 +185,7 @@ def test_generalized_qsp_with_complex_poly_on_random_unitaries(
     random_state = np.random.RandomState(42)
 
     for _ in range(10):
-        U = RandomGate.create(bitsize, random_state=random_state)
+        U = MatrixGate.random(bitsize, random_state=random_state)
         P = random_qsp_polynomial(degree, random_state=random_state)
         verify_generalized_qsp(U, P, negative_power=negative_power)
 
@@ -202,7 +202,7 @@ def test_call_graph(negative_power: int):
             return arbitrary_rotation
         return bloq
 
-    U = RandomGate.create(1, random_state=random_state)
+    U = MatrixGate.random(1, random_state=random_state)
     P = (0.5, 0, 0.5)
     gsqp_U = GeneralizedQSP.from_qsp_polynomial(U, P, negative_power=negative_power)
 
@@ -349,4 +349,4 @@ def test_complementary_polynomials_for_jacobi_anger_approximations(t: float, pre
     check_polynomial_pair_on_random_points_on_unit_circle(
         P, Q, random_state=random_state, rtol=precision
     )
-    verify_generalized_qsp(RandomGate.create(1, random_state=random_state), P, Q)
+    verify_generalized_qsp(MatrixGate.random(1, random_state=random_state), P, Q)

--- a/qualtran/serialization/resolver_dict.py
+++ b/qualtran/serialization/resolver_dict.py
@@ -75,7 +75,7 @@ import qualtran.bloqs.for_testing.atom
 import qualtran.bloqs.for_testing.casting
 import qualtran.bloqs.for_testing.interior_alloc
 import qualtran.bloqs.for_testing.many_registers
-import qualtran.bloqs.for_testing.random_gate
+import qualtran.bloqs.for_testing.matrix_gate
 import qualtran.bloqs.for_testing.with_call_graph
 import qualtran.bloqs.for_testing.with_decomposition
 import qualtran.bloqs.hubbard_model
@@ -263,7 +263,7 @@ RESOLVER_DICT = {
     "qualtran.bloqs.for_testing.many_registers.TestMultiRegister": qualtran.bloqs.for_testing.many_registers.TestMultiRegister,
     "qualtran.bloqs.for_testing.many_registers.TestMultiTypedRegister": qualtran.bloqs.for_testing.many_registers.TestMultiTypedRegister,
     "qualtran.bloqs.for_testing.many_registers.TestQFxp": qualtran.bloqs.for_testing.many_registers.TestQFxp,
-    "qualtran.bloqs.for_testing.random_gate.RandomGate": qualtran.bloqs.for_testing.random_gate.RandomGate,
+    "qualtran.bloqs.for_testing.matrix_gate.MatrixGate": qualtran.bloqs.for_testing.matrix_gate.MatrixGate,
     "qualtran.bloqs.for_testing.with_call_graph.TestBloqWithCallGraph": qualtran.bloqs.for_testing.with_call_graph.TestBloqWithCallGraph,
     "qualtran.bloqs.for_testing.with_decomposition.TestIndependentParallelCombo": qualtran.bloqs.for_testing.with_decomposition.TestIndependentParallelCombo,
     "qualtran.bloqs.for_testing.with_decomposition.TestParallelCombo": qualtran.bloqs.for_testing.with_decomposition.TestParallelCombo,


### PR DESCRIPTION
The name `RandomGate` doesn't make sense because we can instantiate with a matrix of choice as well.
This also renames `RandomGate.create(...)` -> `MatrixGate.random(...)` which makes more sense.

@mpharrigan @tanujkhattar PTAL