### PR TITLE
QROAM stub

### DIFF
--- a/qualtran/bloqs/data_loading/qroam.py
+++ b/qualtran/bloqs/data_loading/qroam.py
@@ -194,8 +194,8 @@ class QROAM(Bloq):
         )[1]
         return {(Toffoli(), cost)}
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        name = soq.reg.name
+    def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        name = reg.name
         if name == 'selection':
             return TextBox('In')
         elif 'target' in name:

--- a/qualtran/bloqs/data_loading/qroam.py
+++ b/qualtran/bloqs/data_loading/qroam.py
@@ -1,0 +1,118 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Common Chemistry bloqs which have costs that differ from those currently implemented in qualtran.
+
+These are for temporary convenience to lock-in the quoted literature costs.
+"""
+from functools import cached_property
+from typing import Optional, Set, Tuple, TYPE_CHECKING
+
+import attrs
+import cirq
+import numpy as np
+from attrs import field, frozen
+
+from qualtran import Bloq, BloqBuilder, QAny, QBit, Register, Signature, Soquet, SoquetT
+from qualtran.bloqs.basic_gates import Toffoli
+from qualtran.bloqs.mcmt.multi_control_multi_target_pauli import MultiControlPauli
+from qualtran.drawing import Circle, TextBox, WireSymbol
+
+if TYPE_CHECKING:
+    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+
+
+def get_qroam_cost(
+    data_size: int, bitsize: int, adjoint: bool = False, qroam_block_size: Optional[int] = None
+) -> int:
+    """This gives the optimal k and minimum cost for a QROM over L values of size M.
+
+    Adapted from openfermion and accounts for quoted inverse cost.
+
+    Args:
+        data_size: Amount of data we want to load.
+        bitsize: the amount of bits of output we need.
+        adjoint: whether to get costs from inverse qrom (true) or not (false).
+        qroam_block_size: The block size for QROAM. Default find the optimal
+            value given the data size.
+
+    Returns:
+       val_opt: minimal (optimal) cost of QROM
+    """
+    if qroam_block_size == 1:
+        return data_size - 1
+    if adjoint:
+        if qroam_block_size is None:
+            log_blk = 0.5 * np.log2(data_size)
+            qroam_block_size = 2**log_blk
+        value = lambda x: data_size / x + x
+    else:
+        if qroam_block_size is None:
+            log_blk = 0.5 * np.log2(data_size / bitsize)
+            assert log_blk >= 0
+            qroam_block_size = 2**log_blk
+        value = lambda x: data_size / x + bitsize * (x - 1)
+    k = np.log2(qroam_block_size)
+    k_int = np.array([np.floor(k), np.ceil(k)])
+    k_opt = k_int[np.argmin(value(2**k_int))]
+    val_opt = np.ceil(value(2**k_opt))
+    return int(val_opt)
+
+
+@frozen
+class QROAM(Bloq):
+    """Advanced qroam i.e. QRO(A)M for loading data into a target register.
+
+    Args:
+        data: Sequence of integers to load in the target register. If more than one sequence
+            is provided, each sequence must be of the same length.
+        target_bitsizes: Sequence of integers describing the size of target register for each
+            data sequence to load. Defaults to `max(data[i]).bit_length()` for each i.
+        block_size(B): Load batches of `B` data elements in each iteration of traditional QROM
+            (N/B iterations required). Complexity of QROAM scales as
+            `O(B * b + N / B)`, where `B` is the block_size. Defaults to optimal value of
+                `O(sqrt(N / b))`.
+
+    Registers:
+        control: Optional control registers
+        selection: The selection registers which are iterated over when loading the data.
+        target: The target registers for each data set.
+
+    Raises:
+        ValueError: If all target data sequences to load do not have the same length.
+    """
+
+    data_size: int
+    target_bitsize: int
+    is_adjoint: bool = False
+    qroam_block_size: Optional[int] = None
+
+    def pretty_name(self) -> str:
+        dag = '†' if self.is_adjoint else ''
+        return f"QROAM{dag}"
+
+    @cached_property
+    def signature(self) -> Signature:
+        return Signature.build(sel=(self.data_size - 1).bit_length(), trg=self.target_bitsize)
+
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+        cost = get_qroam_cost(
+            self.data_size,
+            self.target_bitsize,
+            adjoint=self.is_adjoint,
+            qroam_block_size=self.qroam_block_size,
+        )
+        return {(Toffoli(), cost)}
+
+    def adjoint(self) -> 'Bloq':
+        return attrs.evolve(self, is_adjoint=not self.is_adjoint)

--- a/qualtran/bloqs/data_loading/qroam.py
+++ b/qualtran/bloqs/data_loading/qroam.py
@@ -11,77 +11,90 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""Common Chemistry bloqs which have costs that differ from those currently implemented in qualtran.
-
-These are for temporary convenience to lock-in the quoted literature costs.
-"""
+"""Advanced Quantum Read Only Memory."""
 from functools import cached_property
