### PR TITLE
Update cirq version to latest pre-release

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -4,7 +4,7 @@ cachetools>=5.3
 networkx
 numpy
 sympy
-cirq-core==1.4.0.dev20240412172235
+cirq-core==1.4.0.dev20240430031656
 fxpmath
 
 # qualtran/testing.py

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -14,7 +14,7 @@ anyio==4.3.0
     # via
     #   httpx
     #   jupyter-server
-anywidget==0.9.7
+anywidget==0.9.10
     # via qsharp-widgets
 argon2-cffi==23.1.0
     # via jupyter-server
@@ -50,7 +50,7 @@ babel==2.14.0
     #   jupyterlab-server
     #   pydata-sphinx-theme
     #   sphinx
-backports-tarfile==1.0.0
+backports-tarfile==1.1.1
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via
@@ -60,7 +60,7 @@ black==22.3.0
     # via -r deps/format.txt
 bleach==6.1.0
     # via nbconvert
-blinker==1.7.0
+blinker==1.8.1
     # via flask
 build==1.2.1
     # via pip-tools
@@ -77,7 +77,7 @@ cffi==1.16.0
     #   cryptography
 charset-normalizer==3.3.2
     # via requests
-cirq-core==1.4.0.dev20240412172235
+cirq-core==1.4.0.dev20240430031656
     # via
     #   -r deps/runtime.txt
     #   openfermion
@@ -95,7 +95,7 @@ contourpy==1.2.1
     # via matplotlib
 cotengra==0.6.0
     # via quimb
-coverage[toml]==7.4.4
+coverage[toml]==7.5.0
     # via pytest-cov
 cryptography==42.0.5
     # via secretstorage
@@ -123,7 +123,7 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   myst-parser
     #   pydata-sphinx-theme
@@ -131,7 +131,7 @@ docutils==0.20.1
     #   sphinx
 duet==0.2.9
     # via cirq-core
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   anyio
     #   ipython
@@ -142,7 +142,7 @@ executing==2.0.1
     # via stack-data
 fastjsonschema==2.19.1
     # via nbformat
-filelock==3.13.4
+filelock==3.14.0
     # via
     #   -r deps/pylint.txt
     #   -r deps/pytest.txt
@@ -159,9 +159,9 @@ fxpmath==0.4.9
     # via -r deps/runtime.txt
 greenlet==3.0.3
     # via sqlalchemy
-grpcio==1.62.1
+grpcio==1.63.0
     # via grpcio-tools
-grpcio-tools==1.62.1
+grpcio-tools==1.63.0
     # via -r deps/packaging.txt
 h11==0.14.0
     # via httpcore
@@ -195,7 +195,7 @@ ipykernel==6.29.4
     #   -r deps/pytest.txt
     #   jupyterlab
     #   myst-nb
-ipython==8.23.0
+ipython==8.24.0
     # via
     #   -r deps/runtime.txt
     #   ipykernel
@@ -212,13 +212,13 @@ isort==5.10.1
     # via
     #   -r deps/format.txt
     #   pylint
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via flask
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.0
+jaraco-functools==4.0.1
     # via keyring
 jax==0.4.26
     # via openfermion
@@ -280,17 +280,17 @@ jupyter-server==2.14.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.1.6
+jupyterlab==4.1.8
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.26.0
+jupyterlab-server==2.27.1
     # via
     #   jupyterlab
     #   notebook
 jupyterlab-widgets==3.0.10
     # via ipywidgets
-keyring==25.1.0
+keyring==25.2.0
     # via twine
 kiwisolver==1.4.5
     # via matplotlib
@@ -335,7 +335,7 @@ more-itertools==10.2.0
     #   jaraco-functools
 mpmath==1.3.0
     # via sympy
-mypy==1.9.0
+mypy==1.10.0
     # via -r deps/mypy.txt
 mypy-extensions==1.0.0
     # via
@@ -345,14 +345,14 @@ mypy-protobuf==3.6.0
     # via -r deps/mypy.txt
 myst-nb==1.1.0
     # via -r deps/docs.txt
-myst-parser==2.0.0
+myst-parser==3.0.1
     # via myst-nb
 nbclient==0.10.0
     # via
     #   jupyter-cache
     #   myst-nb
     #   nbconvert
-nbconvert==7.16.3
+nbconvert==7.16.4
     # via
     #   -r deps/docs.txt
     #   -r deps/runtime.txt
@@ -378,7 +378,7 @@ networkx==3.3
     #   openfermion
 nh3==0.2.17
     # via readme-renderer
