### PR TITLE
Change wire_symbol to use Register and idx

### DIFF
--- a/qualtran/_infra/adjoint.py
+++ b/qualtran/_infra/adjoint.py
@@ -15,7 +15,6 @@
 from functools import cached_property
 from typing import Dict, List, Set, Tuple, TYPE_CHECKING
 
-import attrs
 import cirq
 from attrs import frozen
 from numpy.typing import NDArray
@@ -26,7 +25,7 @@ from .quantum_graph import LeftDangle, RightDangle
 from .registers import Signature
 
 if TYPE_CHECKING:
-    from qualtran import Bloq, CompositeBloq, Signature, Soquet, SoquetT
+    from qualtran import Bloq, CompositeBloq, Register, Signature, Soquet, SoquetT
     from qualtran.drawing import WireSymbol
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 
@@ -183,11 +182,11 @@ class Adjoint(GateWithRegisters):
         """Delegate to subbloq's `__str__` method."""
         return f'Adjoint(subbloq={str(self.subbloq)})'
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         # Note: since we pass are passed a soquet which has the 'new' side, we flip it before
         # delegating and then flip back. Subbloqs only have to answer this protocol
         # if the provided soquet is facing the correct direction.
-        return self.subbloq.wire_symbol(attrs.evolve(soq, reg=soq.reg.adjoint())).adjoint()
+        return self.subbloq.wire_symbol(reg=reg.adjoint(), idx=idx).adjoint()
 
     def _t_complexity_(self):
         """The cirq-style `_t_complexity_` delegates to the subbloq's method with a special shim.

--- a/qualtran/_infra/adjoint_test.py
+++ b/qualtran/_infra/adjoint_test.py
@@ -18,7 +18,7 @@ import pytest
 import sympy
 
 import qualtran.testing as qlt_testing
-from qualtran import Adjoint, Bloq, BloqInstance, CompositeBloq, Side, Signature, Soquet
+from qualtran import Adjoint, Bloq, CompositeBloq, Side, Signature
 from qualtran._infra.adjoint import _adjoint_cbloq
 from qualtran.bloqs.basic_gates import CNOT, CSwap, ZeroState
 from qualtran.bloqs.for_testing.atom import TestAtom
@@ -162,11 +162,8 @@ def test_wire_symbol():
     (reg,) = zero.signature
     adj = Adjoint(zero)  # specifically use the Adjoint wrapper for testing
 
-    # TODO: Remove binst variable.  These BloqInstances are for typing only
-    # and are not really used by the function.
-    # See https://github.com/quantumlib/Qualtran/issues/608
-    ws = zero.wire_symbol(Soquet(BloqInstance(CNOT(), 1), reg))
-    adj_ws = adj.wire_symbol(Soquet(BloqInstance(CNOT(), 2), reg.adjoint()))
+    ws = zero.wire_symbol(reg)
+    adj_ws = adj.wire_symbol(reg.adjoint())
     assert isinstance(ws, LarrowTextBox)
     assert isinstance(adj_ws, RarrowTextBox)
 

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
         BloqBuilder,
         CompositeBloq,
         CtrlSpec,
+        Register,
         Signature,
         Soquet,
         SoquetT,
@@ -503,7 +504,7 @@ class Bloq(metaclass=abc.ABCMeta):
 
         return self.on(*merge_qubits(self.signature, **qubit_regs))
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         """On a musical score visualization, use this `WireSymbol` to represent `soq`.
 
         By default, we use a "directional text box", which is a text box that is either
