### PR TITLE
Changed controlled attribute to is_controlled

### DIFF
--- a/qualtran/bloqs/arithmetic/multiplication.py
+++ b/qualtran/bloqs/arithmetic/multiplication.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 
 
 @frozen
-class PlusEqualProduct(GateWithRegisters, cirq.ArithmeticGate):  # ignore: type[misc]
+class PlusEqualProduct(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[misc]
     """Performs result += a * b"""
 
     a_bitsize: int

--- a/qualtran/bloqs/chemistry/quad_fermion/givens_bloq.py
+++ b/qualtran/bloqs/chemistry/quad_fermion/givens_bloq.py
@@ -131,7 +131,7 @@ class RealGivensRotationByPhaseGradient(Bloq):
             phase_bitsize=self.phasegrad_bitsize,
             right_shift=0,
             sign=1,
-            controlled=1,
+            controlled_by=1,
         )
 
         # clifford block
@@ -247,7 +247,7 @@ class ComplexGivensRotationByPhaseGradient(Bloq):
             phase_bitsize=self.phasegrad_bitsize,
             right_shift=0,
             sign=1,
-            controlled=1,
+            controlled_by=1,
         )
         target_j, cplx_rom_data, phase_gradient = bb.add(
             add_into_phasegrad_gate, x=cplx_rom_data, phase_grad=phase_gradient, ctrl=target_j

--- a/qualtran/bloqs/chemistry/quad_fermion/givens_bloq_test.py
+++ b/qualtran/bloqs/chemistry/quad_fermion/givens_bloq_test.py
@@ -72,7 +72,7 @@ def test_circuit_decomposition_givens():
 @pytest.mark.parametrize("x_bitsize", [4, 5, 6, 7])
 def test_count_t_cliffords(x_bitsize: int):
     add_into_phasegrad_gate = RzAddIntoPhaseGradient(
-        x_bitsize=x_bitsize, phase_bitsize=x_bitsize, right_shift=0, sign=1, controlled=1
+        x_bitsize=x_bitsize, phase_bitsize=x_bitsize, right_shift=0, sign=1, controlled_by=1
     )
     bloq_counts = add_into_phasegrad_gate.bloq_counts()
     # produces Toffoli costs given in chemistry papers
@@ -91,7 +91,7 @@ def test_count_t_cliffords(x_bitsize: int):
 @pytest.mark.parametrize("x_bitsize", [4, 5, 6, 7])
 def test_complex_givens_costs(x_bitsize: int):
     add_into_phasegrad_gate = RzAddIntoPhaseGradient(
-        x_bitsize=x_bitsize, phase_bitsize=x_bitsize, right_shift=0, sign=1, controlled=1
+        x_bitsize=x_bitsize, phase_bitsize=x_bitsize, right_shift=0, sign=1, controlled_by=1
     )
     real_givens_gate = RealGivensRotationByPhaseGradient(phasegrad_bitsize=x_bitsize)
     gate = ComplexGivensRotationByPhaseGradient(phasegrad_bitsize=x_bitsize)

--- a/qualtran/bloqs/qft/approximate_qft.py
+++ b/qualtran/bloqs/qft/approximate_qft.py
@@ -128,7 +128,7 @@ class ApproximateQFT(GateWithRegisters):
             a, b = q[addition_start_index:i], phase_grad[: addition_bitsize + 1]
 
             yield AddIntoPhaseGrad(
-                addition_bitsize, addition_bitsize + 1, right_shift=1, controlled=1
+                addition_bitsize, addition_bitsize + 1, right_shift=1, controlled_by=1
             ).on_registers(ctrl=q[i], x=a[::-1], phase_grad=b)
             yield cirq.H(q[i])
 
@@ -141,13 +141,13 @@ class ApproximateQFT(GateWithRegisters):
         if is_symbolic(self.bitsize, self.phase_bitsize):
             phase_dict[
                 AddIntoPhaseGrad(
-                    self.phase_bitsize, self.phase_bitsize, right_shift=1, controlled=1
+                    self.phase_bitsize, self.phase_bitsize, right_shift=1, controlled_by=1
                 )
             ] = self.bitsize
         else:
             for i in range(1, int(self.bitsize)):
                 b = min(i, self.phase_bitsize - 1)
-                phase_dict[AddIntoPhaseGrad(b, b + 1, right_shift=1, controlled=1)] += 1
+                phase_dict[AddIntoPhaseGrad(b, b + 1, right_shift=1, controlled_by=1)] += 1
         ret = {(Hadamard(), self.bitsize), *phase_dict.items()}
         if self.with_reverse:
             ret |= {(TwoBitSwap(), self.bitsize // 2)}

--- a/qualtran/bloqs/qft/approximate_qft_test.py
+++ b/qualtran/bloqs/qft/approximate_qft_test.py
@@ -111,7 +111,9 @@ def test_approximate_qft_t_complexity(n: int, with_reverse: bool):
         t_complexity = 0
         for i in range(1, n):
             t_complexity += (
-                AddIntoPhaseGrad(min(i, b - 1), min(i, b - 1) + 1, controlled=True).t_complexity().t
+                AddIntoPhaseGrad(min(i, b - 1), min(i, b - 1) + 1, controlled_by=True)
+                .t_complexity()
+                .t
             )
         return t_complexity
 

--- a/qualtran/bloqs/qft/qft_text_book.py
+++ b/qualtran/bloqs/qft/qft_text_book.py
@@ -48,7 +48,7 @@ class QFTTextBook(GateWithRegisters):
     ) -> cirq.OP_TREE:
         yield cirq.H(q[0])
         for i in range(1, len(q)):
-            yield PhaseGradientUnitary(i, exponent=0.5, controlled=True).on_registers(
+            yield PhaseGradientUnitary(i, exponent=0.5, is_controlled=True).on_registers(
                 ctrl=q[i], phase_grad=q[:i][::-1]
             )
             yield cirq.H(q[i])

--- a/qualtran/bloqs/rotations/phase_gradient.py
+++ b/qualtran/bloqs/rotations/phase_gradient.py
@@ -60,14 +60,14 @@ class PhaseGradientUnitary(GateWithRegisters):
 
     bitsize: int
     exponent: float = 1
-    controlled: bool = False
+    is_controlled: bool = False
     eps: float = 1e-10
 
     @cached_property
     def signature(self) -> 'Signature':
         return (
             Signature.build_from_dtypes(ctrl=QBit(), phase_grad=QFxp(self.bitsize, self.bitsize))
-            if self.controlled
+            if self.is_controlled
             else Signature.build_from_dtypes(phase_grad=QFxp(self.bitsize, self.bitsize))
         )
 
@@ -75,12 +75,12 @@ class PhaseGradientUnitary(GateWithRegisters):
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
     ) -> cirq.OP_TREE:
         ctrl = quregs.get('ctrl', ())
-        gate = CZPowGate if self.controlled else ZPowGate
+        gate = CZPowGate if self.is_controlled else ZPowGate
         for i, q in enumerate(quregs['phase_grad']):
             yield gate(exponent=self.exponent / 2**i, eps=self.eps / self.bitsize).on(*ctrl, q)
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
-        wire_symbols = ['@'] * self.controlled + [
+        wire_symbols = ['@'] * self.is_controlled + [
             f'Z^{self.exponent}/{2**(i+1)}' for i in range(self.bitsize)
         ]
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
@@ -88,7 +88,9 @@ class PhaseGradientUnitary(GateWithRegisters):
     def __pow__(self, power):
         if power == 1:
             return self
-        return PhaseGradientUnitary(self.bitsize, self.exponent * power, self.controlled, self.eps)
+        return PhaseGradientUnitary(
+            self.bitsize, self.exponent * power, self.is_controlled, self.eps
+        )
 
 
 @attrs.frozen
@@ -135,7 +137,7 @@ class PhaseGradientState(GateWithRegisters):
 
 
 @attrs.frozen
-class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):
+class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[misc]
     r"""Quantum-quantum addition into a phase gradient register using $b_{phase} - 2$ Toffolis
 
     $$
@@ -149,9 +151,9 @@ class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):
             shifted before adding to the phase gradient register.
         sign: Whether the input register x should be  added or subtracted from the phase gradient
             register.
-        controlled: Whether to control this bloq with a ctrl register. When controlled=None, this bloq
-            is not controlled. When controlled=0, this bloq is active when the ctrl register is 0. When
-            controlled=1, this bloq is active when the ctrl register is 1.
+        controlled_by: Whether to control this bloq with a ctrl register. When controlled_by=None, this bloq
+            is not controlled. When controlled_by=0, this bloq is active when the ctrl register is 0. When
+            controlled_by=1, this bloq is active when the ctrl register is 1.
 
     Registers:
         - ctrl: Control THRU register
@@ -167,7 +169,7 @@ class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):
     phase_bitsize: 'SymbolicInt'
     right_shift: int = 0
     sign: int = +1
-    controlled: Optional[int] = None
+    controlled_by: Optional[int] = None
 
     def pretty_name(self) -> str:
         sign = '+' if self.sign > 0 else '-'
@@ -181,7 +183,7 @@ class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):
                 x=QFxp(self.x_bitsize, self.x_bitsize, signed=False),
                 phase_grad=QFxp(self.phase_bitsize, self.phase_bitsize, signed=False),
             )
-            if self.controlled is not None
+            if self.controlled_by is not None
             else Signature.build_from_dtypes(
                 x=QFxp(self.x_bitsize, self.x_bitsize, signed=False),
                 phase_grad=QFxp(self.phase_bitsize, self.phase_bitsize, signed=False),
@@ -195,7 +197,9 @@ class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):
     def registers(self) -> Sequence[Union[int, Sequence[int]]]:
         if isinstance(self.phase_bitsize, sympy.Expr):
             raise ValueError(f'Symbolic phase {self.phase_bitsize} not supported')
-        if self.controlled is not None:
+        if isinstance(self.x_bitsize, sympy.Expr):
+            raise ValueError(f'Symbolic bitsize {self.x_bitsize} not supported')
+        if self.controlled_by is not None:
             return [2], [2] * self.x_bitsize, [2] * self.phase_bitsize
         return [2] * self.x_bitsize, [2] * self.phase_bitsize
 
@@ -210,7 +214,7 @@ class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):
         return int(x_fxp.astype(float) * 2**self.phase_bitsize)
 
     def apply(self, *args) -> Union[int, Iterable[int]]:
-        if self.controlled is not None:
+        if self.controlled_by is not None:
             ctrl, x, phase_grad = args
             out = self.on_classical_vals(ctrl=ctrl, x=x, phase_grad=phase_grad)
             return out['ctrl'], out['x'], out['phase_grad']
@@ -221,9 +225,9 @@ class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):
 
     def on_classical_vals(self, **kwargs) -> Dict[str, 'ClassicalValT']:
         x, phase_grad = kwargs['x'], kwargs['phase_grad']
-        if self.controlled is not None:
+        if self.controlled_by is not None:
             ctrl = kwargs['ctrl']
-            if ctrl == self.controlled:
+            if ctrl == self.controlled_by:
                 phase_grad_out = (phase_grad + self.sign * self.scaled_val(x)) % (
                     2**self.phase_bitsize
                 )
@@ -236,7 +240,7 @@ class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         num_toffoli = self.phase_bitsize - 2
-        if self.controlled is not None:
+        if self.controlled_by is not None:
             return {(Toffoli(), 2 * num_toffoli)}
 
         return {(Toffoli(), num_toffoli)}
@@ -251,7 +255,7 @@ class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):
             self.phase_bitsize,
             self.right_shift,
             sign=-1 * self.sign,
-            controlled=self.controlled,
+            controlled_by=self.controlled_by,
         )
 
     def __pow__(self, power):

--- a/qualtran/bloqs/rotations/phase_gradient_test.py
+++ b/qualtran/bloqs/rotations/phase_gradient_test.py
@@ -105,7 +105,7 @@ def test_add_into_phase_grad_controlled(controlled: int):
     from qualtran.bloqs.rotations.phase_gradient import _fxp
 
     x_bit, phase_bit = 4, 7
-    bloq = AddIntoPhaseGrad(x_bit, phase_bit, controlled=controlled)
+    bloq = AddIntoPhaseGrad(x_bit, phase_bit, controlled_by=controlled)
     basis_map: Dict[int, int] = {}
     num_bits = 1 + x_bit + phase_bit
     expected_unitary = np.zeros((2**num_bits, 2**num_bits))


### PR DESCRIPTION
- Change controlled attribute to is_controlled or controlled_by.
- This attribute shadows the controlled() function inherited by GateWithRegisters which is confusing and type-unsafe.