### PR TITLE
Enable mypy CI check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,3 +99,20 @@ jobs:
           pip install --no-deps -e .
       - run: |
           check/pylint
+  
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r dev_tools/requirements/envs/pylint.env.txt
+          pip install --no-deps -e .
+      - run: |
+          check/mypy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r dev_tools/requirements/envs/pylint.env.txt
+          pip install -r dev_tools/requirements/envs/dev.env.txt
           pip install --no-deps -e .
       - run: |
           check/mypy

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -3,6 +3,11 @@ show_error_codes = true
 plugins = duet.typing, numpy.typing.mypy_plugin
 allow_redefinition = true
 check_untyped_defs = true
+
+# Temporary: mypy warning in CI but not in local
+# These warnings are all generators with yields instead of returns
+warn_no_return = false
+
 # Disabling function override checking
 # Qualtran has many places where kwargs are used
 # with the intention to override in subclasses in ways mypy does not like

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -4,10 +4,6 @@ plugins = duet.typing, numpy.typing.mypy_plugin
 allow_redefinition = true
 check_untyped_defs = true
 
-# Temporary: mypy warning in CI but not in local
-# These warnings are all generators with yields instead of returns
-warn_no_return = false
-
 # Disabling function override checking
 # Qualtran has many places where kwargs are used
 # with the intention to override in subclasses in ways mypy does not like

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
         BloqBuilder,
         CompositeBloq,
         CtrlSpec,
+        GateWithRegister,
         Register,
         Signature,
         Soquet,
@@ -167,7 +168,7 @@ class Bloq(metaclass=abc.ABCMeta):
         bb, initial_soqs = BloqBuilder.from_signature(self.signature, add_registers_allowed=False)
         return bb.finalize(**bb.add_d(self, **initial_soqs))
 
-    def adjoint(self) -> 'Adjoint':
+    def adjoint(self) -> 'GateWithRegister':
         """The adjoint of this bloq.
 
         Bloq authors can override this method in certain circumstances. Otherwise, the default

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -168,7 +168,7 @@ class Bloq(metaclass=abc.ABCMeta):
         bb, initial_soqs = BloqBuilder.from_signature(self.signature, add_registers_allowed=False)
         return bb.finalize(**bb.add_d(self, **initial_soqs))
 
-    def adjoint(self) -> 'GateWithRegisters':
+    def adjoint(self) -> 'Bloq':
         """The adjoint of this bloq.
 
         Bloq authors can override this method in certain circumstances. Otherwise, the default

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
     from qualtran import (
         AddControlledT,
+        Adjoint,
         BloqBuilder,
         CompositeBloq,
         CtrlSpec,
@@ -166,7 +167,7 @@ class Bloq(metaclass=abc.ABCMeta):
         bb, initial_soqs = BloqBuilder.from_signature(self.signature, add_registers_allowed=False)
         return bb.finalize(**bb.add_d(self, **initial_soqs))
 
-    def adjoint(self) -> 'Bloq':
+    def adjoint(self) -> 'Adjoint':
         """The adjoint of this bloq.
 
         Bloq authors can override this method in certain circumstances. Otherwise, the default

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
         BloqBuilder,
         CompositeBloq,
         CtrlSpec,
-        GateWithRegister,
+        GateWithRegisters,
         Register,
         Signature,
         Soquet,
@@ -168,7 +168,7 @@ class Bloq(metaclass=abc.ABCMeta):
         bb, initial_soqs = BloqBuilder.from_signature(self.signature, add_registers_allowed=False)
         return bb.finalize(**bb.add_d(self, **initial_soqs))
 
-    def adjoint(self) -> 'GateWithRegister':
+    def adjoint(self) -> 'GateWithRegisters':
         """The adjoint of this bloq.
 
         Bloq authors can override this method in certain circumstances. Otherwise, the default

--- a/qualtran/_infra/controlled.py
+++ b/qualtran/_infra/controlled.py
@@ -445,7 +445,7 @@ class Controlled(GateWithRegisters):
         return self.ctrl_spec.wire_symbol(i, reg, idx)
 
     def adjoint(self) -> 'Bloq':
-        return self.subbloq.adjoint().controlled(self.ctrl_spec)
+        return self.subbloq.adjoint().controlled(ctrl_spec=self.ctrl_spec)
 
     def pretty_name(self) -> str:
         return f'C[{self.subbloq.pretty_name()}]'

--- a/qualtran/_infra/controlled_test.py
+++ b/qualtran/_infra/controlled_test.py
@@ -415,7 +415,7 @@ ctrl: ───@────────
 q: ──────X^0.25───''',
     )
 
-    ctrl_0_gate = XPowGate(0.25).controlled(CtrlSpec(cvs=0))
+    ctrl_0_gate = XPowGate(0.25).controlled(ctrl_spec=CtrlSpec(cvs=0))
     cirq.testing.assert_has_diagram(
         cirq.Circuit(ctrl_0_gate.on_registers(**get_named_qubits(ctrl_0_gate.signature))),
         '''
@@ -424,7 +424,7 @@ ctrl: ───(0)──────
 q: ──────X^0.25───''',
     )
 
-    multi_ctrl_gate = XPowGate(0.25).controlled(CtrlSpec(cvs=[0, 1]))
+    multi_ctrl_gate = XPowGate(0.25).controlled(ctrl_spec=CtrlSpec(cvs=[0, 1]))
     cirq.testing.assert_has_diagram(
         cirq.Circuit(multi_ctrl_gate.on_registers(**get_named_qubits(multi_ctrl_gate.signature))),
         '''
@@ -435,7 +435,7 @@ ctrl[1]: ───@────────
 q: ─────────X^0.25───''',
     )
 
-    ctrl_bloq = Swap(2).controlled(CtrlSpec(cvs=[0, 1]))
+    ctrl_bloq = Swap(2).controlled(ctrl_spec=CtrlSpec(cvs=[0, 1]))
     cirq.testing.assert_has_diagram(
         cirq.Circuit(ctrl_bloq.on_registers(**get_named_qubits(ctrl_bloq.signature))),
         '''

--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -357,7 +357,7 @@ class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
     ) -> cirq.Operation:
         return self.on(*merge_qubits(self.signature, **qubit_regs))
 