-notebook==7.1.2
+notebook==7.1.3
     # via -r deps/dev-tools.txt
 notebook-shim==0.2.4
     # via
@@ -443,23 +443,23 @@ pip-tools==7.4.1
     # via -r deps/pip-tools.txt
 pkginfo==1.10.0
     # via twine
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   black
     #   jupyter-core
     #   pylint
     #   virtualenv
-plotly==5.20.0
+plotly==5.21.0
     # via
     #   -r deps/runtime.txt
     #   dash
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prometheus-client==0.20.0
     # via jupyter-server
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==4.25.3
+protobuf==5.26.1
     # via
     #   -r deps/runtime.txt
     #   grpcio-tools
@@ -500,13 +500,13 @@ pyparsing==3.1.2
     # via
     #   matplotlib
     #   pydot
-pyproject-hooks==1.0.0
+pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
 pyscf==2.5.0
     # via openfermion
-pytest==8.1.1
+pytest==8.2.0
     # via
     #   -r deps/pylint.txt
     #   -r deps/pytest.txt
@@ -517,7 +517,7 @@ pytest-asyncio==0.23.6
     # via -r deps/pytest.txt
 pytest-cov==5.0.0
     # via -r deps/pytest.txt
-pytest-xdist==3.5.0
+pytest-xdist==3.6.1
     # via -r deps/pytest.txt
 python-dateutil==2.9.0.post0
     # via
@@ -536,20 +536,20 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   tensorflow-docs
-pyzmq==26.0.0
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qsharp==1.3.1
+qsharp==1.4.0
     # via -r deps/runtime.txt
-qsharp-widgets==1.3.1
+qsharp-widgets==1.4.0
     # via -r deps/runtime.txt
 quimb==1.8.0
     # via -r deps/runtime.txt
 readme-renderer==43.0
     # via twine
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -612,7 +612,7 @@ sortedcontainers==2.4.0
     # via cirq-core
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   -r deps/docs.txt
     #   -r deps/pylint.txt
@@ -652,7 +652,7 @@ terminado==0.18.1
     # via
     #   jupyter-server
     #   jupyter-server-terminals
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via nbconvert
 tomli==2.0.1
     # via
@@ -664,8 +664,8 @@ tomli==2.0.1
     #   mypy
     #   pip-tools
     #   pylint
-    #   pyproject-hooks
     #   pytest
+    #   sphinx
 tomlkit==0.12.4
     # via pylint
 toolz==0.12.1
@@ -682,7 +682,7 @@ tqdm==4.66.2
     # via
     #   cirq-core
     #   quimb
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -699,7 +699,7 @@ traitlets==5.14.2
     #   nbformat
 twine==5.0.0
     # via -r deps/packaging.txt
-types-protobuf==4.25.0.20240410
+types-protobuf==5.26.0.20240422
     # via mypy-protobuf
 types-python-dateutil==2.9.0.20240316
     # via arrow
@@ -724,7 +724,7 @@ urllib3==2.2.1
     # via
     #   requests
     #   twine
-virtualenv==20.25.1
+virtualenv==20.26.1
     # via -r deps/packaging.txt
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -734,7 +734,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via jupyter-server
 werkzeug==3.0.2
     # via

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -16,7 +16,7 @@ alabaster==0.7.16
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-anywidget==0.9.7
+anywidget==0.9.10
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -55,7 +55,7 @@ bleach==6.1.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-blinker==1.7.0
+blinker==1.8.1
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -71,7 +71,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.0.dev20240412172235
+cirq-core==1.4.0.dev20240430031656
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -129,7 +129,7 @@ defusedxml==0.7.1
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   -c envs/dev.env.txt
     #   myst-parser
@@ -139,7 +139,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   -c envs/dev.env.txt
     #   ipython
@@ -185,7 +185,7 @@ ipykernel==6.29.4
     # via
     #   -c envs/dev.env.txt
     #   myst-nb
-ipython==8.23.0
+ipython==8.24.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -198,7 +198,7 @@ ipywidgets==8.1.2
     #   -r deps/docs.txt
     #   -r deps/runtime.txt
     #   anywidget
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -296,7 +296,7 @@ myst-nb==1.1.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
-myst-parser==2.0.0
+myst-parser==3.0.1
     # via
     #   -c envs/dev.env.txt
     #   myst-nb
@@ -306,7 +306,7 @@ nbclient==0.10.0
     #   jupyter-cache
     #   myst-nb
     #   nbconvert
