### PR TITLE
remove circular import in t_counts_from_sigma

### DIFF
--- a/qualtran/bloqs/util_bloqs_test.py
+++ b/qualtran/bloqs/util_bloqs_test.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import subprocess
 from functools import cached_property
 from typing import Dict, Type, Union
 
@@ -290,3 +291,8 @@ def test_power_circuit_diagram():
 @pytest.mark.notebook
 def test_notebook():
     execute_notebook('util_bloqs')
+
+
+def test_no_circular_import():
+    # There was a circular import that would only be triggered by this import incantation
+    subprocess.check_call(['python', '-c', 'from qualtran.bloqs import util_bloqs'])

--- a/qualtran/resource_counting/t_counts_from_sigma.py
+++ b/qualtran/resource_counting/t_counts_from_sigma.py
@@ -17,20 +17,19 @@ from typing import Mapping, Optional, Tuple, Type, TYPE_CHECKING
 
 import cirq
 
-from qualtran.bloqs.basic_gates.rotation import _HasEps
 from qualtran.resource_counting.symbolic_counting_utils import ceil, SymbolicInt
 
 if TYPE_CHECKING:
-    import sympy
-
     from qualtran import Bloq
+    from qualtran.bloqs.basic_gates.rotation import _HasEps
 
 
-def _get_all_rotation_types() -> Tuple[Type[_HasEps], ...]:
+def _get_all_rotation_types() -> Tuple[Type['_HasEps'], ...]:
     """Returns all classes defined in bloqs.basic_gates which have an attribute `eps`."""
-    import qualtran.bloqs.basic_gates  # pylint: disable=unused-import
+    from qualtran.bloqs.basic_gates import GlobalPhase
+    from qualtran.bloqs.basic_gates.rotation import _HasEps
 
-    bloqs_to_exclude = [qualtran.bloqs.basic_gates.GlobalPhase]
+    bloqs_to_exclude = [GlobalPhase]
 
     return tuple(
         v


### PR DESCRIPTION
Current import dependencies are `qualtran` <-- `qualtran.[protocol]` where protocol!=bloqs <--- `qualtran.bloqs`

This gets a little dicey when doing resource counting because we need to know bloq types. In the future, it might make sense to have a final `qualtran.bloqs.costs` set of costs cc #899 that can depend on bloqs. Right now, we use local imports 

Fixes the issue identified by @NoureldinYosri in #924 