-    def __pow__(self, power: int) -> 'Bloq':
+    def __pow__(self, power: int) -> 'GateWithRegisters':
         bloq = self if power > 0 else self.adjoint()
         if abs(power) == 1:
             return bloq

--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -15,6 +15,7 @@
 import abc
 from typing import (
     Any,
+    cast,
     Collection,
     Dict,
     Iterable,
@@ -358,7 +359,7 @@ class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
         return self.on(*merge_qubits(self.signature, **qubit_regs))
 
     def __pow__(self, power: int) -> 'GateWithRegisters':
-        bloq = self if power > 0 else self.adjoint()
+        bloq = self if power > 0 else cast(GateWithRegisters, self.adjoint())
         if abs(power) == 1:
             return bloq
         if all(reg.side == Side.THRU for reg in self.signature):

--- a/qualtran/_infra/gate_with_registers_test.py
+++ b/qualtran/_infra/gate_with_registers_test.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Dict, TYPE_CHECKING
+from typing import Dict, Iterator, TYPE_CHECKING
 
 import cirq
 import numpy as np
@@ -46,7 +46,7 @@ class _TestGate(GateWithRegisters):
         regs = Signature([r1, r2, r3])
         return regs
 
-    def decompose_from_registers(self, *, context, **quregs) -> cirq.OP_TREE:
+    def decompose_from_registers(self, *, context, **quregs) -> Iterator[cirq.OP_TREE]:
         yield cirq.H.on_each(quregs['r1'])
         yield cirq.X.on_each(quregs['r2'])
         yield cirq.X.on_each(quregs['r3'])

--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -14,7 +14,19 @@
 import itertools
 import math
 from functools import cached_property
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    TYPE_CHECKING,
+    Union,
+)
 
 import cirq
 import numpy as np
