### PR TITLE
Move `symbolic_counting_utils.py` to a new module in `qualtran/symbolics/`

### DIFF
--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -64,8 +64,8 @@ if TYPE_CHECKING:
 
     from qualtran.drawing import WireSymbol
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
-    from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
     from qualtran.simulation.classical_sim import ClassicalValT
+    from qualtran.symbolics import SymbolicInt
 
 
 @frozen

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -47,8 +47,8 @@ from qualtran.drawing.musical_score import TextBox
 if TYPE_CHECKING:
     from qualtran import BloqBuilder
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
-    from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
     from qualtran.simulation.classical_sim import ClassicalValT
+    from qualtran.symbolics import SymbolicInt
 
 
 @frozen

--- a/qualtran/bloqs/arithmetic/multiplication.py
+++ b/qualtran/bloqs/arithmetic/multiplication.py
@@ -31,7 +31,7 @@ from qualtran import (
 )
 from qualtran.bloqs.basic_gates import TGate, Toffoli
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
-from qualtran.resource_counting.symbolic_counting_utils import smax
+from qualtran.symbolics import smax
 
 if TYPE_CHECKING:
     import quimb.tensor as qtn

--- a/qualtran/bloqs/arithmetic/sorting.py
+++ b/qualtran/bloqs/arithmetic/sorting.py
@@ -19,7 +19,7 @@ from attrs import frozen
 from qualtran import Bloq, bloq_example, BloqDocSpec, QAny, QBit, Register, Side, Signature
 from qualtran.bloqs.arithmetic import GreaterThan
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
-from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
+from qualtran.symbolics import SymbolicInt
 
 
 @frozen

--- a/qualtran/bloqs/basic_gates/global_phase.py
+++ b/qualtran/bloqs/basic_gates/global_phase.py
@@ -21,10 +21,10 @@ from attrs import frozen
 from qualtran import bloq_example, BloqDocSpec, DecomposeTypeError
 from qualtran.cirq_interop import CirqGateAsBloqBase
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
+from qualtran.symbolics import sconj, SymbolicComplex
 
 if TYPE_CHECKING:
     from qualtran import CompositeBloq
-    from qualtran.resource_counting.symbolic_counting_utils import SymbolicComplex
 
 
 @frozen
@@ -47,8 +47,6 @@ class GlobalPhase(CirqGateAsBloqBase):
         raise DecomposeTypeError(f"{self} is atomic")
 
     def adjoint(self) -> 'GlobalPhase':
-        from qualtran.resource_counting.symbolic_counting_utils import sconj
-
         return attrs.evolve(self, coefficient=sconj(self.coefficient))
 
     def pretty_name(self) -> str:

--- a/qualtran/bloqs/basic_gates/on_each.py
+++ b/qualtran/bloqs/basic_gates/on_each.py
@@ -23,7 +23,7 @@ from qualtran import Bloq, BloqBuilder, QAny, Register, Signature, Soquet, Soque
 from qualtran.drawing import WireSymbol
 from qualtran.drawing.musical_score import TextBox
 from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
-from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
+from qualtran.symbolics import SymbolicInt
 
 
 @attrs.frozen

--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -23,7 +23,7 @@ from attrs import frozen
 from qualtran import bloq_example, BloqDocSpec, CompositeBloq, DecomposeTypeError
 from qualtran.cirq_interop import CirqGateAsBloqBase
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
-from qualtran.resource_counting.symbolic_counting_utils import SymbolicFloat
+from qualtran.symbolics import SymbolicFloat
 
 
 @runtime_checkable

--- a/qualtran/bloqs/basic_gates/su2_rotation.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation.py
@@ -23,12 +23,12 @@ from qualtran import bloq_example, BloqDocSpec, GateWithRegisters, Register, Sig
 from qualtran.bloqs.basic_gates import GlobalPhase, Ry, ZPowGate
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import TextBox
-from qualtran.resource_counting.symbolic_counting_utils import is_symbolic, SymbolicFloat
+from qualtran.symbolics import is_symbolic, SymbolicFloat
 
 if TYPE_CHECKING:
     import quimb.tensor as qtn
 