-nbconvert==7.16.3
+nbconvert==7.16.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
@@ -376,11 +376,11 @@ pillow==10.3.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
-plotly==5.20.0
+plotly==5.21.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -389,7 +389,7 @@ prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.3
+protobuf==5.26.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -449,16 +449,16 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   tensorflow-docs
-pyzmq==26.0.0
+pyzmq==26.0.2
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
-qsharp==1.3.1
+qsharp==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.3.1
+qsharp-widgets==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -466,7 +466,7 @@ quimb==1.8.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -509,7 +509,7 @@ soupsieve==2.5
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
@@ -565,10 +565,14 @@ tensorflow-docs==2023.5.24.56664
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
+tomli==2.0.1
+    # via
+    #   -c envs/dev.env.txt
+    #   sphinx
 toolz==0.12.1
     # via
     #   -c envs/dev.env.txt
@@ -583,7 +587,7 @@ tqdm==4.66.2
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   -c envs/dev.env.txt
     #   comm

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/format.env.txt deps/format.txt deps/runtime.txt
 #
-anywidget==0.9.7
+anywidget==0.9.10
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -40,7 +40,7 @@ bleach==6.1.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-blinker==1.7.0
+blinker==1.8.1
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -56,7 +56,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.0.dev20240412172235
+cirq-core==1.4.0.dev20240430031656
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -113,7 +113,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   -c envs/dev.env.txt
     #   ipython
@@ -149,7 +149,7 @@ importlib-metadata==7.1.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-ipython==8.23.0
+ipython==8.24.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -163,7 +163,7 @@ isort==5.10.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/format.txt
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -242,7 +242,7 @@ nbclient==0.10.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-nbconvert==7.16.3
+nbconvert==7.16.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -307,12 +307,12 @@ pillow==10.3.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   -c envs/dev.env.txt
     #   black
     #   jupyter-core
-plotly==5.20.0
+plotly==5.21.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -321,7 +321,7 @@ prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.3
+protobuf==5.26.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -365,15 +365,15 @@ pytz==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-pyzmq==26.0.0
+pyzmq==26.0.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
-qsharp==1.3.1
+qsharp==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.3.1
+qsharp-widgets==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -381,7 +381,7 @@ quimb==1.8.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -432,7 +432,7 @@ tenacity==8.2.3
     # via
     #   -c envs/dev.env.txt
     #   plotly
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -454,7 +454,7 @@ tqdm==4.66.2
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   -c envs/dev.env.txt
     #   comm

--- a/dev_tools/requirements/envs/pip-tools.env.txt
+++ b/dev_tools/requirements/envs/pip-tools.env.txt
@@ -20,7 +20,7 @@ pip-tools==7.4.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pip-tools.txt
-pyproject-hooks==1.0.0
+pyproject-hooks==1.1.0
     # via
     #   -c envs/dev.env.txt
     #   build
@@ -30,7 +30,6 @@ tomli==2.0.1
     #   -c envs/dev.env.txt
     #   build
     #   pip-tools
-    #   pyproject-hooks
 wheel==0.43.0
     # via
     #   -c envs/dev.env.txt

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -12,7 +12,7 @@ alabaster==0.7.16
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-anywidget==0.9.7
+anywidget==0.9.10
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -56,7 +56,7 @@ bleach==6.1.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-blinker==1.7.0
+blinker==1.8.1
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -72,7 +72,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.0.dev20240412172235
+cirq-core==1.4.0.dev20240430031656
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -133,7 +133,7 @@ dill==0.3.8
     # via
     #   -c envs/dev.env.txt
     #   pylint
-docutils==0.20.1
+docutils==0.21.2
     # via
     #   -c envs/dev.env.txt
     #   sphinx
@@ -141,7 +141,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   -c envs/dev.env.txt
     #   ipython
@@ -154,7 +154,7 @@ fastjsonschema==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-filelock==3.13.4
+filelock==3.14.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
@@ -191,7 +191,7 @@ iniconfig==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
-ipython==8.23.0
+ipython==8.24.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -205,7 +205,7 @@ isort==5.10.1
     # via
     #   -c envs/dev.env.txt
     #   pylint
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -304,7 +304,7 @@ nbclient==0.10.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-nbconvert==7.16.3
+nbconvert==7.16.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -386,17 +386,17 @@ pillow==10.3.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
     #   pylint
-plotly==5.20.0
+plotly==5.21.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   dash
-pluggy==1.4.0
+pluggy==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -404,7 +404,7 @@ prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.3
+protobuf==5.26.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -452,7 +452,7 @@ pyscf==2.5.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-pytest==8.1.1
+pytest==8.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
@@ -470,15 +470,15 @@ pyyaml==6.0.1
     # via
     #   -c envs/dev.env.txt
     #   tensorflow-docs
