### PR TITLE
Fix `t_complexity` for symbolic ham. sim. by gqsp example

### DIFF
--- a/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp.py
+++ b/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import cast, Dict, Tuple, TYPE_CHECKING, Union
+from typing import cast, Dict, Set, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 from attrs import field, frozen
@@ -29,6 +29,7 @@ from qualtran.symbolics import is_symbolic, Shaped, SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, SoquetT
+    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 
 
 @frozen
@@ -176,6 +177,21 @@ class HamiltonianSimulationByGQSP(GateWithRegisters):
 
         return soqs
 
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+        if self.is_symbolic():
+            from qualtran.bloqs.basic_gates.su2_rotation import SU2RotationGate
+
+            d = self.degree
+            return {
+                (self.walk_operator.prepare, 1),
+                (self.walk_operator.prepare.adjoint(), 1),
+                (self.walk_operator.controlled(control_values=[0]), d),
+                (self.walk_operator.adjoint().controlled(), d),
+                (SU2RotationGate.arbitrary(ssa), 2 * d + 1),
+            }
+
+        return super().build_call_graph(ssa)
+
 
 @bloq_example
 def _hubbard_time_evolution_by_gqsp() -> HamiltonianSimulationByGQSP:
@@ -192,9 +208,8 @@ def _symbolic_hamsim_by_gqsp() -> HamiltonianSimulationByGQSP:
 
     from qualtran.bloqs.hubbard_model import get_walk_operator_for_hubbard_model
 
-    walk_op = get_walk_operator_for_hubbard_model(2, 2, 1, 1)
-
-    t, inv_eps = sympy.symbols("t N")
+    tau, t, inv_eps = sympy.symbols(r"\tau t \epsilon^{-1}", positive=True)
+    walk_op = get_walk_operator_for_hubbard_model(2, 2, tau, 4 * tau)
     symbolic_hamsim_by_gqsp = HamiltonianSimulationByGQSP(walk_op, t=t, precision=1 / inv_eps)
     return symbolic_hamsim_by_gqsp
 

--- a/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp_test.py
+++ b/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp_test.py
@@ -16,6 +16,7 @@ import cirq
 import numpy as np
 import pytest
 import scipy
+import sympy
 from numpy.typing import NDArray
 
 from qualtran.bloqs.for_testing.matrix_gate import MatrixGate
@@ -26,6 +27,8 @@ from qualtran.bloqs.qsp.generalized_qsp_test import (
     verify_generalized_qsp,
 )
 from qualtran.bloqs.qubitization_walk_operator import QubitizationWalkOperator