-    from qualtran import BloqBuilder, Soquet, SoquetT
+    from qualtran import BloqBuilder, SoquetT
     from qualtran.drawing import WireSymbol
     from qualtran.resource_counting import SympySymbolAllocator
 

--- a/qualtran/bloqs/factoring/ecc/ec_point.py
+++ b/qualtran/bloqs/factoring/ecc/ec_point.py
@@ -14,7 +14,7 @@
 
 from attrs import frozen
 
-from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
+from qualtran.symbolics import SymbolicInt
 
 
 @frozen

--- a/qualtran/bloqs/factoring/ecc/find_ecc_private_key.py
+++ b/qualtran/bloqs/factoring/ecc/find_ecc_private_key.py
@@ -22,7 +22,7 @@ from qualtran import Bloq, bloq_example, BloqBuilder, BloqDocSpec, QUInt, Signat
 from qualtran.bloqs.basic_gates import IntState
 from qualtran.bloqs.util_bloqs import Free
 from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
-from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
+from qualtran.symbolics import SymbolicInt
 
 from .ec_phase_estimate_r import ECPhaseEstimateR
 from .ec_point import ECPoint

--- a/qualtran/bloqs/for_testing/qubitization_walk_test.py
+++ b/qualtran/bloqs/for_testing/qubitization_walk_test.py
@@ -24,7 +24,7 @@ from qualtran.bloqs.multiplexers.select_pauli_lcu import SelectPauliLCU
 from qualtran.bloqs.qubitization_walk_operator import QubitizationWalkOperator
 from qualtran.bloqs.select_and_prepare import PrepareOracle
 from qualtran.bloqs.state_preparation import PrepareUniformSuperposition
-from qualtran.resource_counting.symbolic_counting_utils import SymbolicFloat
+from qualtran.symbolics import SymbolicFloat
 
 
 @attrs.frozen

--- a/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp.py
+++ b/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp.py
@@ -25,12 +25,7 @@ from qualtran.linalg.jacobi_anger_approximations import (
     approx_exp_cos_by_jacobi_anger,
     degree_jacobi_anger_approximation,
 )
-from qualtran.resource_counting.symbolic_counting_utils import (
-    is_symbolic,
-    Shaped,
-    SymbolicFloat,
-    SymbolicInt,
-)
+from qualtran.symbolics import is_symbolic, Shaped, SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, SoquetT

--- a/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp_test.py
+++ b/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp_test.py
@@ -26,7 +26,7 @@ from qualtran.bloqs.qsp.generalized_qsp_test import (
     verify_generalized_qsp,
 )
 from qualtran.bloqs.qubitization_walk_operator import QubitizationWalkOperator