@@ -197,7 +209,7 @@ class Add(Bloq):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         # reverse the order of qubits for big endian-ness.
         input_bits = quregs['a'][::-1]
         output_bits = quregs['b'][::-1]

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -90,7 +90,7 @@ class LessThanConstant(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         """Decomposes the gate into 4N And and And† operations for a T complexity of 4N.
 
         The decomposition proceeds from the most significant qubit -bit 0- to the least significant
@@ -358,7 +358,7 @@ _SQ_CMP_DOC = BloqDocSpec(bloq_cls=SingleQubitCompare, examples=[_sq_cmp])
 
 def _equality_with_zero(
     context: cirq.DecompositionContext, qubits: Sequence[cirq.Qid], z: cirq.Qid
-) -> cirq.OP_TREE:
+) -> Iterator[cirq.OP_TREE]:
     """Helper decomposition used in `LessThanEqual`"""
     if len(qubits) == 1:
         (q,) = qubits
@@ -451,7 +451,7 @@ class LessThanEqual(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[mis
 
     def _decompose_via_tree(
         self, context: cirq.DecompositionContext, X: Sequence[cirq.Qid], Y: Sequence[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         if len(X) == 1:
             return
         if len(X) == 2:

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -217,7 +217,7 @@ class BiQubitsMixer(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         x, y, ancilla = quregs['x'], quregs['y'], quregs['ancilla']
         x_msb, x_lsb = x
         y_msb, y_lsb = y
@@ -310,7 +310,7 @@ class SingleQubitCompare(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         a = quregs['a']
         b = quregs['b']
         less_than = quregs['less_than']
@@ -467,7 +467,7 @@ class LessThanEqual(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[mis
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         lhs, rhs, (target,) = list(quregs['x']), list(quregs['y']), quregs['target']
 
         n = min(len(lhs), len(rhs))

--- a/qualtran/bloqs/arithmetic/hamming_weight.py
+++ b/qualtran/bloqs/arithmetic/hamming_weight.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import List, Set, TYPE_CHECKING
+from typing import Iterator, List, Set, TYPE_CHECKING
 
 import cirq
 from attrs import frozen
@@ -76,7 +76,7 @@ class HammingWeightCompute(GateWithRegisters):
 
     def _decompose_using_three_to_two_adders(
         self, x: List[cirq.Qid], junk: List[cirq.Qid], out: List[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         for out_idx in range(len(out)):
             y = []
             for in_idx in range(0, len(x) - 2, 2):
@@ -94,7 +94,7 @@ class HammingWeightCompute(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         # Qubit order needs to be reversed because the registers store Big Endian representation
         # of integers.
         x: List[cirq.Qid] = [*quregs['x'][::-1]]

--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Any, Dict, Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import Any, Dict, Iterator, Sequence, Set, Tuple, TYPE_CHECKING, Union
 
 import cirq
 import numpy as np
@@ -137,7 +137,7 @@ class TwoBitCSwap(Bloq):
         ctrl: NDArray[cirq.Qid],  # type: ignore[type-var]
         x: NDArray[cirq.Qid],  # type: ignore[type-var]
         y: NDArray[cirq.Qid],  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         (ctrl,) = ctrl
         (x,) = x
         (y,) = y

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -287,7 +287,7 @@ class _IntVector(Bloq):
         val: The register of size `bitsize` which initializes the value `val`.
     """
 
-    val: int = attrs.field()
+    val: Union[int, sympy.Expr] = attrs.field()
     bitsize: Union[int, sympy.Expr]
     state: bool
 
@@ -362,7 +362,7 @@ class _IntVector(Bloq):
 
         tn.add(qtn.Tensor(data=data, inds=inds, tags=[self.short_name(), tag]))
 
-    def on_classical_vals(self, *, val: Optional[int] = None) -> Dict[str, int]:
+    def on_classical_vals(self, *, val: Optional[int] = None) -> Dict[str, Union[int, sympy.Expr]]:
         if self.state:
             assert val is None
             return {'val': self.val}
@@ -401,7 +401,7 @@ class IntState(_IntVector):
         val: The register of size `bitsize` which initializes the value `val`.
     """
 
-    def __init__(self, val: int, bitsize: Union[int, sympy.Expr]):
+    def __init__(self, val: Union[int, sympy.Expr], bitsize: Union[int, sympy.Expr]):
         self.__attrs_init__(val=val, bitsize=bitsize, state=True)
 
 

--- a/qualtran/bloqs/factoring/ecc/_ecc_shims.py
+++ b/qualtran/bloqs/factoring/ecc/_ecc_shims.py
@@ -13,10 +13,11 @@
 #  limitations under the License.
 
 from functools import cached_property
+from typing import Tuple
 
 from attrs import frozen
 
-from qualtran import Bloq, DecomposeTypeError, QBit, Register, Side, Signature, Soquet
+from qualtran import Bloq, CompositeBloq, DecomposeTypeError, QBit, Register, Side, Signature
 from qualtran.drawing import RarrowTextBox, WireSymbol
 
 
@@ -31,9 +32,10 @@ class MeasureQFT(Bloq):
     def decompose_bloq(self) -> 'CompositeBloq':
         raise DecomposeTypeError('MeasureQFT is a placeholder, atomic bloq.')
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'x':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'x':
             return RarrowTextBox('MeasQFT')
+        raise ValueError(f'Unrecognized register name {reg.name}')
 
     def __str__(self):
         return 'MeasureQFT'

--- a/qualtran/bloqs/factoring/ecc/ec_add_r.py
+++ b/qualtran/bloqs/factoring/ecc/ec_add_r.py
@@ -13,12 +13,12 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict
+from typing import Dict, Tuple, Union
 
 import sympy
 from attrs import frozen
 
-from qualtran import Bloq, bloq_example, BloqDocSpec, QBit, QUInt, Register, Signature, Soquet
+from qualtran import Bloq, bloq_example, BloqDocSpec, QBit, QUInt, Register, Signature
 from qualtran.drawing import Circle, TextBox, WireSymbol
 from qualtran.simulation.classical_sim import ClassicalValT
 
@@ -67,7 +67,7 @@ class ECAddR(Bloq):
             [Register('ctrl', QBit()), Register('x', QUInt(self.n)), Register('y', QUInt(self.n))]
         )
 
-    def on_classical_vals(self, ctrl, x, y) -> Dict[str, 'ClassicalValT']:
+    def on_classical_vals(self, ctrl, x, y) -> Dict[str, Union['ClassicalValT', sympy.Expr]]:
         if ctrl == 0:
             return {'ctrl': ctrl, 'x': x, 'y': y}
 
@@ -75,13 +75,14 @@ class ECAddR(Bloq):
         result: ECPoint = A + self.R
         return {'ctrl': 1, 'x': result.x, 'y': result.y}
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'ctrl':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'ctrl':
             return Circle()
-        if soq.reg.name == 'x':
+        if reg.name == 'x':
             return TextBox(f'$+{self.R.x}$')
-        if soq.reg.name == 'y':
+        if reg.name == 'y':
             return TextBox(f'$+{self.R.y}$')
+        raise ValueError(f'Unrecognized register name {reg.name}')
 
     def __str__(self):
         return 'ECAddR'
@@ -143,13 +144,14 @@ class ECWindowAddR(Bloq):
             ]
         )
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'ctrl':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'ctrl':
             return Circle()
-        if soq.reg.name == 'x':
+        if reg.name == 'x':
             return TextBox(f'$+{self.R.x}$')
-        if soq.reg.name == 'y':
+        if reg.name == 'y':
             return TextBox(f'$+{self.R.y}$')
+        raise ValueError(f'Unrecognized register name {reg.name}')
 
     def __str__(self):
         return f'ECWindowAddR({self.n=})'

--- a/qualtran/bloqs/factoring/ecc/find_ecc_private_key.py
+++ b/qualtran/bloqs/factoring/ecc/find_ecc_private_key.py
@@ -22,6 +22,7 @@ from qualtran import Bloq, bloq_example, BloqBuilder, BloqDocSpec, QUInt, Signat
 from qualtran.bloqs.basic_gates import IntState
 from qualtran.bloqs.util_bloqs import Free
 from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
 
 from .ec_phase_estimate_r import ECPhaseEstimateR
 from .ec_point import ECPoint
@@ -80,13 +81,13 @@ class FindECCPrivateKey(Bloq):
         return Signature([])
 
     @property
-    def mod(self) -> int:
+    def mod(self) -> SymbolicInt:
         if self.base_point.mod != self.public_key.mod:
             raise ValueError("Inconsistent moduli in the two points.")
         return self.base_point.mod
 
     @property
-    def curve_a(self) -> int:
+    def curve_a(self) -> SymbolicInt:
         if self.base_point.curve_a != self.public_key.curve_a:
             raise ValueError("Inconsistent curve parameters in the two points.")
         return self.base_point.curve_a

--- a/qualtran/bloqs/for_testing/atom.py
+++ b/qualtran/bloqs/for_testing/atom.py
@@ -158,7 +158,7 @@ class TestGWRAtom(GateWithRegisters):
     def _unitary_(self):
         return np.eye(2)
 
-    def adjoint(self) -> 'Bloq':
+    def adjoint(self) -> 'TestGWRAtom':
         return attrs.evolve(self, is_adjoint=not self.is_adjoint)
 
     def _t_complexity_(self) -> 'TComplexity':

--- a/qualtran/bloqs/for_testing/qubitization_walk_test.py
+++ b/qualtran/bloqs/for_testing/qubitization_walk_test.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Optional, Tuple
+from typing import Iterator, Optional, Tuple
 
 import attrs
 import cirq
@@ -49,7 +49,7 @@ class PrepareUniformSuperpositionTest(PrepareOracle):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         yield PrepareUniformSuperposition(self.n, self.cvs).on_registers(target=quregs['selection'])
 
 

--- a/qualtran/bloqs/for_testing/random_select_and_prepare.py
+++ b/qualtran/bloqs/for_testing/random_select_and_prepare.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Optional, Sequence, Tuple
+from typing import Iterator, Optional, Sequence, Tuple
 
 import attrs
 import cirq
@@ -166,7 +166,7 @@ class TestPauliSelectOracle(SelectOracle):
         selection: NDArray[cirq.Qid],  # type: ignore[type-var]
         target: NDArray[cirq.Qid],  # type: ignore[type-var]
         **quregs: NDArray[cirq.Qid],  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         if self.control_val is not None:
             selection = np.concatenate([selection, quregs['control']])
 

--- a/qualtran/bloqs/hubbard_model.py
+++ b/qualtran/bloqs/hubbard_model.py
@@ -47,7 +47,7 @@ considered in both the PREPARE and SELECT operations corresponding to the terms 
 See the documentation for `PrepareHubbard` and `SelectHubbard` for details.
 """
 from functools import cached_property
-from typing import Collection, Optional, Sequence, Tuple, TYPE_CHECKING, Union
+from typing import Collection, Iterator, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import cirq
@@ -157,7 +157,7 @@ class SelectHubbard(SelectOracle):
         *,
         context: cirq.DecompositionContext,
         **quregs: NDArray[cirq.Qid],  # type:ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         p_x, p_y, q_x, q_y = quregs['p_x'], quregs['p_y'], quregs['q_x'], quregs['q_y']
         U, V, alpha, beta = quregs['U'], quregs['V'], quregs['alpha'], quregs['beta']
         control, target = quregs.get('control', ()), quregs['target']
@@ -325,7 +325,7 @@ class PrepareHubbard(PrepareOracle):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         p_x, p_y, q_x, q_y = quregs['p_x'], quregs['p_y'], quregs['q_x'], quregs['q_y']
         U, V, alpha, beta = quregs['U'], quregs['V'], quregs['alpha'], quregs['beta']
         temp = quregs['temp']

--- a/qualtran/bloqs/mcmt/and_bloq.py
+++ b/qualtran/bloqs/mcmt/and_bloq.py
@@ -24,7 +24,7 @@ to the and of its control registers. `And` will output the result into a fresh r
 
 import itertools
 from functools import cached_property
-from typing import Any, Dict, Iterable, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Dict, Iterable, Iterator, Optional, Sequence, Set, Tuple, Union
 
 import attrs
 import cirq
@@ -168,7 +168,7 @@ class And(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         """Decomposes a single `And` gate on 2 controls and 1 target in terms of Clifford+T gates.
 
         * And(cv).on(c1, c2, target) uses 4 T-gates and assumes target is in |0> state.
@@ -302,7 +302,7 @@ class MultiAnd(Bloq):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         control, ancilla, target = (
             quregs['ctrl'].flatten(),
             quregs.get('junk', np.array([])).flatten(),

--- a/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
+++ b/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Any, Dict, Set, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Iterator, Set, Tuple, TYPE_CHECKING
 
 import cirq
 import numpy as np
@@ -133,7 +133,7 @@ class MultiControlPauli(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray['cirq.Qid']
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         controls, target = quregs.get('controls', np.array([])), quregs['target']
         if len(self.cvs) < 2:
             controls = controls.flatten()

--- a/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
+++ b/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
@@ -69,7 +69,7 @@ class MultiTargetCNOT(GateWithRegisters):
         control: NDArray[cirq.Qid],  # type: ignore[type-var]
         targets: NDArray[cirq.Qid],  # type: ignore[type-var]
     ):
-        def cnots_for_depth_i(i: int, q: NDArray[cirq.Qid]) -> cirq.OP_TREE:  # type: ignore[type-var]
+        def cnots_for_depth_i(i: int, q: NDArray[cirq.Qid]) -> Iterator[cirq.OP_TREE]:  # type: ignore[type-var]
             for c, t in zip(q[: 2**i], q[2**i : min(len(q), 2 ** (i + 1))]):
                 yield cirq.CNOT(c, t)
 

--- a/qualtran/bloqs/mean_estimation/complex_phase_oracle.py
+++ b/qualtran/bloqs/mean_estimation/complex_phase_oracle.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Tuple
+from typing import Iterator, Tuple
 
 import attrs
 import cirq
@@ -56,7 +56,7 @@ class ComplexPhaseOracle(GateWithRegisters):
         *,
         context: cirq.DecompositionContext,
         **quregs: NDArray[cirq.Qid],  # type:ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         qm = context.qubit_manager
         target_reg = {
             reg.name: qm.qalloc(reg.total_bits()) for reg in self.encoder.target_registers

--- a/qualtran/bloqs/mean_estimation/mean_estimation_operator.py
+++ b/qualtran/bloqs/mean_estimation/mean_estimation_operator.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Collection, Optional, Sequence, Tuple, Union
+from typing import Collection, Iterator, Optional, Sequence, Tuple, Union
 
 import attrs
 import cirq
@@ -120,7 +120,7 @@ class MeanEstimationOperator(GateWithRegisters):
         *,
         context: cirq.DecompositionContext,
         **quregs: NDArray[cirq.Qid],  # type:ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         select_reg = {reg.name: quregs[reg.name] for reg in self.select.signature}
         reflect_reg = {reg.name: quregs[reg.name] for reg in self.reflect.signature}
         yield self.select.on_registers(**select_reg)

--- a/qualtran/bloqs/mean_estimation/mean_estimation_operator_test.py
+++ b/qualtran/bloqs/mean_estimation/mean_estimation_operator_test.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Optional, Sequence, Tuple
+from typing import Iterator, Optional, Sequence, Tuple
 
 import cirq
 import numpy as np
@@ -44,7 +44,7 @@ class BernoulliSynthesizer(PrepareOracle):
 
     def decompose_from_registers(  # type:ignore[override]
         self, context, q: Sequence[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         theta = np.arccos(np.sqrt(1 - self.p))
         yield cirq.ry(2 * theta).on(q[0])
         yield [cirq.CNOT(q[0], q[i]) for i in range(1, len(q))]
@@ -74,7 +74,7 @@ class BernoulliEncoder(SelectOracle):
 
     def decompose_from_registers(  # type:ignore[override]
         self, context, q: Sequence[cirq.Qid], t: Sequence[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         y0_bin = bit_tools.iter_bits(self.y[0], self.target_bitsize)
         y1_bin = bit_tools.iter_bits(self.y[1], self.target_bitsize)
 
@@ -188,7 +188,7 @@ class GroverSynthesizer(PrepareOracle):
 
     def decompose_from_registers(  # type:ignore[override]
         self, *, context, selection: Sequence[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         yield cirq.H.on_each(*selection)
 
     def __pow__(self, power):
@@ -219,7 +219,7 @@ class GroverEncoder(SelectOracle):
 
     def decompose_from_registers(  # type:ignore[override]
         self, context, *, selection: Sequence[cirq.Qid], target: Sequence[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         selection_cv = [
             *bit_tools.iter_bits(self.marked_item, total_bits(self.selection_registers))
         ]

--- a/qualtran/bloqs/mod_arithmetic/_shims.py
+++ b/qualtran/bloqs/mod_arithmetic/_shims.py
@@ -22,16 +22,19 @@ and moved to their final organizational location soon (written: 2024-05-06).
 
 from collections import defaultdict
 from functools import cached_property
-from typing import Set
+from typing import Dict, Set, Tuple, TYPE_CHECKING
 
 from attrs import frozen
 
-from qualtran import Bloq, QBit, QUInt, Register, Signature, Soquet
+from qualtran import Bloq, QBit, QUInt, Register, Signature
 from qualtran.bloqs.arithmetic import Add, AddK
 from qualtran.bloqs.arithmetic._shims import CHalf, Lt, MultiCToffoli, Negate, Sub
 from qualtran.bloqs.basic_gates import CNOT, CSwap, Swap, Toffoli
 from qualtran.drawing import Circle, TextBox, WireSymbol
-from qualtran.resource_counting.symbolic_counting_utils import log2
+from qualtran.resource_counting.symbolic_counting_utils import ceil, log2
+
+if TYPE_CHECKING:
+    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 
 
 @frozen
@@ -67,15 +70,16 @@ class CModSub(Bloq):
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         # Roetteler
-        return {(Toffoli(), 16 * self.n * log2(self.n) - 23.8 * self.n)}
+        return {(Toffoli(), ceil(16 * self.n * log2(self.n) - 23.8 * self.n))}
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'ctrl':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'ctrl':
             return Circle()
-        elif soq.reg.name == 'x':
+        elif reg.name == 'x':
             return TextBox('x')
-        elif soq.reg.name == 'y':
+        elif reg.name == 'y':
             return TextBox('x-y')
+        raise ValueError(f'Unrecognized register name {reg.name}')
 
     def __str__(self):
         return self.__class__.__name__
@@ -123,16 +127,17 @@ class _ModInvInner(Bloq):
         ]
         # Since the listing is time-ordered and the call graph protocol expects
         # unique bloq keys, we group counts by bloqs.
-        summer = defaultdict(lambda: 0)
+        summer: Dict[Bloq, int] = defaultdict(lambda: 0)
         for bloq, n in listing:
             summer[bloq] += n
         return set(summer.items())
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'x':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'x':
             return TextBox('x')
-        elif soq.reg.name == 'out':
+        elif reg.name == 'out':
             return TextBox('$x^{-1}$')
+        raise ValueError(f'Unrecognized register name {reg.name}')
 
     def __str__(self):
         return self.__class__.__name__
@@ -157,11 +162,12 @@ class ModInv(Bloq):
             (Swap(self.n), 1),
         }
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'x':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'x':
             return TextBox('x')
-        elif soq.reg.name == 'out':
+        elif reg.name == 'out':
             return TextBox('$x^{-1}$')
+        raise ValueError(f'Unrecognized register name {reg.name}')
 
     def __str__(self):
         return self.__class__.__name__
@@ -184,13 +190,14 @@ class ModMul(Bloq):
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         # Roetteler montgomery
-        return {(Toffoli(), 16 * self.n**2 * log2(self.n) - 26.3 * self.n**2)}
+        return {(Toffoli(), ceil(16 * self.n**2 * log2(self.n) - 26.3 * self.n**2))}
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name in ['x', 'y']:
-            return TextBox(soq.reg.name)
-        elif soq.reg.name == 'out':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name in ['x', 'y']:
+            return TextBox(reg.name)
+        elif reg.name == 'out':
             return TextBox('x*y')
+        raise ValueError(f'Unrecognized register name {reg.name}')
 
     def __str__(self):
         return self.__class__.__name__
@@ -205,11 +212,12 @@ class ModDbl(Bloq):
     def signature(self) -> 'Signature':
         return Signature([Register('x', QUInt(self.n)), Register('out', QUInt(self.n))])
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'x':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'x':
             return TextBox('x')
-        elif soq.reg.name == 'out':
+        elif reg.name == 'out':
             return TextBox('$2x$')
+        raise ValueError(f'Unrecognized register name {reg.name}')
 
     def __str__(self):
         return self.__class__.__name__
@@ -232,9 +240,10 @@ class ModNeg(Bloq):
             (AddK(self.n, k=self.mod).controlled(), 1),
         }
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'x':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'x':
             return TextBox('$-x$')
+        raise ValueError(f'Unrecognized register name {reg.name}')
 
     def __str__(self):
         return self.__class__.__name__
@@ -251,13 +260,14 @@ class CModNeg(Bloq):
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         # Roetteler
-        return {(Toffoli(), 8 * self.n * log2(self.n) - 14.5 * self.n)}
+        return {(Toffoli(), ceil(8 * self.n * log2(self.n) - 14.5 * self.n))}
 
-    def wire_symbol(self, soq: 'Soquet') -> 'WireSymbol':
-        if soq.reg.name == 'ctrl':
+    def wire_symbol(self, reg: 'Register', idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg.name == 'ctrl':
             return Circle()
-        elif soq.reg.name == 'x':
+        elif reg.name == 'x':
             return TextBox('$-x$')
+        raise ValueError(f'Unrecognized register name {reg.name}')
 
     def __str__(self):
         return self.__class__.__name__

--- a/qualtran/bloqs/multiplexers/select_pauli_lcu.py
+++ b/qualtran/bloqs/multiplexers/select_pauli_lcu.py
@@ -15,7 +15,7 @@
 """Bloqs for applying SELECT unitary for LCU of Pauli Strings."""
 
 from functools import cached_property
-from typing import Collection, Iterable, Optional, Sequence, Tuple, Union
+from typing import Collection, Iterable, Iterator, Optional, Sequence, Tuple, Union
 
 import attrs
 import cirq
@@ -91,7 +91,7 @@ class SelectPauliLCU(SelectOracle, UnaryIterationGate):
 
     def decompose_from_registers(
         self, context, **quregs: NDArray[cirq.Qid]  # type:ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         if self.control_val == 0:
             yield cirq.X(*quregs['control'])
         yield super(SelectPauliLCU, self).decompose_from_registers(context=context, **quregs)

--- a/qualtran/bloqs/multiplexers/selected_majorana_fermion.py
+++ b/qualtran/bloqs/multiplexers/selected_majorana_fermion.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Sequence, Tuple, Union
+from typing import Iterator, Sequence, Tuple, Union
 
 import attrs
 import cirq
@@ -98,7 +98,7 @@ class SelectedMajoranaFermion(UnaryIterationGate):
 
     def decompose_from_registers(
         self, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         quregs['accumulator'] = np.array(context.qubit_manager.qalloc(1))
         control = quregs[self.control_regs[0].name] if total_bits(self.control_registers) else []
         yield cirq.X(*quregs['accumulator']).controlled_by(*control)
@@ -120,7 +120,7 @@ class SelectedMajoranaFermion(UnaryIterationGate):
         target: Sequence[cirq.Qid],
         accumulator: Sequence[cirq.Qid],
         **selection_indices: int,
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         if any(
             isinstance(reg.dtype.iteration_length_or_zero(), sympy.Expr)
             for reg in self.selection_regs

--- a/qualtran/bloqs/multiplexers/unary_iteration_bloq_test.py
+++ b/qualtran/bloqs/multiplexers/unary_iteration_bloq_test.py
@@ -14,7 +14,7 @@
 
 import itertools
 from functools import cached_property
-from typing import List, Sequence, Set, Tuple, TYPE_CHECKING
+from typing import Iterator, List, Sequence, Set, Tuple, TYPE_CHECKING
 
 import cirq
 import pytest
@@ -125,7 +125,7 @@ class ApplyXToIJKthQubit(UnaryIterationGate):
         t1: Sequence[cirq.Qid],
         t2: Sequence[cirq.Qid],
         t3: Sequence[cirq.Qid],
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         yield [cirq.CNOT(control, t1[i]), cirq.CNOT(control, t2[j]), cirq.CNOT(control, t3[k])]
 
     def nth_operation_callgraph(self, **selection_regs_name_to_val) -> Set['BloqCountT']:

--- a/qualtran/bloqs/phase_estimation/lp_resource_state.py
+++ b/qualtran/bloqs/phase_estimation/lp_resource_state.py
@@ -14,7 +14,7 @@
 
 """Resource states proposed by A. Luis and J. Peřina (1996) for optimal phase measurements"""
 from functools import cached_property
-from typing import Set, Tuple, TYPE_CHECKING
+from typing import Iterator, Set, Tuple, TYPE_CHECKING
 
 import attrs
 import cirq
@@ -69,7 +69,7 @@ class LPRSInterimPrep(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         if isinstance(self.bitsize, sympy.Expr):
             raise ValueError(f'Symbolic bitsize {self.bitsize} not supported')
         q, anc = quregs['m'].tolist()[::-1], quregs['anc']
@@ -129,7 +129,7 @@ class LPResourceState(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         """Use the _LPResourceStateHelper and do a single round of amplitude amplification."""
         q = quregs['m'].flatten().tolist()
         anc, flag = context.qubit_manager.qalloc(2)

--- a/qualtran/bloqs/phase_estimation/qubitization_qpe.py
+++ b/qualtran/bloqs/phase_estimation/qubitization_qpe.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Set, Tuple, TYPE_CHECKING
+from typing import Iterator, Set, Tuple, TYPE_CHECKING
 
 import attrs
 import cirq
@@ -132,7 +132,7 @@ class QubitizationQPE(GateWithRegisters):
 
     def decompose_from_registers(
         self, context: cirq.DecompositionContext, **quregs
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         walk_regs = {reg.name: quregs[reg.name] for reg in self.walk.signature}
         reflect_regs = {reg.name: walk_regs[reg.name] for reg in self.walk.reflect.signature}
 

--- a/qualtran/bloqs/phase_estimation/text_book_qpe.py
+++ b/qualtran/bloqs/phase_estimation/text_book_qpe.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Set, Tuple, TYPE_CHECKING
+from typing import Iterator, Set, Tuple, TYPE_CHECKING
 
 import attrs
 import cirq
@@ -221,7 +221,7 @@ class TextbookQPE(GateWithRegisters):
 
     def decompose_from_registers(
         self, context: cirq.DecompositionContext, **quregs
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         target_quregs = {reg.name: quregs[reg.name] for reg in self.target_registers}
         unitary_op = self.unitary.on_registers(**target_quregs)
 

--- a/qualtran/bloqs/qft/approximate_qft.py
+++ b/qualtran/bloqs/qft/approximate_qft.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 from collections import defaultdict
 from functools import cached_property
-from typing import Dict, Set, TYPE_CHECKING
+from typing import Dict, Iterator, Set, TYPE_CHECKING
 
 import attrs
 import cirq
@@ -114,7 +114,7 @@ class ApproximateQFT(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         if self.bitsize == 1:
             yield cirq.H(*quregs['q'])
             return

--- a/qualtran/bloqs/qft/qft_phase_gradient.py
+++ b/qualtran/bloqs/qft/qft_phase_gradient.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
+from typing import Iterator
 
 import attrs
 import cirq
@@ -60,7 +61,7 @@ class QFTPhaseGradient(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         if self.bitsize == 1:
             yield cirq.H(*quregs['q'])
             return

--- a/qualtran/bloqs/qft/qft_text_book.py
+++ b/qualtran/bloqs/qft/qft_text_book.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
+from typing import Iterator
 
 import attrs
 import cirq
@@ -45,7 +46,7 @@ class QFTTextBook(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, q: NDArray[cirq.Qid]  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         yield cirq.H(q[0])
         for i in range(1, len(q)):
             yield PhaseGradientUnitary(i, exponent=0.5, is_controlled=True).on_registers(

--- a/qualtran/bloqs/qsp/generalized_qsp.py
+++ b/qualtran/bloqs/qsp/generalized_qsp.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 from collections import Counter
 from functools import cached_property
-from typing import Iterable, Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import Iterable, Iterator, Sequence, Set, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 from attrs import field, frozen
@@ -395,7 +395,7 @@ class GeneralizedQSP(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: 'cirq.DecompositionContext', signal, **quregs: NDArray['cirq.Qid']  # type: ignore[type-var]
-    ) -> 'cirq.OP_TREE':
+    ) -> Iterator['cirq.OP_TREE']:
         (signal_qubit,) = signal
 
         num_inverse_applications = self.negative_power

--- a/qualtran/bloqs/qubitization_walk_operator.py
+++ b/qualtran/bloqs/qubitization_walk_operator.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Collection, Optional, Sequence, Tuple, Union
+from typing import Collection, Iterator, Optional, Sequence, Tuple, Union
 
 import attrs
 import cirq
@@ -100,7 +100,7 @@ class QubitizationWalkOperator(GateWithRegisters):
         self,
         context: cirq.DecompositionContext,
         **quregs: NDArray[cirq.Qid],  # type:ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         select_reg = {reg.name: quregs[reg.name] for reg in self.select.signature}
         yield self.select.on_registers(**select_reg)
 

--- a/qualtran/bloqs/reflection.py
+++ b/qualtran/bloqs/reflection.py
@@ -65,8 +65,8 @@ class Reflection(Bloq):
         )
 
     def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
-        idx = int(reg.name[3:])
-        filled = bool(self.cvs[idx])
+        cvs_idx = int(reg.name[3:])
+        filled = bool(self.cvs[cvs_idx])
         return Circle(filled)
 
     def build_composite_bloq(self, bb: 'BloqBuilder', **regs) -> Dict[str, 'Soquet']:

--- a/qualtran/bloqs/reflection_using_prepare.py
+++ b/qualtran/bloqs/reflection_using_prepare.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Collection, Optional, Sequence, Tuple, Union
+from typing import Collection, Iterator, Optional, Sequence, Tuple, Union
 
 import attrs
 import cirq
@@ -82,7 +82,7 @@ class ReflectionUsingPrepare(GateWithRegisters):
         self,
         context: cirq.DecompositionContext,
         **quregs: NDArray[cirq.Qid],  # type:ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         qm = context.qubit_manager
         # 0. Allocate new ancillas, if needed.
         phase_target = qm.qalloc(1)[0] if self.control_val is None else quregs.pop('control')[0]

--- a/qualtran/bloqs/rotations/phase_gradient.py
+++ b/qualtran/bloqs/rotations/phase_gradient.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Any, Dict, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import Any, Dict, Iterator, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import cirq
@@ -72,7 +72,7 @@ class PhaseGradientUnitary(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         ctrl = quregs.get('ctrl', ())
         gate = CZPowGate if self.is_controlled else ZPowGate
         for i, q in enumerate(quregs['phase_grad']):
@@ -128,7 +128,7 @@ class PhaseGradientState(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         if isinstance(self.bitsize, sympy.Expr):
             raise ValueError(f'Symbolic Bitsize not supported {self.bitsize}')
         # Assumes `phase_grad` is in big-endian representation.
@@ -409,7 +409,7 @@ class AddScaledValIntoPhaseReg(GateWithRegisters, cirq.ArithmeticGate):  # type:
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         if isinstance(self.gamma, sympy.Expr):
             raise ValueError(f'Symbolic gamma {self.gamma} not allowed')
         x, phase_grad = quregs['x'], quregs['phase_grad']

--- a/qualtran/bloqs/rotations/programmable_rotation_gate_array.py
+++ b/qualtran/bloqs/rotations/programmable_rotation_gate_array.py
@@ -14,7 +14,7 @@
 
 import abc
 from functools import cached_property
-from typing import Sequence, Tuple
+from typing import Iterator, Sequence, Tuple
 
 import cirq
 import numpy as np
@@ -132,7 +132,7 @@ class ProgrammableRotationGateArrayBase(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         selection, kappa_load_target = quregs.pop('selection'), quregs.pop('kappa_load_target')
         rotations_target = quregs.pop('rotations_target')
         interleaved_unitary_target = quregs

--- a/qualtran/bloqs/rotations/programmable_rotation_gate_array_test.py
+++ b/qualtran/bloqs/rotations/programmable_rotation_gate_array_test.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Tuple
+from typing import Iterator, Tuple
 
 import cirq
 import numpy as np
@@ -94,7 +94,7 @@ def test_programmable_rotation_gate_array(angles, kappa, constructor):
     # Build circuit.
     simulator = cirq.Simulator(dtype=np.complex128)
 
-    def rotation_ops(theta: int) -> cirq.OP_TREE:
+    def rotation_ops(theta: int) -> Iterator[cirq.OP_TREE]:
         # OP-TREE to apply rotation, by integer-approximated angle `theta`, on the target register.
         for i, b in enumerate(bin(theta)[2:][::-1]):
             if b == '1':

--- a/qualtran/bloqs/rotations/quantum_variable_rotation_test.py
+++ b/qualtran/bloqs/rotations/quantum_variable_rotation_test.py
@@ -11,12 +11,14 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from typing import Iterator
+
 import attrs
 import cirq
 import numpy as np
 import pytest
 from fxpmath import Fxp
-from numpy._typing import NDArray
+from numpy.typing import NDArray
 
 from qualtran import GateWithRegisters, QFxp, Register, Signature
 from qualtran.bloqs.rotations.phase_gradient import PhaseGradientUnitary
@@ -51,7 +53,7 @@ class TestQvrPhaseGradient(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         x = quregs[self.cost_reg.name]
         phase_grad = context.qubit_manager.qalloc(int(self.qvr.b_grad))
         yield cirq.H.on_each(*phase_grad)

--- a/qualtran/bloqs/state_preparation/prepare_uniform_superposition.py
+++ b/qualtran/bloqs/state_preparation/prepare_uniform_superposition.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Tuple, Union
+from typing import Iterator, Tuple, Union
 
 import attrs
 import cirq
@@ -72,7 +72,7 @@ class PrepareUniformSuperposition(GateWithRegisters):
         *,
         context: cirq.DecompositionContext,
         **quregs: NDArray[cirq.Qid],  # type:ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         controls, target = quregs.get('ctrl', ()), quregs['target']
         # Find K and L as per https://arxiv.org/abs/1805.03662 Fig 12.
         n, k = self.n, 0

--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
@@ -21,7 +21,7 @@ largest absolute error that one can tolerate in the prepared amplitudes.
 """
 
 from functools import cached_property
-from typing import Sequence, Tuple, TYPE_CHECKING
+from typing import Iterator, Sequence, Tuple, TYPE_CHECKING
 
 import attrs
 import cirq
@@ -170,7 +170,7 @@ class StatePreparationAliasSampling(PrepareOracle):
         *,
         context: cirq.DecompositionContext,
         **quregs: NDArray[cirq.Qid],  # type:ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         N = self.selection_registers[0].dtype.iteration_length_or_zero()
         yield PrepareUniformSuperposition(N).on(*quregs['selection'])
         if self.mu == 0:

--- a/qualtran/bloqs/swap_network/cswap_approx.py
+++ b/qualtran/bloqs/swap_network/cswap_approx.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Set, TYPE_CHECKING
+from typing import Dict, Iterator, Set, TYPE_CHECKING
 
 import cirq
 from attrs import frozen
@@ -67,7 +67,7 @@ class CSwapApprox(GateWithRegisters):
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]  # type: ignore[type-var]
-    ) -> cirq.OP_TREE:
+    ) -> Iterator[cirq.OP_TREE]:
         ctrl, target_x, target_y = quregs['ctrl'], quregs['x'], quregs['y']
 
         def g(q: cirq.Qid, adjoint=False) -> cirq.ops.op_tree.OpTree:

--- a/qualtran/cirq_interop/_cirq_to_bloq_test.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq_test.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Dict, Tuple
+from typing import Dict, Iterator, Tuple
 
 import attr
 import cirq
@@ -211,7 +211,7 @@ def test_cirq_gate_as_bloq_for_left_only_gates():
         def signature(self):
             return Signature([Register('junk', QAny(2), side=Side.LEFT)])
 
-        def decompose_from_registers(self, *, context, junk) -> cirq.OP_TREE:
+        def decompose_from_registers(self, *, context, junk) -> Iterator[cirq.OP_TREE]:
             yield cirq.CNOT(*junk)
             yield cirq.reset_each(*junk)
 

--- a/qualtran/cirq_interop/testing_test.py
+++ b/qualtran/cirq_interop/testing_test.py
@@ -11,6 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from typing import Iterator
+
 import cirq
 import numpy as np
 import pytest
@@ -71,7 +73,7 @@ class InconsistentDecompostion(cirq.Operation):
     def _t_complexity_(self) -> TComplexity:
         return TComplexity(rotations=1)
 
-    def _decompose_(self) -> cirq.OP_TREE:
+    def _decompose_(self) -> Iterator[cirq.OP_TREE]:
         yield cirq.X(self.qubits[0])
 
     @property