-from typing import Optional, Set, Tuple, TYPE_CHECKING
+from typing import Dict, List, Optional, Sequence, Set, Tuple, TYPE_CHECKING
 
 import attrs
 import cirq
 import numpy as np
-from attrs import field, frozen
+from attrs import frozen
+from numpy.typing import ArrayLike, NDArray
 
-from qualtran import Bloq, BloqBuilder, QAny, QBit, Register, Signature, Soquet, SoquetT
+from qualtran import (
+    Bloq,
+    bloq_example,
+    BloqDocSpec,
+    BoundedQUInt,
+    QAny,
+    Register,
+    Signature,
+    Soquet,
+)
 from qualtran.bloqs.basic_gates import Toffoli
-from qualtran.bloqs.mcmt.multi_control_multi_target_pauli import MultiControlPauli
-from qualtran.drawing import Circle, TextBox, WireSymbol
+from qualtran.bloqs.data_loading.qrom import _to_tuple
+from qualtran.drawing import TextBox, WireSymbol
+from qualtran.simulation.classical_sim import ClassicalValT
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 
 
-def get_qroam_cost(
-    data_size: int, bitsize: int, adjoint: bool = False, qroam_block_size: Optional[int] = None
+def find_optimal_log_block_size(
+    iteration_length: int, target_bitsize: int, adjoint: bool = False
 ) -> int:
-    """This gives the optimal k and minimum cost for a QROM over L values of size M.
+    """Find optimal block size, which is a power of 2, for QROAM and the corresponding Toffoli cost.
 
-    Adapted from openfermion and accounts for quoted inverse cost.
+    This functions returns the optimal `k` s.t.
+        * k is in an integer and k >= 0.
+        * iteration_length/2^k + target_bitsize*(2^k - 1) is minimized.
+    The corresponding block size for SelectSwapQROM would be 2^k.
 
     Args:
-        data_size: Amount of data we want to load.
-        bitsize: the amount of bits of output we need.
-        adjoint: whether to get costs from inverse qrom (true) or not (false).
-        qroam_block_size: The block size for QROAM. Default find the optimal
-            value given the data size.
+        iteration_length: The amount of data to load for each data set (the array length).
+        target_bitsize: The total bitsize of the target register(s).
+        adjoint: Whether we are doing inverse qrom or not.
 
     Returns:
-       val_opt: minimal (optimal) cost of QROM
+        k_opt: The optimal log block size.
+        val_opt: The optimal toffoli cost with the block size.
     """
-    if qroam_block_size == 1:
-        return data_size - 1
     if adjoint:
-        if qroam_block_size is None:
-            log_blk = 0.5 * np.log2(data_size)
-            qroam_block_size = 2**log_blk
-        value = lambda x: data_size / x + x
+        k = 0.5 * np.log2(iteration_length)
+
+        def value(kk: List[int]):
+            return iteration_length / np.power(2, kk) + target_bitsize
+
     else:
-        if qroam_block_size is None:
-            log_blk = 0.5 * np.log2(data_size / bitsize)
-            assert log_blk >= 0
-            qroam_block_size = 2**log_blk
-        value = lambda x: data_size / x + bitsize * (x - 1)
-    k = np.log2(qroam_block_size)
-    k_int = np.array([np.floor(k), np.ceil(k)])
-    k_opt = k_int[np.argmin(value(2**k_int))]
-    val_opt = np.ceil(value(2**k_opt))
-    return int(val_opt)
+        k = 0.5 * np.log2(iteration_length / target_bitsize)
+
+        def value(kk: List[int]):
+            return iteration_length / np.power(2, kk) + target_bitsize * (np.power(2, kk) - 1)
+
+    if k < 0:
+        return 1, np.ceil(value(2))
+    k_int = [np.floor(k), np.ceil(k)]  # restrict optimal k to integers
+    k_opt = int(k_int[np.argmin(value(k_int))])  # obtain optimal k
+    val_opt = int(np.ceil(value(2**k_opt)))
+    return k_opt, val_opt
 
 
+@cirq.value_equality()
 @frozen
 class QROAM(Bloq):
-    """Advanced qroam i.e. QRO(A)M for loading data into a target register.
+    r"""Advanced qroam i.e. QRO(A)M for loading data into a target register.
 
     Args:
         data: Sequence of integers to load in the target register. If more than one sequence
-            is provided, each sequence must be of the same length.
+            is provided, each sequence must be of the same length. Each array must be one
+            dimensional.
         target_bitsizes: Sequence of integers describing the size of target register for each
-            data sequence to load. Defaults to `max(data[i]).bit_length()` for each i.
+            data sequence to load.
         block_size(B): Load batches of `B` data elements in each iteration of traditional QROM
             (N/B iterations required). Complexity of QROAM scales as
             `O(B * b + N / B)`, where `B` is the block_size. Defaults to optimal value of
-                `O(sqrt(N / b))`.
+            `\sim sqrt(N / b)`.
+        is_adjoint: Whether this bloq is daggered or not.
 
     Registers:
         control: Optional control registers
@@ -92,27 +105,112 @@ class QROAM(Bloq):
         ValueError: If all target data sequences to load do not have the same length.
     """
 
-    data_size: int
-    target_bitsize: int
+    data: Sequence[NDArray] = attrs.field(converter=_to_tuple)
+    target_bitsizes: Tuple[int, ...] = attrs.field(
+        converter=lambda x: tuple(x.tolist() if isinstance(x, np.ndarray) else x)
+    )
+    block_size: int = 1
     is_adjoint: bool = False
-    qroam_block_size: Optional[int] = None
+
+    def __attrs_post_init__(self):
+        assert self.block_size == 1, "Use QROM for block_size == 1"
+        assert len(set(len(d) for d in self.data)) == 1
+        assert len(self.target_bitsizes) == len(self.data)
+        assert all(t >= int(max(d)).bit_length() for t, d in zip(self.target_bitsizes, self.data))
+        assert 0 < self.block_size <= len(self.data[0])
+
+    @classmethod
+    def build(
+        cls,
+        *data: ArrayLike,
+        target_bitsizes: Optional[int] = None,
+        block_size: Optional[int] = None,
+    ) -> 'QROAM':
+        """Factory method to build a QROAM block from numpy arrays of input data.
+
+        Args:
+            data: Sequence of integers to load in the target register. If more than one sequence
+                is provided, each sequence must be of the same length.
+            target_bitsizes: Sequence of integers describing the size of target register for each
+                data sequence to load. Defaults to `max(data[i]).bit_length()` for each i.
+        """
+        _data = [np.array(d, dtype=int) for d in data]
+        if target_bitsizes is None:
+            target_bitsizes = tuple(max(int(np.max(d)).bit_length(), 1) for d in data)
+        if target_bitsizes is None:
+            target_bitsizes = [int(max(d)).bit_length() for d in data]
+        if block_size is None:
+            # Figure out optimal value of block_size
+            block_size = 2 ** find_optimal_log_block_size(len(_data[0]), sum(target_bitsizes))[0]
+        return QROAM(data=_data, target_bitsizes=target_bitsizes, block_size=block_size)
+
+    def on_classical_vals(self, **vals: 'ClassicalValT') -> Dict[str, 'ClassicalValT']:
+        idx = vals['selection']
+        selections = {'selection': idx}
+        # Retrieve the data; bitwise add them in to the input target values
+        targets = {f'target{d_i}_': d[idx] for d_i, d in enumerate(self.data)}
+        targets = {k: v ^ vals[k] for k, v in targets.items()}
+        return selections | targets
+
+    def adjoint(self) -> 'Bloq':
+        k_opt, _ = find_optimal_log_block_size(
+            len(self.data[0]), sum(self.target_bitsizes), adjoint=not self.is_adjoint
+        )
+        return attrs.evolve(self, is_adjoint=not self.is_adjoint, block_size=2**k_opt)
 
     def pretty_name(self) -> str:
         dag = '†' if self.is_adjoint else ''
         return f"QROAM{dag}"
 
     @cached_property
+    def selection_registers(self) -> Tuple[Register, ...]:
+        data_len = len(self.data[0])
+        sel_bitsize = (data_len - 1).bit_length()
+        return (Register('selection', BoundedQUInt(sel_bitsize, data_len)),)
+
+    @cached_property
+    def target_registers(self) -> Tuple[Register, ...]:
+        # See https://github.com/quantumlib/Qualtran/issues/556 for unusual placement of underscore.
+        return tuple(
+            Register(f'target{sequence_id}_', QAny(self.target_bitsizes[sequence_id]))
+            for sequence_id in range(len(self.data))
+        )
+
+    @cached_property
     def signature(self) -> Signature:
-        return Signature.build(sel=(self.data_size - 1).bit_length(), trg=self.target_bitsize)
+        return Signature([*self.selection_registers, *self.target_registers])
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        cost = get_qroam_cost(
-            self.data_size,
-            self.target_bitsize,
-            adjoint=self.is_adjoint,
-            qroam_block_size=self.qroam_block_size,
-        )
+        cost = find_optimal_log_block_size(
+            len(self.data[0]), sum(self.target_bitsizes), adjoint=self.is_adjoint
+        )[1]
         return {(Toffoli(), cost)}
 
-    def adjoint(self) -> 'Bloq':
-        return attrs.evolve(self, is_adjoint=not self.is_adjoint)
+    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
+        name = soq.reg.name
+        if name == 'selection':
+            return TextBox('In')
+        elif 'target' in name:
+            trg_indx = int(name.replace('target', '').replace('_', ''))
+            # match the sel index
+            subscript = chr(ord('a') + trg_indx)
+            return TextBox(f'data_{subscript}')
+        raise ValueError(f'Unknown register name {name}')
+
+    def _value_equality_values_(self):
+        data_tuple = tuple(tuple(d.flatten()) for d in self.data)
+        return (self.selection_registers, self.target_registers, data_tuple)
+
+
+@bloq_example
+def _qroam_small() -> QROAM:
+    data = np.arange(5)
+    qrom_small = QROAM.build(data)
+    return qrom_small
+
+
+_QROAM_DOC = BloqDocSpec(
+    bloq_cls=QROAM,
+    import_line='from qualtran.bloqs.data_loading.qroam import QROAM',
+    examples=[_qroam_small],
+)

--- a/qualtran/bloqs/data_loading/qroam.py
+++ b/qualtran/bloqs/data_loading/qroam.py
@@ -103,6 +103,10 @@ class QROAM(Bloq):
 
     Raises:
         ValueError: If all target data sequences to load do not have the same length.
+
+    References:
+        [Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization](https://quantum-journal.org/papers/q-2019-12-02-208).
+        Last paragraph of page 8 / top of page 9 and appendices A - C.
     """
 
     data: Sequence[NDArray] = attrs.field(converter=_to_tuple)
@@ -113,7 +117,8 @@ class QROAM(Bloq):
     is_adjoint: bool = False
 
     def __attrs_post_init__(self):
-        assert self.block_size == 1, "Use QROM for block_size == 1"
+        print(self)
+        assert self.block_size != 1, "Use QROM for block_size == 1"
         assert len(set(len(d) for d in self.data)) == 1
         assert len(self.target_bitsizes) == len(self.data)
         assert all(t >= int(max(d)).bit_length() for t, d in zip(self.target_bitsizes, self.data))
@@ -204,7 +209,7 @@ class QROAM(Bloq):
 
 @bloq_example
 def _qroam_small() -> QROAM:
-    data = np.arange(5)
+    data = np.arange(10)
     qrom_small = QROAM.build(data)
     return qrom_small
 

--- a/qualtran/bloqs/data_loading/qroam_test.py
+++ b/qualtran/bloqs/data_loading/qroam_test.py
@@ -1,0 +1,97 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import numpy as np
+
+from qualtran._infra.gate_with_registers import split_qubits, total_bits
+from qualtran.bloqs.basic_gates import CNOT, TGate
+from qualtran.bloqs.data_loading.qroam import _qroam_small, QROAM
+from qualtran.cirq_interop.bit_tools import iter_bits
+from qualtran.cirq_interop.t_complexity_protocol import t_complexity
+from qualtran.cirq_interop.testing import assert_circuit_inp_out_cirqsim, GateHelper
+from qualtran.resource_counting.generalizers import cirq_to_bloqs
+from qualtran.testing import (
+    assert_valid_bloq_decomposition,
+    assert_wire_symbols_match_expected,
+    execute_notebook,
+)
+
+
+def test_qroam_small(bloq_autotester):
+    bloq_autotester(_qroam_small)
+
+
+# def test_qroam_classical():
+#     rs = np.random.RandomState()
+#     data = rs.randint(0, 2**3, size=10)
+#     sel_size = int(np.ceil(np.log2(10)))
+#     qrom = QROM([data], (sel_size,), target_bitsizes=(3,))
+#     cbloq = qrom.decompose_bloq()
+#     for i in range(len(data)):
+#         i_out, data_out = qrom.call_classically(selection=i, target0_=0)
+#         assert i_out == i
+#         assert data_out == data[i]
+
+#         decomp_ret = cbloq.call_classically(selection=i, target0_=0)
+#         assert decomp_ret == (i_out, data_out)
+
+
+# def test_qroam_classical_nonzero_target():
+#     rs = np.random.RandomState()
+#     data = rs.randint(0, 2**3, size=10)
+#     sel_size = int(np.ceil(np.log2(10)))
+#     qrom = QROM([data], (sel_size,), target_bitsizes=(3,))
+#     cbloq = qrom.decompose_bloq()
+#     for i in range(len(data)):
+#         target_in = int('111', 2)
+#         i_out, data_out = qrom.call_classically(selection=i, target0_=target_in)
+#         assert i_out == i
+#         assert data_out == data[i] ^ target_in
+
+#         decomp_ret = cbloq.call_classically(selection=i, target0_=target_in)
+#         assert decomp_ret == (i_out, data_out)
+
+
+# def test_qroam_1d_multitarget_classical():
+#     rs = np.random.RandomState()
+#     n = 10
+#     data_sets = [rs.randint(0, 2**3, size=n) for _ in range(3)]
+#     sel_size = int(np.ceil(np.log2(10)))
+#     qrom = QROM(data_sets, (sel_size,), target_bitsizes=(3, 3, 3))
+#     cbloq = qrom.decompose_bloq()
+#     for i in range(n):
+#         init = {f'target{i}_': 0 for i in range(3)}
+#         i_out, *data_out = qrom.call_classically(selection=i, **init)
+#         assert i_out == i
+#         assert data_out == [data[i] for data in data_sets]
+
+#         decomp_i_out, *decomp_data_out = cbloq.call_classically(selection=i, **init)
+#         assert decomp_i_out == i_out
+#         assert len(data_out) == len(decomp_data_out)
+#         for do, decomp_do in zip(data_out, decomp_data_out):
+#             np.testing.assert_array_equal(do, decomp_do)
+
+
+# def test_qroam_wire_symbols():
+#     qrom = QROM.build([3, 3, 3, 3])
+#     assert_wire_symbols_match_expected(qrom, ['In', 'data_a'])
+
+#     qrom = QROM.build([3, 3, 3, 3], [2, 2, 2, 2])
+#     assert_wire_symbols_match_expected(qrom, ['In', 'data_a', 'data_b'])
+
+#     qrom = QROM.build([[3, 3], [3, 3]], [[2, 2], [2, 2]], [[1, 1], [2, 2]])
+#     assert_wire_symbols_match_expected(qrom, ['In_i', 'In_j', 'data_a', 'data_b', 'data_c'])
+
+#     qrom = QROM.build(np.arange(27).reshape(3, 3, 3))
+#     assert_wire_symbols_match_expected(qrom, ['In_i', 'In_j', 'In_k', 'data_a'])

--- a/qualtran/bloqs/data_loading/qroam_test.py
+++ b/qualtran/bloqs/data_loading/qroam_test.py
@@ -32,66 +32,34 @@ def test_qroam_small(bloq_autotester):
     bloq_autotester(_qroam_small)
 
 
-# def test_qroam_classical():
-#     rs = np.random.RandomState()
-#     data = rs.randint(0, 2**3, size=10)
-#     sel_size = int(np.ceil(np.log2(10)))
-#     qrom = QROM([data], (sel_size,), target_bitsizes=(3,))
-#     cbloq = qrom.decompose_bloq()
-#     for i in range(len(data)):
-#         i_out, data_out = qrom.call_classically(selection=i, target0_=0)
-#         assert i_out == i
-#         assert data_out == data[i]
+def test_qroam_classical():
+    rs = np.random.RandomState()
+    data = rs.randint(0, 2**3, size=10)
+    qrom = QROAM([data], target_bitsizes=(3,), block_size=2)
+    for i in range(len(data)):
+        i_out, data_out = qrom.call_classically(selection=i, target0_=0)
+        assert i_out == i
+        assert data_out == data[i]
 
-#         decomp_ret = cbloq.call_classically(selection=i, target0_=0)
-#         assert decomp_ret == (i_out, data_out)
+        decomp_ret = qrom.call_classically(selection=i, target0_=0)
+        assert decomp_ret == (i_out, data_out)
 
 
-# def test_qroam_classical_nonzero_target():
-#     rs = np.random.RandomState()
-#     data = rs.randint(0, 2**3, size=10)
-#     sel_size = int(np.ceil(np.log2(10)))
-#     qrom = QROM([data], (sel_size,), target_bitsizes=(3,))
-#     cbloq = qrom.decompose_bloq()
-#     for i in range(len(data)):
-#         target_in = int('111', 2)
-#         i_out, data_out = qrom.call_classically(selection=i, target0_=target_in)
-#         assert i_out == i
-#         assert data_out == data[i] ^ target_in
-
-#         decomp_ret = cbloq.call_classically(selection=i, target0_=target_in)
-#         assert decomp_ret == (i_out, data_out)
+def test_qroam_1d_multitarget_classical():
+    rs = np.random.RandomState()
+    n = 10
+    data_sets = [rs.randint(0, 2**3, size=n) for _ in range(3)]
+    qroam = QROAM.build(*data_sets, target_bitsizes=(3, 3, 3), block_size=2)
+    for i in range(n):
+        init = {f'target{i}_': 0 for i in range(3)}
+        i_out, *data_out = qroam.call_classically(selection=i, **init)
+        assert i_out == i
+        assert data_out == [data[i] for data in data_sets]
 
 
-# def test_qroam_1d_multitarget_classical():
-#     rs = np.random.RandomState()
-#     n = 10
-#     data_sets = [rs.randint(0, 2**3, size=n) for _ in range(3)]
-#     sel_size = int(np.ceil(np.log2(10)))
-#     qrom = QROM(data_sets, (sel_size,), target_bitsizes=(3, 3, 3))
-#     cbloq = qrom.decompose_bloq()
-#     for i in range(n):
-#         init = {f'target{i}_': 0 for i in range(3)}
-#         i_out, *data_out = qrom.call_classically(selection=i, **init)
-#         assert i_out == i
-#         assert data_out == [data[i] for data in data_sets]
-
-#         decomp_i_out, *decomp_data_out = cbloq.call_classically(selection=i, **init)
-#         assert decomp_i_out == i_out
-#         assert len(data_out) == len(decomp_data_out)
-#         for do, decomp_do in zip(data_out, decomp_data_out):
-#             np.testing.assert_array_equal(do, decomp_do)
-
-
-# def test_qroam_wire_symbols():
-#     qrom = QROM.build([3, 3, 3, 3])
-#     assert_wire_symbols_match_expected(qrom, ['In', 'data_a'])
-
-#     qrom = QROM.build([3, 3, 3, 3], [2, 2, 2, 2])
-#     assert_wire_symbols_match_expected(qrom, ['In', 'data_a', 'data_b'])
-
-#     qrom = QROM.build([[3, 3], [3, 3]], [[2, 2], [2, 2]], [[1, 1], [2, 2]])
-#     assert_wire_symbols_match_expected(qrom, ['In_i', 'In_j', 'data_a', 'data_b', 'data_c'])
-
-#     qrom = QROM.build(np.arange(27).reshape(3, 3, 3))
-#     assert_wire_symbols_match_expected(qrom, ['In_i', 'In_j', 'In_k', 'data_a'])
+def test_qroam_wire_symbols():
+    n = 10
+    rs = np.random.RandomState()
+    data_sets = [rs.randint(0, 2**3, size=n) for _ in range(3)]
+    qroam = QROAM.build(*data_sets, target_bitsizes=(3, 3, 3), block_size=2)
+    assert_wire_symbols_match_expected(qroam, ['In', 'data_a', 'data_b', 'data_c'])

--- a/qualtran/serialization/resolver_dict.py
+++ b/qualtran/serialization/resolver_dict.py
@@ -65,6 +65,7 @@ import qualtran.bloqs.chemistry.trotter.hubbard.hopping
 import qualtran.bloqs.chemistry.trotter.hubbard.interaction
 import qualtran.bloqs.chemistry.trotter.ising.unitaries
 import qualtran.bloqs.chemistry.trotter.trotterized_unitary
+import qualtran.bloqs.data_loading.qroam
 import qualtran.bloqs.data_loading.qrom
 import qualtran.bloqs.data_loading.select_swap_qrom
 import qualtran.bloqs.factoring.mod_add
@@ -244,6 +245,7 @@ RESOLVER_DICT = {
     "qualtran.bloqs.chemistry.trotter.hubbard.hopping.HoppingTile": qualtran.bloqs.chemistry.trotter.hubbard.hopping.HoppingTile,
     "qualtran.bloqs.chemistry.trotter.trotterized_unitary": qualtran.bloqs.chemistry.trotter.trotterized_unitary,
     "qualtran.bloqs.data_loading.qrom.QROM": qualtran.bloqs.data_loading.qrom.QROM,
+    "qualtran.bloqs.data_loading.qroam.QROAM": qualtran.bloqs.data_loading.qroam.QROAM,
     "qualtran.bloqs.data_loading.select_swap_qrom.SelectSwapQROM": qualtran.bloqs.data_loading.select_swap_qrom.SelectSwapQROM,
     "qualtran.bloqs.factoring.mod_add.CtrlAddK": qualtran.bloqs.factoring.mod_add.CtrlAddK,
     "qualtran.bloqs.factoring.mod_add.CtrlModAddK": qualtran.bloqs.factoring.mod_add.CtrlModAddK,

--- a/qualtran/testing.py
+++ b/qualtran/testing.py
@@ -238,7 +238,6 @@ def assert_wire_symbols_match_expected(bloq: Bloq, expected_ws: List[Union[str, 
         expected_ws: A list of the expected wire symbols or their associated text.
     """
     expected_idx = 0
-    ws = []
     for reg in bloq.signature:
         if reg.shape:
             indices = np.ndindex(reg.shape)


### PR DESCRIPTION
In the interim before we have a bone fide qroam bloq with decomposition (xref #368), it's important to capture the costs in a better way that what is in https://github.com/quantumlib/Qualtran/blob/main/qualtran/bloqs/chemistry/black_boxes.py#L73, i.e. the bloq has a proper signature and can be used with existing chemistry bloqs in their decompositions. This would "fix" our current costs which rely on SelectSwapQROM and results a ~ 2x discrepancy from the literature values.

TODO:

- [ ] delete / replace the QROAM bloq in black_boxes. The downside to this is I would need to fake some input date for some bloqs which don't accept hamiltonian coefficients yet.