-from qualtran.resource_counting.symbolic_counting_utils import Shaped
+from qualtran.symbolics import Shaped
 
 from .hamiltonian_simulation_by_gqsp import (
     _hubbard_time_evolution_by_gqsp,

--- a/qualtran/bloqs/hubbard_model.py
+++ b/qualtran/bloqs/hubbard_model.py
@@ -68,7 +68,7 @@ from qualtran.bloqs.state_preparation.prepare_uniform_superposition import (
 )
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting.symbolic_counting_utils import SymbolicFloat
+    from qualtran.symbolics import SymbolicFloat
 
 
 @attrs.frozen

--- a/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
+++ b/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
@@ -40,8 +40,8 @@ if TYPE_CHECKING:
     import quimb.tensor as qtn
 
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
-    from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
     from qualtran.simulation.classical_sim import ClassicalValT
+    from qualtran.symbolics import SymbolicInt
 
 
 @frozen

--- a/qualtran/bloqs/mod_arithmetic/_shims.py
+++ b/qualtran/bloqs/mod_arithmetic/_shims.py
@@ -31,7 +31,7 @@ from qualtran.bloqs.arithmetic import Add, AddK
 from qualtran.bloqs.arithmetic._shims import CHalf, Lt, MultiCToffoli, Negate, Sub
 from qualtran.bloqs.basic_gates import CNOT, CSwap, Swap, Toffoli
 from qualtran.drawing import Circle, TextBox, WireSymbol
-from qualtran.resource_counting.symbolic_counting_utils import ceil, log2
+from qualtran.symbolics import ceil, log2
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator

--- a/qualtran/bloqs/multiplexers/unary_iteration_bloq.py
+++ b/qualtran/bloqs/multiplexers/unary_iteration_bloq.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
     from qualtran import Bloq
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
-    from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
+    from qualtran.symbolics import SymbolicInt
 
 
 def _unary_iteration_segtree(

--- a/qualtran/bloqs/phase_estimation/lp_resource_state.py
+++ b/qualtran/bloqs/phase_estimation/lp_resource_state.py
@@ -35,7 +35,7 @@ from qualtran import (
 from qualtran.bloqs.basic_gates import CZPowGate, GlobalPhase, Hadamard, OnEach, Ry, Rz, XGate
 from qualtran.bloqs.mcmt import MultiControlPauli
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
-from qualtran.resource_counting.symbolic_counting_utils import is_symbolic, pi, SymbolicInt
+from qualtran.symbolics import acos, is_symbolic, pi, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
@@ -160,8 +160,6 @@ class LPResourceState(GateWithRegisters):
         context.qubit_manager.qfree([flag, anc])
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        from qualtran.resource_counting.symbolic_counting_utils import acos
-
         flag_angle = acos(1 / (1 + 2**self.bitsize))
 
         return {

--- a/qualtran/bloqs/phase_estimation/qubitization_qpe.py
+++ b/qualtran/bloqs/phase_estimation/qubitization_qpe.py
@@ -21,14 +21,7 @@ from qualtran import Bloq, bloq_example, BloqDocSpec, GateWithRegisters, QFxp, R
 from qualtran.bloqs.phase_estimation.lp_resource_state import LPResourceState
 from qualtran.bloqs.qft.qft_text_book import QFTTextBook
 from qualtran.bloqs.qubitization_walk_operator import QubitizationWalkOperator
-from qualtran.resource_counting.symbolic_counting_utils import (
-    ceil,
-    is_symbolic,
-    log2,
-    pi,
-    SymbolicFloat,
-    SymbolicInt,
-)
+from qualtran.symbolics import ceil, is_symbolic, log2, pi, SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator

--- a/qualtran/bloqs/phase_estimation/text_book_qpe.py
+++ b/qualtran/bloqs/phase_estimation/text_book_qpe.py
@@ -20,14 +20,7 @@ import cirq
 from qualtran import Bloq, bloq_example, BloqDocSpec, GateWithRegisters, QFxp, Register, Signature
 from qualtran.bloqs.basic_gates import Hadamard, OnEach
 from qualtran.bloqs.qft.qft_text_book import QFTTextBook
-from qualtran.resource_counting.symbolic_counting_utils import (
-    ceil,
-    is_symbolic,
-    log2,
-    pi,
-    SymbolicFloat,
-    SymbolicInt,
-)
+from qualtran.symbolics import ceil, is_symbolic, log2, pi, SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator

--- a/qualtran/bloqs/qft/approximate_qft.py
+++ b/qualtran/bloqs/qft/approximate_qft.py
@@ -25,13 +25,7 @@ from numpy.typing import NDArray
 from qualtran import bloq_example, BloqDocSpec, GateWithRegisters, QFxp, QUInt, Signature
 from qualtran.bloqs.basic_gates import Hadamard, TwoBitSwap
 from qualtran.bloqs.rotations import AddIntoPhaseGrad
-from qualtran.resource_counting.symbolic_counting_utils import (
-    ceil,
-    is_symbolic,
-    log2,
-    SymbolicFloat,
-    SymbolicInt,
-)
+from qualtran.symbolics import ceil, is_symbolic, log2, SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator

--- a/qualtran/bloqs/qft/qft_text_book.py
+++ b/qualtran/bloqs/qft/qft_text_book.py
@@ -20,7 +20,7 @@ from numpy.typing import NDArray
 
 from qualtran import GateWithRegisters, QUInt, Signature
 from qualtran.bloqs.rotations.phase_gradient import PhaseGradientUnitary
-from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
+from qualtran.symbolics import SymbolicInt
 
 
 @attrs.frozen

--- a/qualtran/bloqs/qsp/generalized_qsp.py
+++ b/qualtran/bloqs/qsp/generalized_qsp.py
@@ -22,14 +22,7 @@ from numpy.typing import NDArray
 
 from qualtran import bloq_example, BloqDocSpec, GateWithRegisters, QBit, Register, Signature
 from qualtran.bloqs.basic_gates.su2_rotation import SU2RotationGate
-from qualtran.resource_counting.symbolic_counting_utils import (
-    is_symbolic,
-    Shaped,
-    slen,
-    smax,
-    smin,
-    SymbolicInt,
-)
+from qualtran.symbolics import is_symbolic, Shaped, slen, smax, smin, SymbolicInt
 
 if TYPE_CHECKING:
     import cirq

--- a/qualtran/bloqs/qsp/generalized_qsp_test.py
+++ b/qualtran/bloqs/qsp/generalized_qsp_test.py
@@ -28,7 +28,7 @@ from qualtran.bloqs.for_testing.atom import TestGWRAtom
 from qualtran.bloqs.for_testing.matrix_gate import MatrixGate
 from qualtran.bloqs.qubitization_walk_operator_test import get_walk_operator_for_1d_ising_model
 from qualtran.resource_counting import SympySymbolAllocator
-from qualtran.resource_counting.symbolic_counting_utils import Shaped
+from qualtran.symbolics import Shaped
 
 from .generalized_qsp import (
     _gqsp,

--- a/qualtran/bloqs/qubitization_walk_operator.py
+++ b/qualtran/bloqs/qubitization_walk_operator.py
@@ -28,7 +28,7 @@ from qualtran.resource_counting.generalizers import (
     ignore_cliffords,
     ignore_split_join,
 )
-from qualtran.resource_counting.symbolic_counting_utils import SymbolicFloat
+from qualtran.symbolics import SymbolicFloat
 
 
 @attrs.frozen(cache_hash=True)

--- a/qualtran/bloqs/rotations/hamming_weight_phasing.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing.py
@@ -25,7 +25,7 @@ from qualtran.bloqs.rotations.quantum_variable_rotation import QvrPhaseGradient
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, SoquetT
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
-    from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
+    from qualtran.symbolics import SymbolicInt
 
 
 @attrs.frozen

--- a/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing_test.py
@@ -31,7 +31,7 @@ from qualtran.resource_counting.generalizers import (
     generalize_rotation_angle,
     ignore_split_join,
 )
-from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
+from qualtran.symbolics import SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, SoquetT

--- a/qualtran/bloqs/rotations/phase_gradient.py
+++ b/qualtran/bloqs/rotations/phase_gradient.py
@@ -33,8 +33,8 @@ if TYPE_CHECKING:
 
     from qualtran import Bloq, SoquetT
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
-    from qualtran.resource_counting.symbolic_counting_utils import SymbolicFloat, SymbolicInt
     from qualtran.simulation.classical_sim import ClassicalValT
+    from qualtran.symbolics import SymbolicFloat, SymbolicInt
 
 
 @attrs.frozen

--- a/qualtran/bloqs/rotations/quantum_variable_rotation.py
+++ b/qualtran/bloqs/rotations/quantum_variable_rotation.py
@@ -75,7 +75,7 @@ from qualtran import (
 )
 from qualtran.bloqs.basic_gates.rotation import ZPowGate
 from qualtran.bloqs.rotations.phase_gradient import AddScaledValIntoPhaseReg
-from qualtran.resource_counting.symbolic_counting_utils import (
+from qualtran.symbolics import (
     bit_length,
     ceil,
     is_symbolic,
@@ -90,7 +90,6 @@ from qualtran.resource_counting.symbolic_counting_utils import (
 if TYPE_CHECKING:
     from qualtran import SoquetT
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
-    from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
 
 
 class QvrInterface(GateWithRegisters, metaclass=abc.ABCMeta):

--- a/qualtran/bloqs/select_and_prepare.py
+++ b/qualtran/bloqs/select_and_prepare.py
@@ -19,7 +19,7 @@ from typing import Optional, Tuple, TYPE_CHECKING
 from qualtran import GateWithRegisters, Register, Signature
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting.symbolic_counting_utils import SymbolicFloat
+    from qualtran.symbolics import SymbolicFloat
 
 
 class SelectOracle(GateWithRegisters):

--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
@@ -45,7 +45,7 @@ from qualtran.resource_counting.generalizers import (
 )
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting.symbolic_counting_utils import SymbolicFloat
+    from qualtran.symbolics import SymbolicFloat
 
 
 @cirq.value_equality()

--- a/qualtran/bloqs/util_bloqs.py
+++ b/qualtran/bloqs/util_bloqs.py
@@ -37,8 +37,8 @@ from qualtran import (
 )
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import directional_text_box, WireSymbol
-from qualtran.resource_counting.symbolic_counting_utils import is_symbolic, SymbolicInt
 from qualtran.simulation.classical_sim import bits_to_ints, ints_to_bits
+from qualtran.symbolics import is_symbolic, SymbolicInt
 
 if TYPE_CHECKING:
     import cirq

--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -19,12 +19,7 @@ import cirq
 
 from qualtran import Bloq, Controlled
 from qualtran.cirq_interop.decompose_protocol import _decompose_once_considering_known_decomposition
-from qualtran.resource_counting.symbolic_counting_utils import (
-    ceil,
-    log2,
-    SymbolicFloat,
-    SymbolicInt,
-)
+from qualtran.symbolics import ceil, log2, SymbolicFloat, SymbolicInt
 
 _T_GATESET = cirq.Gateset(cirq.T, cirq.T**-1, unroll_circuit_op=False)
 _ROTS_GATESET = cirq.Gateset(cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate, cirq.CZPowGate)

--- a/qualtran/linalg/jacobi_anger_approximations.py
+++ b/qualtran/linalg/jacobi_anger_approximations.py
@@ -19,11 +19,7 @@ import sympy
 from numpy.typing import NDArray
 
 from qualtran.resource_counting import big_O
-from qualtran.resource_counting.symbolic_counting_utils import (
-    is_symbolic,
-    SymbolicFloat,
-    SymbolicInt,
-)
+from qualtran.symbolics import is_symbolic, SymbolicFloat, SymbolicInt
 
 
 def degree_jacobi_anger_approximation(t: SymbolicFloat, *, precision: SymbolicFloat) -> SymbolicInt:

--- a/qualtran/resource_counting/_call_graph_test.py
+++ b/qualtran/resource_counting/_call_graph_test.py
@@ -31,7 +31,7 @@ from qualtran.resource_counting import (
     get_bloq_callee_counts,
     SympySymbolAllocator,
 )
-from qualtran.resource_counting.symbolic_counting_utils import SymbolicInt
+from qualtran.symbolics import SymbolicInt
 
 
 @frozen

--- a/qualtran/resource_counting/t_counts_from_sigma.py
+++ b/qualtran/resource_counting/t_counts_from_sigma.py
@@ -17,7 +17,7 @@ from typing import Mapping, Optional, Tuple, Type, TYPE_CHECKING
 
 import cirq
 
-from qualtran.resource_counting.symbolic_counting_utils import ceil, SymbolicInt
+from qualtran.symbolics import ceil, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran import Bloq

--- a/qualtran/symbolics/__init__.py
+++ b/qualtran/symbolics/__init__.py
@@ -1,0 +1,35 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from qualtran.symbolics.math_funcs import (
+    acos,
+    bit_length,
+    ceil,
+    floor,
+    log2,
+    pi,
+    sabs,
+    sconj,
+    slen,
+    smax,
+    smin,
+)
+from qualtran.symbolics.types import (
+    is_symbolic,
+    Shaped,
+    SymbolicComplex,
+    SymbolicFloat,
+    SymbolicInt,
+)

--- a/qualtran/symbolics/math_funcs.py
+++ b/qualtran/symbolics/math_funcs.py
@@ -15,58 +15,14 @@ from typing import cast, Sized, Union
 
 import numpy as np
 import sympy
-from attrs import field, frozen, validators
-from cirq._doc import document
 
-SymbolicFloat = Union[float, sympy.Expr]
-document(SymbolicFloat, """A floating point value or a sympy expression.""")
-
-SymbolicInt = Union[int, sympy.Expr]
-document(SymbolicFloat, """A floating point value or a sympy expression.""")
-
-SymbolicComplex = Union[complex, sympy.Expr]
-document(SymbolicComplex, """A complex value or a sympy expression.""")
-
-
-@frozen
-class Shaped:
-    """Symbolic value for an object that has a shape.
-
-    A Shaped object can be used as a symbolic replacement for any object that has an attribute `shape`,
-    for example numpy NDArrays.
-    Each dimension can be either an positive integer value or a sympy expression.
-
-    This is useful to do symbolic analysis of Bloqs whose call graph only depends on the shape of the input,
-    but not on the actual values.
-    For example, T-cost of the `QROM` Bloq depends only on the iteration length (shape) and not on actual data values.
-    """
-
-    shape: tuple[SymbolicInt, ...] = field(validator=validators.instance_of(tuple))
-
-    def is_symbolic(self):
-        return True
-
-
-def is_symbolic(*args) -> bool:
-    """Returns whether the inputs contain any symbolic object.
-
-    Returns:
-        True if any argument is either a sympy object,
-        or implements the `is_symbolic` method which returns True.
-    """
-
-    if len(args) != 1:
-        return any(is_symbolic(arg) for arg in args)
-
-    (arg,) = args
-    if isinstance(arg, sympy.Basic):
-        return True
-
-    checker = getattr(arg, 'is_symbolic', None)
-    if checker is not None:
-        return checker()
-
-    return False
+from qualtran.symbolics.types import (
+    is_symbolic,
+    Shaped,
+    SymbolicComplex,
+    SymbolicFloat,
+    SymbolicInt,
+)
 
 
 def pi(*args) -> SymbolicFloat:

--- a/qualtran/symbolics/math_funcs_test.py
+++ b/qualtran/symbolics/math_funcs_test.py
@@ -16,16 +16,7 @@ import pytest
 import sympy
 from sympy.codegen.cfunctions import log2 as sympy_log2
 
-from qualtran.resource_counting.symbolic_counting_utils import (
-    bit_length,
-    ceil,
-    is_symbolic,
-    log2,
-    Shaped,
-    slen,
-    smax,
-    smin,
-)
+from qualtran.symbolics import bit_length, ceil, is_symbolic, log2, Shaped, slen, smax, smin
 
 
 def test_log2():

--- a/qualtran/symbolics/types.py
+++ b/qualtran/symbolics/types.py
@@ -1,0 +1,68 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import Union
+
+import sympy
+from attrs import field, frozen, validators
+from cirq._doc import document
+
+SymbolicFloat = Union[float, sympy.Expr]
+document(SymbolicFloat, """A floating point value or a sympy expression.""")
+
+SymbolicInt = Union[int, sympy.Expr]
+document(SymbolicFloat, """A floating point value or a sympy expression.""")
+
+SymbolicComplex = Union[complex, sympy.Expr]
+document(SymbolicComplex, """A complex value or a sympy expression.""")
+
+
+@frozen
+class Shaped:
+    """Symbolic value for an object that has a shape.
+
+    A Shaped object can be used as a symbolic replacement for any object that has an attribute `shape`,
+    for example numpy NDArrays.
+    Each dimension can be either an positive integer value or a sympy expression.
+
+    This is useful to do symbolic analysis of Bloqs whose call graph only depends on the shape of the input,
+    but not on the actual values.
+    For example, T-cost of the `QROM` Bloq depends only on the iteration length (shape) and not on actual data values.
+    """
+
+    shape: tuple[SymbolicInt, ...] = field(validator=validators.instance_of(tuple))
+
+    def is_symbolic(self):
+        return True
+
+
+def is_symbolic(*args) -> bool:
+    """Returns whether the inputs contain any symbolic object.
+
+    Returns:
+        True if any argument is either a sympy object,
+        or implements the `is_symbolic` method which returns True.
+    """
+
+    if len(args) != 1:
+        return any(is_symbolic(arg) for arg in args)
+
+    (arg,) = args
+    if isinstance(arg, sympy.Basic):
+        return True
+
+    checker = getattr(arg, 'is_symbolic', None)
+    if checker is not None:
+        return checker()
+
+    return False


### PR DESCRIPTION
With improved typing, we want to use types like `SymbolicInt` etc everywhere, including `qualtran/_infra`. This leads to cyclic imports since `qualtran/resource_counting/` depends on `qualtran/_infra`. Moving symbolic utils to its own module helps avoid these cyclic imports and provides the right place to add future utilities for dealing with symbolics 