--- a/qualtran/drawing/qpic_diagram.py
+++ b/qualtran/drawing/qpic_diagram.py
@@ -39,7 +39,7 @@ from qualtran.drawing.musical_score import (
 )
 
 if TYPE_CHECKING:
-    from qualtran import Bloq, Connection, Signature
+    from qualtran import Bloq, Connection, QDType, Signature
 
 
 def _wire_name_prefix_for_soq(soq: Soquet) -> str:
@@ -270,8 +270,7 @@ def get_qpic_data(bloq: 'Bloq', file_path: Union[None, pathlib.Path, str] = None
     if file_path:
         with open(file_path, 'w') as f:
             f.write('\n'.join(qpic_circuit.data))
-    else:
-        return qpic_circuit.data
+    return qpic_circuit.data
 
 
 def _to_snake_case(name):

--- a/qualtran/testing.py
+++ b/qualtran/testing.py
@@ -16,7 +16,7 @@ import itertools
 import traceback
 from enum import Enum
 from pathlib import Path
-from typing import cast, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import sympy
@@ -238,12 +238,11 @@ def assert_wire_symbols_match_expected(bloq: Bloq, expected_ws: List[Union[str, 
         expected_ws: A list of the expected wire symbols or their associated text.
     """
     expected_idx = 0
-    ws = []
     for reg in bloq.signature:
         if reg.shape:
             indices = np.ndindex(reg.shape)
         else:
-            indices = [(0,)]
+            indices = np.ndindex((1,))
         for idx in indices:
             wire_symbol = bloq.wire_symbol(reg, idx)
             expected_symbol = expected_ws[expected_idx]

--- a/qualtran/testing.py
+++ b/qualtran/testing.py
@@ -16,7 +16,7 @@ import itertools
 import traceback
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import cast, Dict, List, Optional, Sequence, Tuple, Union
 
 import sympy
 
@@ -34,6 +34,7 @@ from qualtran import (
 )
 from qualtran._infra.composite_bloq import _get_flat_dangling_soqs
 from qualtran._infra.data_types import check_dtypes_consistent, QDTypeCheckingSeverity
+from qualtran.drawing import TextBox
 from qualtran.resource_counting import GeneralizerT
 
 
@@ -239,7 +240,7 @@ def assert_wire_symbols_match_expected(bloq: Bloq, expected_ws: List[str]):
     for i, r in enumerate(regs):
         # note this will only work if shape = ().
         # See: https://github.com/quantumlib/Qualtran/issues/608
-        ws.append(bloq.wire_symbol(r, (i,)).text)
+        ws.append(cast(TextBox, bloq.wire_symbol(r, (i,))).text)
 
     assert ws == expected_ws
 


### PR DESCRIPTION
- This enables the mypy CI check
- It also fixes the mypy issues introduced in the past few days.
- Also fixes items that occured from mypy 1.9.0 to 1.9.1
-   (mypy 1.9.1 is apparently more strict about the return type of generators)