-pyzmq==26.0.0
+pyzmq==26.0.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
-qsharp==1.3.1
+qsharp==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.3.1
+qsharp-widgets==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -486,7 +486,7 @@ quimb==1.8.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -535,7 +535,7 @@ soupsieve==2.5
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
@@ -581,7 +581,7 @@ tensorflow-docs==2023.5.24.56664
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -590,6 +590,7 @@ tomli==2.0.1
     #   -c envs/dev.env.txt
     #   pylint
     #   pytest
+    #   sphinx
 tomlkit==0.12.4
     # via
     #   -c envs/dev.env.txt
@@ -607,7 +608,7 @@ tqdm==4.66.2
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   -c envs/dev.env.txt
     #   comm

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/pytest.env.txt deps/pytest.txt deps/runtime.txt
 #
-anywidget==0.9.7
+anywidget==0.9.10
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -36,7 +36,7 @@ bleach==6.1.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-blinker==1.7.0
+blinker==1.8.1
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -52,7 +52,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.0.dev20240412172235
+cirq-core==1.4.0.dev20240430031656
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -74,7 +74,7 @@ cotengra==0.6.0
     # via
     #   -c envs/dev.env.txt
     #   quimb
-coverage[toml]==7.4.4
+coverage[toml]==7.5.0
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -122,7 +122,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   -c envs/dev.env.txt
     #   ipython
@@ -139,7 +139,7 @@ fastjsonschema==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-filelock==3.13.4
+filelock==3.14.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -176,7 +176,7 @@ ipykernel==6.29.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-ipython==8.23.0
+ipython==8.24.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -187,7 +187,7 @@ ipywidgets==8.1.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   anywidget
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -279,7 +279,7 @@ nbclient==0.10.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-nbconvert==7.16.3
+nbconvert==7.16.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -361,16 +361,16 @@ pillow==10.3.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
-plotly==5.20.0
+plotly==5.21.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   dash
-pluggy==1.4.0
+pluggy==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -378,7 +378,7 @@ prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.3
+protobuf==5.26.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -421,7 +421,7 @@ pyscf==2.5.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-pytest==8.1.1
+pytest==8.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -436,7 +436,7 @@ pytest-cov==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-pytest-xdist==3.5.0
+pytest-xdist==3.6.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -450,16 +450,16 @@ pytz==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-pyzmq==26.0.0
+pyzmq==26.0.2
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
-qsharp==1.3.1
+qsharp==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.3.1
+qsharp-widgets==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -467,7 +467,7 @@ quimb==1.8.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -525,7 +525,7 @@ tenacity==8.2.3
     # via
     #   -c envs/dev.env.txt
     #   plotly
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -548,7 +548,7 @@ tqdm==4.66.2
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   -c envs/dev.env.txt
     #   comm

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/runtime.env.txt deps/runtime.txt
 #
-anywidget==0.9.7
+anywidget==0.9.10
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -32,7 +32,7 @@ bleach==6.1.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-blinker==1.7.0
+blinker==1.8.1
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -48,7 +48,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.0.dev20240412172235
+cirq-core==1.4.0.dev20240430031656
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -104,7 +104,7 @@ duet==0.2.9
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   -c envs/dev.env.txt
     #   ipython
@@ -136,7 +136,7 @@ importlib-metadata==7.1.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-ipython==8.23.0
+ipython==8.24.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -146,7 +146,7 @@ ipywidgets==8.1.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   anywidget
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -221,7 +221,7 @@ nbclient==0.10.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-nbconvert==7.16.3
+nbconvert==7.16.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -282,11 +282,11 @@ pillow==10.3.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
-plotly==5.20.0
+plotly==5.21.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -295,7 +295,7 @@ prompt-toolkit==3.0.43
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==4.25.3
+protobuf==5.26.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -339,15 +339,15 @@ pytz==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-pyzmq==26.0.0
+pyzmq==26.0.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
-qsharp==1.3.1
+qsharp==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.3.1
+qsharp-widgets==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -355,7 +355,7 @@ quimb==1.8.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -406,7 +406,7 @@ tenacity==8.2.3
     # via
     #   -c envs/dev.env.txt
     #   plotly
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -423,7 +423,7 @@ tqdm==4.66.2
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   -c envs/dev.env.txt
     #   comm


### PR DESCRIPTION
This fixes failing tests in https://github.com/quantumlib/Qualtran/pull/908 by incorporating https://github.com/quantumlib/Cirq/pull/6579