+from qualtran.cirq_interop.t_complexity_protocol import TComplexity
+from qualtran.resource_counting import big_O
 from qualtran.symbolics import Shaped
 
 from .hamiltonian_simulation_by_gqsp import (
@@ -100,3 +103,8 @@ def test_hamiltonian_simulation_by_gqsp(
 def test_hamiltonian_simulation_by_gqsp_t_complexity():
     hubbard_time_evolution_by_gqsp = _hubbard_time_evolution_by_gqsp.make()
     _ = hubbard_time_evolution_by_gqsp.t_complexity()
+
+    symbolic_hamsim_by_gqsp = _symbolic_hamsim_by_gqsp()
+    tau, t, inv_eps = sympy.symbols(r"\tau t \epsilon^{-1}", positive=True)
+    T = big_O(tau * t + sympy.log(inv_eps) / sympy.log(sympy.log(inv_eps)))
+    assert symbolic_hamsim_by_gqsp.t_complexity() == TComplexity(t=T, clifford=T, rotations=T)  # type: ignore[arg-type]

--- a/qualtran/bloqs/hubbard_model.py
+++ b/qualtran/bloqs/hubbard_model.py
@@ -66,6 +66,7 @@ from qualtran.bloqs.select_and_prepare import PrepareOracle, SelectOracle
 from qualtran.bloqs.state_preparation.prepare_uniform_superposition import (
     PrepareUniformSuperposition,
 )
+from qualtran.symbolics.math_funcs import acos, ssqrt
 
 if TYPE_CHECKING:
     from qualtran.symbolics import SymbolicFloat
@@ -308,7 +309,7 @@ class PrepareHubbard(PrepareOracle):
         temp = quregs['temp']
 
         N = self.x_dim * self.y_dim * 2
-        yield cirq.Ry(rads=2 * np.arccos(np.sqrt(self.t * N / self.l1_norm_of_coeffs))).on(*V)
+        yield cirq.Ry(rads=2 * acos(ssqrt(self.t * N / self.l1_norm_of_coeffs))).on(*V)
         yield cirq.Ry(rads=2 * np.arccos(np.sqrt(1 / 5))).on(*U).controlled_by(*V)
         yield PrepareUniformSuperposition(self.x_dim).on_registers(controls=[], target=p_x)
         yield PrepareUniformSuperposition(self.y_dim).on_registers(controls=[], target=p_y)

--- a/qualtran/bloqs/util_bloqs.py
+++ b/qualtran/bloqs/util_bloqs.py
@@ -50,11 +50,12 @@ if TYPE_CHECKING:
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
-class UtilBloq(Bloq, metaclass=abc.ABCMeta):
-    """Base class for util bloqs.
+class _BookkeepingBloq(Bloq, metaclass=abc.ABCMeta):
+    """Base class for utility bloqs used for bookkeeping.
 
-    1. Trivial controlled - pass through the control register.
-    2. Do not affect T complexity.
+    This bloq:
+    - has trivial controlled versions, which pass through the control register.
+    - does not affect T complexity.
     """
 
     def get_ctrl_system(
@@ -74,7 +75,7 @@ class UtilBloq(Bloq, metaclass=abc.ABCMeta):
 
 
 @frozen
-class Split(UtilBloq):
+class Split(_BookkeepingBloq):
     """Split a bitsize `n` register into a length-`n` array-register.
 
     Attributes:
@@ -133,7 +134,7 @@ class Split(UtilBloq):
 
 
 @frozen
-class Join(UtilBloq):
+class Join(_BookkeepingBloq):
     """Join a length-`n` array-register into one register of bitsize `n`.
 
     Attributes:
@@ -192,7 +193,7 @@ class Join(UtilBloq):
 
 
 @frozen
-class Partition(UtilBloq):
+class Partition(_BookkeepingBloq):
     """Partition a generic index into multiple registers.
 
     Args:
@@ -315,7 +316,7 @@ class Partition(UtilBloq):
 
 
 @frozen
-class Allocate(UtilBloq):
+class Allocate(_BookkeepingBloq):
     """Allocate an `n` bit register.
 
     Attributes:
@@ -356,7 +357,7 @@ class Allocate(UtilBloq):
 
 
 @frozen
-class Free(UtilBloq):
+class Free(_BookkeepingBloq):
     """Free (i.e. de-allocate) an `n` bit register.
 
     The tensor decomposition assumes the `n` bit register is uncomputed and is in the $|0^{n}>$
@@ -426,7 +427,7 @@ class ArbitraryClifford(Bloq):
 
 
 @frozen
-class Cast(UtilBloq):
+class Cast(_BookkeepingBloq):
     """Cast a register from one n-bit QDType to another QDType.
 
 

--- a/qualtran/symbolics/math_funcs.py
+++ b/qualtran/symbolics/math_funcs.py
@@ -41,6 +41,12 @@ def sabs(x: SymbolicFloat) -> SymbolicFloat:
     return cast(SymbolicFloat, abs(x))
 
 
+def ssqrt(x: SymbolicFloat) -> SymbolicFloat:
+    if isinstance(x, sympy.Basic):
+        return sympy.sqrt(x)
+    return np.sqrt(x)
+
+
 def ceil(x: SymbolicFloat) -> SymbolicInt:
     if not isinstance(x, sympy.Basic):
         return int(np.ceil(x))


### PR DESCRIPTION
- fixes the first bug reported in https://github.com/quantumlib/Qualtran/issues/935#issuecomment-2102719963 - adds a simplified override for the call graph of a symbolic HamSimbyGQSP bloq.
- introduces `_BookkeepingBloq` for utility bloqs that are used for book-keeping (i.e. cast, split/join, alloc/free)