### PR TITLE
Fix coefficient type for `GlobalPhase`, and convert from cirq correctly

### DIFF
--- a/qualtran/bloqs/basic_gates/global_phase.py
+++ b/qualtran/bloqs/basic_gates/global_phase.py
@@ -12,11 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import attrs
 import cirq
-import sympy
 from attrs import frozen
 
 from qualtran import bloq_example, BloqDocSpec, DecomposeTypeError
@@ -25,6 +24,7 @@ from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 
 if TYPE_CHECKING:
     from qualtran import CompositeBloq
+    from qualtran.resource_counting.symbolic_counting_utils import SymbolicComplex
 
 
 @frozen
@@ -36,7 +36,7 @@ class GlobalPhase(CirqGateAsBloqBase):
         eps: precision
     """
 
-    coefficient: Union[complex, sympy.Expr]
+    coefficient: 'SymbolicComplex'
     eps: float = 1e-11
 
     @property
@@ -47,14 +47,9 @@ class GlobalPhase(CirqGateAsBloqBase):
         raise DecomposeTypeError(f"{self} is atomic")
 
     def adjoint(self) -> 'GlobalPhase':
-        from qualtran.resource_counting.symbolic_counting_utils import is_symbolic
+        from qualtran.resource_counting.symbolic_counting_utils import sconj
 
-        coefficient = (
-            sympy.conjugate(self.coefficient)
-            if is_symbolic(self.coefficient)
-            else complex(self.coefficient).conjugate()
-        )
-        return attrs.evolve(self, coefficient=coefficient)
+        return attrs.evolve(self, coefficient=sconj(self.coefficient))
 
     def pretty_name(self) -> str:
         return 'GPhase'

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -399,7 +399,7 @@ def _cirq_gate_to_bloq(gate: cirq.Gate) -> Bloq:
             exponent=gate.exponent, global_shift=gate.global_shift
         )
 
-    if isinstance(gate, cirq.GlobalPhaseGate) and isinstance(gate.coefficient, (float, complex)):
+    if isinstance(gate, cirq.GlobalPhaseGate):
         return GlobalPhase(coefficient=gate.coefficient)
 
     # No known basic gate, wrap the cirq gate in a CirqGateAsBloq wrapper.

--- a/qualtran/resource_counting/symbolic_counting_utils.py
+++ b/qualtran/resource_counting/symbolic_counting_utils.py
@@ -24,6 +24,9 @@ document(SymbolicFloat, """A floating point value or a sympy expression.""")
 SymbolicInt = Union[int, sympy.Expr]
 document(SymbolicFloat, """A floating point value or a sympy expression.""")
 
+SymbolicComplex = Union[complex, sympy.Expr]
+document(SymbolicComplex, """A complex value or a sympy expression.""")
+
 
 @frozen
 class Shaped:
@@ -116,6 +119,11 @@ def acos(x: SymbolicFloat) -> SymbolicFloat:
     if not isinstance(x, sympy.Basic):
         return np.arccos(x)
     return sympy.acos(x)
+
+
+def sconj(x: SymbolicComplex) -> SymbolicComplex:
+    """Compute the complex conjugate."""
+    return sympy.conjugate(x) if is_symbolic(x) else np.conjugate(x)
 
 
 def slen(x: Union[Sized, Shaped]) -> SymbolicInt:


### PR DESCRIPTION
The gate now supports symbolic phase coefficients.

The `_cirq_gate_to_bloq` was changed in #891 to only consider `float|complex`. This PR fixes the type in `GlobalPhase`, so that every `cirq.GlobalPhaseGate` can be converted to it.