@@ -516,4 +517,10 @@ class Bloq(metaclass=abc.ABCMeta):
         """
         from qualtran.drawing import directional_text_box
 
-        return directional_text_box(text=soq.pretty(), side=soq.reg.side)
+        label = reg.name
+        if len(idx) > 0:
+            pretty_str = f'{label}[{", ".join(str(i) for i in idx)}]'
+        else:
+            pretty_str = label
+
+        return directional_text_box(text=pretty_str, side=reg.side)

--- a/qualtran/_infra/controlled.py
+++ b/qualtran/_infra/controlled.py
@@ -166,15 +166,15 @@ class CtrlSpec:
                 return False
         return True
 
-    def wire_symbol(self, i: int, soq: 'Soquet') -> 'WireSymbol':
+    def wire_symbol(self, i: int, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         # Return a circle for bits; a box otherwise.
         from qualtran.drawing import Circle, TextBox
 
-        if soq.reg.bitsize == 1:
-            cv = self.cvs[i][soq.idx]
+        if reg.bitsize == 1:
+            cv = self.cvs[i][idx]
             return Circle(filled=(cv == 1))
 
-        cv = self.cvs[i][soq.idx]
+        cv = self.cvs[i][idx]
         return TextBox(f'{cv}')
 
     @cached_property
@@ -431,14 +431,14 @@ class Controlled(GateWithRegisters):
         # Unable to determine the unitary effect.
         return NotImplemented
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name not in self.ctrl_reg_names:
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name not in self.ctrl_reg_names:
             # Delegate to subbloq
-            return self.subbloq.wire_symbol(soq)
+            return self.subbloq.wire_symbol(reg, idx)
 
         # Otherwise, it's part of the control register.
-        i = self.ctrl_reg_names.index(soq.reg.name)
-        return self.ctrl_spec.wire_symbol(i, soq)
+        i = self.ctrl_reg_names.index(reg.name)
+        return self.ctrl_spec.wire_symbol(i, reg, idx)
 
     def adjoint(self) -> 'Bloq':
         return self.subbloq.adjoint().controlled(self.ctrl_spec)

--- a/qualtran/_infra/controlled.py
+++ b/qualtran/_infra/controlled.py
@@ -434,6 +434,8 @@ class Controlled(GateWithRegisters):
     def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         if reg.name not in self.ctrl_reg_names:
             # Delegate to subbloq
+            print(self.subbloq)
+            print(type(self.subbloq))
             return self.subbloq.wire_symbol(reg, idx)
 
         # Otherwise, it's part of the control register.

--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -33,7 +33,6 @@ from numpy.typing import NDArray
 
 from qualtran._infra.bloq import Bloq, DecomposeNotImplementedError, DecomposeTypeError
 from qualtran._infra.composite_bloq import CompositeBloq
-from qualtran._infra.quantum_graph import Soquet
 from qualtran._infra.registers import Register, Side
 
 if TYPE_CHECKING:
@@ -309,10 +308,10 @@ class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
         )
         return self.on_registers(**all_quregs), out_quregs
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         from qualtran.cirq_interop._cirq_to_bloq import _wire_symbol_from_gate
 
-        return _wire_symbol_from_gate(self, self.signature, soq)
+        return _wire_symbol_from_gate(self, self.signature, reg, idx)
 
     # Part-2: Cirq-FT style interface can be used to implemented algorithms by Bloq authors.
 

--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -150,13 +150,13 @@ class Add(Bloq):
         wire_symbols += ["In(y)/Out(x+y)"] * int(self.b_dtype.bitsize)
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         from qualtran.drawing import directional_text_box
 
-        if soq.reg.name == 'a':
-            return directional_text_box('a', side=soq.reg.side)
-        elif soq.reg.name == 'b':
-            return directional_text_box('a+b', side=soq.reg.side)
+        if reg.name == 'a':
+            return directional_text_box('a', side=reg.side)
+        elif reg.name == 'b':
+            return directional_text_box('a+b', side=reg.side)
         else:
             raise ValueError()
 

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -677,7 +677,6 @@ class LinearDepthGreaterThan(Bloq):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', a: Soquet, b: Soquet, target: SoquetT
     ) -> Dict[str, 'SoquetT']:
-
         # Base Case: Comparing two qubits.
         # Signed doesn't matter because we can't represent signed integers with 1 qubit.
         if self.bitsize == 1:

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Iterable, Iterator, List, Sequence, Set, TYPE_CHECKING, Union
+from typing import Dict, Iterable, Iterator, List, Sequence, Set, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import cirq
@@ -599,14 +599,14 @@ class GreaterThan(Bloq):
         # See: https://github.com/quantumlib/Qualtran/issues/217
         return t_complexity(LessThanEqual(self.a_bitsize, self.b_bitsize))
 
-    def wire_symbol(self, soq: Soquet) -> WireSymbol:
-        if soq.reg.name == 'a':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> WireSymbol:
+        if reg.name == 'a':
             return TextBox("In(a)")
-        if soq.reg.name == 'b':
+        if reg.name == 'b':
             return TextBox("In(b)")
-        elif soq.reg.name == 'target':
+        elif reg.name == 'target':
             return TextBox("⨁(a > b)")
-        raise ValueError(f'Unknown register name {soq.reg.name}')
+        raise ValueError(f'Unknown register name {reg.name}')
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         # TODO Determine precise clifford count and/or ignore.
@@ -831,12 +831,12 @@ class GreaterThanConstant(Bloq):
     def short_name(self) -> str:
         return f"x > {self.val}"
 
-    def wire_symbol(self, soq: Soquet) -> WireSymbol:
-        if soq.reg.name == 'x':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> WireSymbol:
+        if reg.name == 'x':
             return TextBox("In(x)")
-        elif soq.reg.name == 'target':
+        elif reg.name == 'target':
             return TextBox(f"⨁(x > {self.val})")
-        raise ValueError(f'Unknown register symbol {soq.reg.name}')
+        raise ValueError(f'Unknown register symbol {reg.name}')
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         # TODO Determine precise clifford count and/or ignore.
@@ -884,12 +884,12 @@ class EqualsAConstant(Bloq):
     def short_name(self) -> str:
         return f"x == {self.val}"
 
-    def wire_symbol(self, soq: Soquet) -> WireSymbol:
-        if soq.reg.name == 'x':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> WireSymbol:
+        if reg.name == 'x':
             return TextBox("In(x)")
-        elif soq.reg.name == 'target':
+        elif reg.name == 'target':
             return TextBox(f"⨁(x = {self.val})")
-        raise ValueError(f'Unknown register symbol {soq.reg.name}')
+        raise ValueError(f'Unknown register symbol {reg.name}')
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         # See: https://github.com/quantumlib/Qualtran/issues/219

--- a/qualtran/bloqs/arithmetic/conversions.py
+++ b/qualtran/bloqs/arithmetic/conversions.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Set, TYPE_CHECKING
+from typing import Dict, Set, Tuple, TYPE_CHECKING
 
 from attrs import frozen
 
@@ -28,7 +28,6 @@ from qualtran import (
     Side,
     Signature,
 )
-from qualtran._infra.quantum_graph import Soquet
 from qualtran.bloqs.basic_gates import Toffoli
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import WireSymbol
@@ -89,10 +88,10 @@ class ToContiguousIndex(Bloq):
         num_toffoli = self.bitsize**2 + self.bitsize - 1
         return TComplexity(t=4 * num_toffoli)
 
-    def wire_symbol(self, soq: Soquet) -> WireSymbol:
-        if soq.reg.name == 'mu':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> WireSymbol:
+        if reg.name == 'mu':
             return TextBox(r'$\mu$')
-        elif soq.reg.name == 'nu':
+        elif reg.name == 'nu':
             return TextBox(r'$\mu$')
         else:
             text = r'$\oplus\nu(\nu-1)/2+\mu$'

--- a/qualtran/bloqs/basic_gates/cnot.py
+++ b/qualtran/bloqs/basic_gates/cnot.py
@@ -29,8 +29,8 @@ from qualtran import (
     CompositeBloq,
     CtrlSpec,
     DecomposeTypeError,
+    Register,
     Signature,
-    Soquet,
     SoquetT,
 )
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
@@ -131,12 +131,12 @@ class CNOT(Bloq):
         (target,) = target
         return cirq.CNOT(ctrl, target), {'ctrl': np.array([ctrl]), 'target': np.array([target])}
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'ctrl':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'ctrl':
             return Circle(filled=True)
-        elif soq.reg.name == 'target':
+        elif reg.name == 'target':
             return ModPlus()
-        raise ValueError(f'Bad wire symbol soquet: {soq}')
+        raise ValueError(f'Unknown wire symbol register name: {reg.name}')
 
     def _t_complexity_(self) -> 'TComplexity':
         return TComplexity(clifford=1)

--- a/qualtran/bloqs/basic_gates/hadamard.py
+++ b/qualtran/bloqs/basic_gates/hadamard.py
@@ -24,8 +24,8 @@ from qualtran import (
     BloqDocSpec,
     CompositeBloq,
     DecomposeTypeError,
+    Register,
     Signature,
-    Soquet,
     SoquetT,
 )
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
@@ -95,7 +95,7 @@ class Hadamard(Bloq):
     def short_name(self) -> 'str':
         return 'H'
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         return TextBox('H')
 
 

--- a/qualtran/bloqs/basic_gates/on_each.py
+++ b/qualtran/bloqs/basic_gates/on_each.py
@@ -14,12 +14,11 @@
 
 """Classes to apply single qubit bloq to multiple qubits."""
 from functools import cached_property
-from typing import Dict, Set
+from typing import Dict, Set, Tuple
 
 import attrs
 
 from qualtran import Bloq, BloqBuilder, QAny, Register, Signature, SoquetT
-from qualtran._infra.quantum_graph import Soquet
 from qualtran.drawing import WireSymbol
 from qualtran.drawing.musical_score import TextBox
 from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
@@ -53,7 +52,7 @@ class OnEach(Bloq):
     def short_name(self) -> str:
         return rf'{self.gate.short_name()}⨂{self.n}'
 
-    def wire_symbol(self, soq: Soquet) -> WireSymbol:
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> WireSymbol:
         return TextBox(self.gate.short_name())
 
     def build_composite_bloq(self, bb: BloqBuilder, *, q: SoquetT) -> Dict[str, SoquetT]:

--- a/qualtran/bloqs/basic_gates/s_gate.py
+++ b/qualtran/bloqs/basic_gates/s_gate.py
@@ -19,7 +19,7 @@ import attrs
 import numpy as np
 from attrs import frozen
 
-from qualtran import Bloq, bloq_example, BloqDocSpec, Signature, Soquet, SoquetT
+from qualtran import Bloq, bloq_example, BloqDocSpec, Register, Signature, SoquetT
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import TextBox, WireSymbol
 
@@ -86,7 +86,7 @@ class SGate(Bloq):
         maybe_dag = '†' if self.is_adjoint else ''
         return f'S{maybe_dag}'
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         return TextBox(self.pretty_name())
 
     def adjoint(self) -> 'Bloq':

--- a/qualtran/bloqs/basic_gates/su2_rotation.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation.py
@@ -12,14 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, Dict, Tuple, TYPE_CHECKING
 
 import numpy as np
 import sympy
 from attrs import frozen
 from numpy.typing import NDArray
 
-from qualtran import bloq_example, BloqDocSpec, GateWithRegisters, Signature
+from qualtran import bloq_example, BloqDocSpec, GateWithRegisters, Register, Signature
 from qualtran.bloqs.basic_gates import GlobalPhase, Ry, ZPowGate
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import TextBox
@@ -143,7 +143,7 @@ class SU2RotationGate(GateWithRegisters):
     def pretty_name(self) -> str:
         return 'SU_2'
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         return TextBox(
             f"{self.pretty_name()}({self.theta}, {self.phi}, {self.lambd}, {self.global_shift})"
         )

--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -236,12 +236,12 @@ class Swap(Bloq):
     def short_name(self) -> str:
         return 'swap'
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'x':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = ()) -> 'WireSymbol':
+        if reg.name == 'x':
             return TextBox('×(x)')
-        elif soq.reg.name == 'y':
+        elif reg.name == 'y':
             return TextBox('×(y)')
-        raise ValueError(f"Bad register name {soq.reg.name}")
+        raise ValueError(f"Bad register name {reg.name}")
 
     def adjoint(self) -> 'Bloq':
         return self

--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -29,6 +29,7 @@ from qualtran import (
     BloqDocSpec,
     DecomposeTypeError,
     GateWithRegisters,
+    Register,
     Signature,
     Soquet,
     SoquetT,
@@ -185,8 +186,8 @@ class TwoBitCSwap(Bloq):
     def short_name(self) -> str:
         return 'swap'
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'ctrl':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = ()) -> 'WireSymbol':
+        if reg.name == 'ctrl':
             return Circle(filled=True)
         else:
             return TextBox('×')
@@ -318,10 +319,10 @@ class CSwap(GateWithRegisters):
             )
         return cirq.CircuitDiagramInfo(("@",) + ("×(x)",) * self.bitsize + ("×(y)",) * self.bitsize)
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'x':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'x':
             return TextBox('×(x)')
-        elif soq.reg.name == 'y':
+        elif reg.name == 'y':
             return TextBox('×(y)')
         else:
             return Circle(filled=True)

--- a/qualtran/bloqs/basic_gates/t_gate.py
+++ b/qualtran/bloqs/basic_gates/t_gate.py
@@ -19,7 +19,7 @@ import attrs
 import numpy as np
 from attrs import frozen
 
-from qualtran import Bloq, bloq_example, BloqDocSpec, Signature, Soquet, SoquetT
+from qualtran import Bloq, bloq_example, BloqDocSpec, Register, Signature, SoquetT
 from qualtran.drawing import TextBox, WireSymbol
 
 if TYPE_CHECKING:
@@ -111,7 +111,7 @@ class TGate(Bloq):
         maybe_dag = 'is_adjoint=True' if self.is_adjoint else ''
         return f'TGate({maybe_dag})'
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         return TextBox(self.pretty_name())
 
 

--- a/qualtran/bloqs/basic_gates/toffoli.py
+++ b/qualtran/bloqs/basic_gates/toffoli.py
@@ -113,14 +113,14 @@ class Toffoli(Bloq):
         (trg,) = target
         return cirq.CCNOT(*ctrl[:, 0], trg), {'ctrl': ctrl, 'target': target}
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         from qualtran.drawing import Circle, ModPlus
 
-        if soq.reg.name == 'ctrl':
+        if reg.name == 'ctrl':
             return Circle(filled=True)
-        elif soq.reg.name == 'target':
+        elif reg.name == 'target':
             return ModPlus()
-        raise ValueError(f'Bad wire symbol soquet: {soq}')
+        raise ValueError(f'Unknown wire symbol register name: {reg.name}')
 
 
 @bloq_example

--- a/qualtran/bloqs/basic_gates/x_basis.py
+++ b/qualtran/bloqs/basic_gates/x_basis.py
@@ -30,7 +30,6 @@ from qualtran import (
     Register,
     Side,
     Signature,
-    Soquet,
     SoquetT,
 )
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
@@ -268,7 +267,7 @@ class XGate(Bloq):
     def _t_complexity_(self):
         return TComplexity(clifford=1)
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         from qualtran.drawing import ModPlus
 
         return ModPlus()

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -34,7 +34,6 @@ from qualtran import (
     Register,
     Side,
     Signature,
-    Soquet,
     SoquetT,
 )
 from qualtran.bloqs.util_bloqs import ArbitraryClifford
@@ -380,10 +379,10 @@ class _IntVector(Bloq):
         s = self.short_name()
         return f'|{s}>' if self.state else f'<{s}|'
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         from qualtran.drawing import directional_text_box
 
-        return directional_text_box(text=f'{self.val}', side=soq.reg.side)
+        return directional_text_box(text=f'{self.val}', side=reg.side)
 
 
 @frozen(init=False, field_transformer=_hide_base_fields)

--- a/qualtran/bloqs/chemistry/black_boxes.py
+++ b/qualtran/bloqs/chemistry/black_boxes.py
@@ -188,11 +188,11 @@ class ApplyControlledZs(Bloq):
             ]
         )
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'system':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'system':
             return TextBox('Z')
 
-        (c_idx,) = soq.idx
+        (c_idx,) = idx
         filled = bool(self.cvs[c_idx])
         return Circle(filled)
 

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_and_prepare.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_and_prepare.py
@@ -137,18 +137,18 @@ class ControlledMultiplexedCSwap3D(MultiplexedCSwap3D):
             ]
         )
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'sel':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'sel':
             return TextBox('In')
-        elif soq.reg.name == 'targets':
+        elif reg.name == 'targets':
             return TextBox('×(x)')
-        elif soq.reg.name == 'junk':
+        elif reg.name == 'junk':
             return TextBox('×(y)')
-        elif soq.reg.name == 'ctrl':
-            (c_idx,) = soq.idx
+        elif reg.name == 'ctrl':
+            (c_idx,) = idx
             filled = bool(self.cvs[c_idx])
             return Circle(filled)
-        raise ValueError(f'Unknown name: {soq.reg.name}')
+        raise ValueError(f'Unknown name: {reg.name}')
 
     def build_composite_bloq(
         self, bb: BloqBuilder, ctrl: SoquetT, sel: SoquetT, targets: SoquetT, junk: SoquetT

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/select_and_prepare.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/select_and_prepare.py
@@ -157,14 +157,14 @@ class MultiplexedCSwap3D(Bloq):
         )
         return merged_qubits.reshape(out_shape)
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'sel':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'sel':
             return TextBox('In')
-        elif soq.reg.name == 'targets':
+        elif reg.name == 'targets':
             return TextBox('×(x)')
-        elif soq.reg.name == 'junk':
+        elif reg.name == 'junk':
             return TextBox('×(y)')
-        raise ValueError(f'Unknown name: {soq.reg.name}')
+        raise ValueError(f'Unknown name: {reg.name}')
 
     def short_name(self) -> str:
         return 'MultiSwap'

--- a/qualtran/bloqs/data_loading/qrom.py
+++ b/qualtran/bloqs/data_loading/qrom.py
@@ -22,7 +22,7 @@ import cirq
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from qualtran import bloq_example, BloqDocSpec, BoundedQUInt, QAny, Register, Soquet
+from qualtran import bloq_example, BloqDocSpec, BoundedQUInt, QAny, Register
 from qualtran._infra.gate_with_registers import merge_qubits, total_bits
 from qualtran.bloqs.basic_gates import CNOT
 from qualtran.bloqs.mcmt.and_bloq import And, MultiAnd
@@ -210,8 +210,8 @@ class QROM(UnaryIterationGate):
             wire_symbols += [f"QROM_{i}"] * target.total_bits()
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        name = soq.reg.name
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        name = reg.name
         if name == 'selection':
             return TextBox('In')
         elif 'selection' in name:

--- a/qualtran/bloqs/data_loading/select_swap_qrom.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom.py
@@ -19,7 +19,7 @@ import cirq
 import numpy as np
 from numpy.typing import NDArray
 
-from qualtran import BoundedQUInt, GateWithRegisters, QAny, Register, Signature, Soquet
+from qualtran import BoundedQUInt, GateWithRegisters, QAny, Register, Signature
 from qualtran._infra.gate_with_registers import merge_qubits, split_qubits, total_bits
 from qualtran.bloqs.data_loading.qrom import QROM
 from qualtran.bloqs.swap_network import SwapWithZero
@@ -242,8 +242,8 @@ class SelectSwapQROM(GateWithRegisters):
             wire_symbols += [f"QROAM_{i}"] * target.total_bits()
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        name = soq.reg.name
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        name = reg.name
         if name == 'selection':
             return TextBox('In')
         elif 'target' in name:

--- a/qualtran/bloqs/factoring/mod_add.py
+++ b/qualtran/bloqs/factoring/mod_add.py
@@ -179,7 +179,6 @@ class MontgomeryModAdd(Bloq):
     def on_classical_vals(
         self, x: 'ClassicalValT', y: 'ClassicalValT'
     ) -> Dict[str, 'ClassicalValT']:
-
         y += x
         y -= self.p
 
@@ -189,7 +188,6 @@ class MontgomeryModAdd(Bloq):
         return {'x': x, 'y': y}
 
     def build_composite_bloq(self, bb: 'BloqBuilder', x: Soquet, y: Soquet) -> Dict[str, 'SoquetT']:
-
         # Allocate ancilla bits for use in addition.
         junk_bit = bb.allocate(n=1)
         sign = bb.allocate(n=1)

--- a/qualtran/bloqs/factoring/mod_add.py
+++ b/qualtran/bloqs/factoring/mod_add.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Set, TYPE_CHECKING, Union
+from typing import Dict, Set, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 import sympy
@@ -77,14 +77,14 @@ class CtrlScaleModAdd(Bloq):
     def short_name(self) -> str:
         return f'y += x*{self.k} % {self.mod}'
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'ctrl':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'ctrl':
             return Circle()
-        if soq.reg.name == 'x':
+        if reg.name == 'x':
             return TextBox('x')
-        if soq.reg.name == 'y':
+        if reg.name == 'y':
             return TextBox(f'y += x*{self.k}')
-        raise ValueError(f"Unknown soquet {soq}")
+        raise ValueError(f"Unknown register name {reg.name}")
 
 
 @frozen

--- a/qualtran/bloqs/factoring/mod_mul.py
+++ b/qualtran/bloqs/factoring/mod_mul.py
@@ -152,7 +152,6 @@ class MontgomeryModDbl(Bloq):
         return {'x': (2 * x) % self.p}
 
     def build_composite_bloq(self, bb: 'BloqBuilder', x: Soquet) -> Dict[str, 'SoquetT']:
-
         # Allocate ancilla bits for sign and double.
         lower_bit = bb.allocate(n=1)
         sign = bb.allocate(n=1)

--- a/qualtran/bloqs/factoring/mod_mul.py
+++ b/qualtran/bloqs/factoring/mod_mul.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Optional, Set, Union
+from typing import Dict, Optional, Set, Tuple, Union
 
 import attrs
 import numpy as np
@@ -114,12 +114,12 @@ class CtrlModMul(Bloq):
     def short_name(self) -> str:
         return f'x *= {self.k} % {self.mod}'
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'ctrl':
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'ctrl':
             return Circle(filled=True)
-        if soq.reg.name == 'x':
-            return directional_text_box(f'*={self.k}', side=soq.reg.side)
-        raise ValueError(f"Unknown register name: {soq.reg.name}")
+        if reg.name == 'x':
+            return directional_text_box(f'*={self.k}', side=reg.side)
+        raise ValueError(f"Unknown register name: {reg.name}")
 
 
 @frozen

--- a/qualtran/bloqs/mcmt/and_bloq.py
+++ b/qualtran/bloqs/mcmt/and_bloq.py
@@ -158,11 +158,11 @@ class And(GateWithRegisters):
             )
         )
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'target':
-            return directional_text_box('∧', side=soq.reg.side)
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'target':
+            return directional_text_box('∧', side=reg.side)
 
-        (c_idx,) = soq.idx
+        (c_idx,) = idx
         filled = bool(self.cv1 if c_idx == 0 else self.cv2)
         return Circle(filled)
 
@@ -320,12 +320,17 @@ class MultiAnd(Bloq):
             t=4 * num_single_and, clifford=9 * num_single_and + 2 * pre_post_cliffords
         )
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'ctrl':
-            return Circle(filled=self.cvs[soq.idx[0]] == 1)
-        if soq.reg.name == 'target':
-            return directional_text_box('∧', side=soq.reg.side)
-        return directional_text_box(text=soq.pretty(), side=soq.reg.side)
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'ctrl':
+            print(idx)
+            return Circle(filled=self.cvs[idx[0]] == 1)
+        if reg.name == 'target':
+            return directional_text_box('∧', side=reg.side)
+        if len(idx) > 0:
+            pretty_text = f'{reg.name}[{", ".join(str(i) for i in idx)}]'
+        else:
+            pretty_text = reg.name
+        return directional_text_box(text=pretty_text, side=reg.side)
 
     def short_name(self) -> str:
         return 'And'

--- a/qualtran/bloqs/reflection.py
+++ b/qualtran/bloqs/reflection.py
@@ -64,8 +64,8 @@ class Reflection(Bloq):
             [Register(f'reg{i}', QAny(bitsize=b)) for i, b in enumerate(self.bitsizes)]
         )
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        idx = int(soq.pretty()[3:])
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        idx = int(reg.name[3:])
         filled = bool(self.cvs[idx])
         return Circle(filled)
 

--- a/qualtran/bloqs/util_bloqs.py
+++ b/qualtran/bloqs/util_bloqs.py
@@ -33,7 +33,6 @@ from qualtran import (
     Register,
     Side,
     Signature,
-    Soquet,
     SoquetT,
 )
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
@@ -109,11 +108,11 @@ class Split(Bloq):
 
         return self, add_controlled
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.shape:
-            text = f'[{", ".join(str(i) for i in soq.idx)}]'
-            return directional_text_box(text, side=soq.reg.side)
-        return directional_text_box(' ', side=soq.reg.side)
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.shape:
+            text = f'[{", ".join(str(i) for i in idx)}]'
+            return directional_text_box(text, side=reg.side)
+        return directional_text_box(' ', side=reg.side)
 
 
 @frozen
@@ -177,11 +176,11 @@ class Join(Bloq):
 
         return self, add_controlled
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.shape:
-            text = f'[{", ".join(str(i) for i in soq.idx)}]'
-            return directional_text_box(text, side=soq.reg.side)
-        return directional_text_box(' ', side=soq.reg.side)
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.shape:
+            text = f'[{", ".join(str(i) for i in idx)}]'
+            return directional_text_box(text, side=reg.side)
+        return directional_text_box(' ', side=reg.side)
 
 
 @frozen
@@ -297,11 +296,11 @@ class Partition(Bloq):
         else:
             return self._classical_unpartition(**vals)
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.shape:
-            text = f'[{",".join(str(i) for i in soq.idx)}]'
-            return directional_text_box(text, side=soq.reg.side)
-        return directional_text_box(' ', side=soq.reg.side)
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.shape:
+            text = f'[{",".join(str(i) for i in idx)}]'
+            return directional_text_box(text, side=reg.side)
+        return directional_text_box(' ', side=reg.side)
 
 
 @frozen
@@ -339,8 +338,8 @@ class Allocate(Bloq):
         data[0] = 1
         tn.add(qtn.Tensor(data=data, inds=(outgoing['reg'],), tags=['Allocate', tag]))
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        assert soq.reg.name == 'reg'
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        assert reg.name == 'reg'
         return directional_text_box('alloc', Side.RIGHT)
 
 
@@ -385,8 +384,8 @@ class Free(Bloq):
         data[0] = 1
         tn.add(qtn.Tensor(data=data, inds=(incoming['reg'],), tags=['Free', tag]))
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        assert soq.reg.name == 'reg'
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        assert reg.name == 'reg'
         return directional_text_box('free', Side.LEFT)
 
 

--- a/qualtran/cirq_interop/_bloq_to_cirq.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq.py
@@ -34,7 +34,7 @@ from qualtran import (
     Signature,
     Soquet,
 )
-from qualtran._infra.composite_bloq import _binst_to_cxns, _reg_to_soq
+from qualtran._infra.composite_bloq import _binst_to_cxns
 from qualtran._infra.gate_with_registers import (
     _get_all_and_output_quregs_from_input,
     merge_qubits,
@@ -302,18 +302,12 @@ def _wire_symbol_to_cirq_diagram_info(
 ) -> cirq.CircuitDiagramInfo:
     wire_symbols = []
     for reg in bloq.signature:
-        # Note: all of our soqs lack a `binst`. The `bloq.wire_symbol` methods
-        # should never use the binst field, but this isn't really enforced anywhere.
-        # https://github.com/quantumlib/Qualtran/issues/608
-        soqs = _reg_to_soq(None, reg)
-        if isinstance(soqs, Soquet):
-            assert soqs.idx == ()
-            soqs = np.array([soqs] * reg.bitsize)
+        if reg.shape:
+            for idx in range(reg.bitsize):
+                for ri in reg.all_idxs():
+                    wire_symbols.append(bloq.wire_symbol(reg, ri))
         else:
-            soqs = np.broadcast_to(soqs, (reg.bitsize,) + reg.shape)
-
-        for soq in soqs.reshape(-1):
-            wire_symbols.append(bloq.wire_symbol(soq))
+            wire_symbols.extend([bloq.wire_symbol(reg)] * reg.bitsize)
 
     def _qualtran_wire_symbols_to_cirq_text(ws: WireSymbol) -> str:
         if isinstance(ws, Circle):

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -162,16 +162,21 @@ class CirqGateAsBloq(CirqGateAsBloqBase):
         return self.gate
 
 
-def _wire_symbol_from_gate(gate: cirq.Gate, signature: Signature, soq: 'Soquet') -> 'WireSymbol':
+def _wire_symbol_from_gate(
+    gate: cirq.Gate, signature: Signature, wire_reg: Register, idx: Tuple[int, ...] = tuple()
+) -> 'WireSymbol':
     from qualtran.drawing import directional_text_box
 
     wire_symbols = cirq.circuit_diagram_info(gate).wire_symbols
     begin = 0
-    symbol: str = soq.pretty()
+    if len(idx) > 0:
+        symbol = f'{wire_reg.name}[{", ".join(str(i) for i in idx)}]'
+    else:
+        symbol = wire_reg.name
     for reg in signature:
         reg_size = int(np.prod(reg.shape))
         finish = begin + reg.bitsize * int(np.prod(reg.shape))
-        if reg == soq.reg:
+        if reg == wire_reg:
             if reg_size == 1:
                 # either shape = () or shape = (1,), wire_symbols is a list of
                 # size reg.bitsize, we only want one label for the register.
@@ -180,14 +185,12 @@ def _wire_symbol_from_gate(gate: cirq.Gate, signature: Signature, soq: 'Soquet')
                 # If the bitsize > 1 AND the shape of the register is non
                 # trivial then we only want to index into the shape, (not shape
                 # * bitsize)
-                symbol = np.array(wire_symbols[begin : begin + reg_size]).reshape(reg.shape)[
-                    soq.idx
-                ]
+                symbol = np.array(wire_symbols[begin : begin + reg_size]).reshape(reg.shape)[idx]
             else:
                 # bitsize = 1 and shape is non trivial, index into the array of wireshapes.
-                symbol = np.array(wire_symbols[begin:finish]).reshape(reg.shape)[soq.idx]
+                symbol = np.array(wire_symbols[begin:finish]).reshape(reg.shape)[idx]
         begin = finish
-    return directional_text_box(text=symbol, side=soq.reg.side)
+    return directional_text_box(text=symbol, side=wire_reg.side)
 
 
 def _add_my_tensors_from_gate(

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -162,9 +162,7 @@ class CirqGateAsBloq(CirqGateAsBloqBase):
         return self.gate
 
 
-
 def _cirq_wire_symbol_to_qualtran_wire_symbol(symbol: str, side: Side) -> 'WireSymbol':
-
     from qualtran.drawing import Circle, directional_text_box, ModPlus
 
     if symbol == "@":
@@ -179,7 +177,6 @@ def _cirq_wire_symbol_to_qualtran_wire_symbol(symbol: str, side: Side) -> 'WireS
 def _wire_symbol_from_gate(
     gate: cirq.Gate, signature: Signature, wire_reg: Register, idx: Tuple[int, ...] = tuple()
 ) -> 'WireSymbol':
-
     wire_symbols = cirq.circuit_diagram_info(gate).wire_symbols
     begin = 0
     if len(idx) > 0:
@@ -203,7 +200,7 @@ def _wire_symbol_from_gate(
                 # bitsize = 1 and shape is non trivial, index into the array of wireshapes.
                 symbol = np.array(wire_symbols[begin:finish]).reshape(reg.shape)[idx]
         begin = finish
-    return _cirq_wire_symbol_to_qualtran_wire_symbol(symbol, reg.side)
+    return _cirq_wire_symbol_to_qualtran_wire_symbol(symbol, wire_reg.side)
 
 
 def _add_my_tensors_from_gate(

--- a/qualtran/drawing/musical_score.py
+++ b/qualtran/drawing/musical_score.py
@@ -480,7 +480,7 @@ def _soq_to_symb(soq: Soquet) -> WireSymbol:
         return Text(soq.pretty() + f'/{soq.reg.dtype}', fontsize=8)
 
     # Otherwise, use `Bloq.wire_symbol`.
-    return soq.binst.bloq.wire_symbol(soq)
+    return soq.binst.bloq.wire_symbol(soq.reg, soq.idx)
 
 
 @mutable

--- a/qualtran/testing.py
+++ b/qualtran/testing.py
@@ -31,7 +31,6 @@ from qualtran import (
     LeftDangle,
     RightDangle,
     Side,
-    Soquet,
 )
 from qualtran._infra.composite_bloq import _get_flat_dangling_soqs
 from qualtran._infra.data_types import check_dtypes_consistent, QDTypeCheckingSeverity
@@ -236,9 +235,7 @@ def assert_wire_symbols_match_expected(bloq: Bloq, expected_ws: List[str]):
     ws = []
     regs = bloq.signature
     for i, r in enumerate(regs):
-        # note this will only work if shape = ().
-        # See: https://github.com/quantumlib/Qualtran/issues/608
-        ws.append(bloq.wire_symbol(Soquet(i, r)).text)
+        ws.append(bloq.wire_symbol(r, (i,)).text)
 
     assert ws == expected_ws
 

--- a/qualtran/testing.py
+++ b/qualtran/testing.py
@@ -234,6 +234,8 @@ def assert_wire_symbols_match_expected(bloq: Bloq, expected_ws: List[str]):
     """
     ws = []
     regs = bloq.signature
+    # note this will only work if shape = ().
+    # See: https://github.com/quantumlib/Qualtran/issues/608
     for i, r in enumerate(regs):
         ws.append(bloq.wire_symbol(r, (i,)).text)
 


### PR DESCRIPTION
- Change wire_symbol to use Register and idx since the wire_symbol should never need to use the binst of a Soquet.

Part of #728