### PR TITLE
Remove title text boxes from arithmetic and basic gates

### DIFF
--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -58,6 +58,7 @@ from qualtran.bloqs.util_bloqs import ArbitraryClifford
 from qualtran.cirq_interop import decompose_from_cirq_style_method
 from qualtran.cirq_interop.bit_tools import iter_bits, iter_bits_twos_complement
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
+from qualtran.drawing import directional_text_box, Text
 
 if TYPE_CHECKING:
     import quimb.tensor as qtn
@@ -161,10 +162,9 @@ class Add(Bloq):
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
-        from qualtran.drawing import directional_text_box, Text
 
         if reg is None:
-            return Text("a+b")
+            return Text("")
         if reg.name == 'a':
             return directional_text_box('a', side=reg.side)
         elif reg.name == 'b':

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -81,7 +81,7 @@ class LessThanConstant(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[
         if reg.name == 'x':
             return TextBox("x")
         if reg.name == 'target':
-            return TextBox("z ^ (x < a)")
+            return TextBox("z^(x<a)")
         raise ValueError(f'Unknown register name {reg.name}')
 
     def registers(self) -> Sequence[Union[int, Sequence[int]]]:
@@ -457,7 +457,7 @@ class LessThanEqual(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[mis
         if reg.name == "y":
             return TextBox('y')
         if reg.name == "target":
-            return TextBox('z ^ (x <= y)')
+            return TextBox('z^(x<=y)')
         raise ValueError(f'Unknown register name {reg.name}')
 
     def on_classical_vals(self, *, x: int, y: int, target: int) -> Dict[str, 'ClassicalValT']:
@@ -837,7 +837,7 @@ class LinearDepthGreaterThan(Bloq):
         if reg.name == "b":
             return TextBox('b')
         if reg.name == "target":
-            return TextBox('t ⨁ (a > b)')
+            return TextBox('t⨁(a>b)')
         raise ValueError(f'Unknown register name {reg.name}')
 
 

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -77,8 +77,12 @@ class LessThanConstant(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[
         self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
     ) -> 'WireSymbol':
         if reg is None:
-            return Text(f'x<{self.less_than_val}')
-        return super().wire_symbol(reg, idx)
+            return Text("")
+        if reg.name == 'x':
+            return TextBox("x")
+        if reg.name == 'target':
+            return TextBox("z ^ (x < a)")
+        raise ValueError(f'Unknown register name {reg.name}')
 
     def registers(self) -> Sequence[Union[int, Sequence[int]]]:
         return [2] * self.bitsize, self.less_than_val, [2]
@@ -447,8 +451,14 @@ class LessThanEqual(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[mis
         self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
     ) -> 'WireSymbol':
         if reg is None:
-            return Text('x <= y')
-        return super().wire_symbol(reg, idx)
+            return Text('')
+        if reg.name == "x":
+            return TextBox('x')
+        if reg.name == "y":
+            return TextBox('y')
+        if reg.name == "target":
+            return TextBox('z ^ (x <= y)')
+        raise ValueError(f'Unknown register name {reg.name}')
 
     def on_classical_vals(self, *, x: int, y: int, target: int) -> Dict[str, 'ClassicalValT']:
         return {'x': x, 'y': y, 'target': target ^ (x <= y)}
@@ -821,8 +831,14 @@ class LinearDepthGreaterThan(Bloq):
         self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
     ) -> 'WireSymbol':
         if reg is None:
-            return Text('a > b')
-        return super().wire_symbol(reg, idx)
+            return Text('')
+        if reg.name == "a":
+            return TextBox('a')
+        if reg.name == "b":
+            return TextBox('b')
+        if reg.name == "target":
+            return TextBox('t ⨁ (a > b)')
+        raise ValueError(f'Unknown register name {reg.name}')
 
 
 @frozen
@@ -860,7 +876,7 @@ class GreaterThanConstant(Bloq):
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> WireSymbol:
         if reg is None:
-            return Text(f"x > {self.val}")
+            return Text("")
         if reg.name == 'x':
             return TextBox("In(x)")
         elif reg.name == 'target':
@@ -912,7 +928,7 @@ class EqualsAConstant(Bloq):
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> WireSymbol:
         if reg is None:
-            return Text(f"x == {self.val}")
+            return Text("")
         if reg.name == 'x':
             return TextBox("In(x)")
         elif reg.name == 'target':

--- a/qualtran/bloqs/basic_gates/hadamard.py
+++ b/qualtran/bloqs/basic_gates/hadamard.py
@@ -29,7 +29,7 @@ from qualtran import (
     SoquetT,
 )
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
-from qualtran.drawing import TextBox, WireSymbol
+from qualtran.drawing import Text, TextBox, WireSymbol
 
 if TYPE_CHECKING:
     import cirq
@@ -89,6 +89,8 @@ class Hadamard(Bloq):
         return TComplexity(clifford=1)
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg is None:
+            return Text('')
         return TextBox('H')
 
 

--- a/qualtran/bloqs/basic_gates/s_gate.py
+++ b/qualtran/bloqs/basic_gates/s_gate.py
@@ -21,7 +21,7 @@ from attrs import frozen
 
 from qualtran import Bloq, bloq_example, BloqDocSpec, Register, Signature, SoquetT
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
-from qualtran.drawing import TextBox, WireSymbol
+from qualtran.drawing import Text, TextBox, WireSymbol
 
 if TYPE_CHECKING:
     import cirq
@@ -87,6 +87,8 @@ class SGate(Bloq):
         return f'S{maybe_dag}'
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg is None:
+            return Text('')
         return TextBox(self.pretty_name())
 
     def adjoint(self) -> 'Bloq':

--- a/qualtran/bloqs/basic_gates/su2_rotation.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation.py
@@ -153,7 +153,7 @@ class SU2RotationGate(GateWithRegisters):
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         if reg is None:
-            return Text("SU_2")
+            return Text("")
 
         return TextBox(
             f"{self.pretty_name()}({self.theta}, {self.phi}, {self.lambd}, {self.global_shift})"

--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -182,7 +182,7 @@ class TwoBitCSwap(Bloq):
 
     def wire_symbol(self, reg: Optional['Register'], idx: Tuple[int, ...] = ()) -> 'WireSymbol':
         if reg is None:
-            return Text('swap')
+            return Text('')
         if reg.name == 'ctrl':
             return Circle(filled=True)
         else:
@@ -231,7 +231,7 @@ class Swap(Bloq):
 
     def wire_symbol(self, reg: Optional['Register'], idx: Tuple[int, ...] = ()) -> 'WireSymbol':
         if reg is None:
-            return Text('swap')
+            return Text('')
         if reg.name == 'x':
             return TextBox('×(x)')
         elif reg.name == 'y':
@@ -313,7 +313,7 @@ class CSwap(GateWithRegisters):
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         if reg is None:
-            return Text(r'x↔y')
+            return Text('')
         if reg.name == 'x':
             return TextBox('×(x)')
         elif reg.name == 'y':

--- a/qualtran/bloqs/basic_gates/t_gate.py
+++ b/qualtran/bloqs/basic_gates/t_gate.py
@@ -20,7 +20,7 @@ import numpy as np
 from attrs import frozen
 
 from qualtran import Bloq, bloq_example, BloqDocSpec, Register, Signature, SoquetT
-from qualtran.drawing import TextBox, WireSymbol
+from qualtran.drawing import Text, TextBox, WireSymbol
 
 if TYPE_CHECKING:
     import cirq
@@ -112,6 +112,8 @@ class TGate(Bloq):
         return f'TGate({maybe_dag})'
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg is None:
+            return Text('')
         return TextBox(self.pretty_name())
 
 

--- a/qualtran/bloqs/mod_arithmetic/_shims.py
+++ b/qualtran/bloqs/mod_arithmetic/_shims.py
@@ -76,7 +76,7 @@ class CModSub(Bloq):
         self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
     ) -> 'WireSymbol':
         if reg is None:
-            return Text(str(self))
+            return Text("")
         if reg.name == 'ctrl':
             return Circle()
         elif reg.name == 'x':
@@ -140,7 +140,7 @@ class _ModInvInner(Bloq):
         self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
     ) -> 'WireSymbol':
         if reg is None:
-            return Text(str(self))
+            return Text("")
         if reg.name == 'x':
             return TextBox('x')
         elif reg.name == 'out':
@@ -174,7 +174,7 @@ class ModInv(Bloq):
         self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
     ) -> 'WireSymbol':
         if reg is None:
-            return Text(str(self))
+            return Text("")
         if reg.name == 'x':
             return TextBox('x')
         elif reg.name == 'out':
@@ -208,7 +208,7 @@ class ModMul(Bloq):
         self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
     ) -> 'WireSymbol':
         if reg is None:
-            return Text(str(self))
+            return Text("")
         if reg.name in ['x', 'y']:
             return TextBox(reg.name)
         elif reg.name == 'out':
@@ -232,7 +232,7 @@ class ModDbl(Bloq):
         self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
     ) -> 'WireSymbol':
         if reg is None:
-            return Text(str(self))
+            return Text("")
         if reg.name == 'x':
             return TextBox('x')
         elif reg.name == 'out':
@@ -264,7 +264,7 @@ class ModNeg(Bloq):
         self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
     ) -> 'WireSymbol':
         if reg is None:
-            return Text(str(self))
+            return Text("")
         if reg.name == 'x':
             return TextBox('$-x$')
         raise ValueError(f'Unrecognized register name {reg.name}')
@@ -290,7 +290,7 @@ class CModNeg(Bloq):
         self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
     ) -> 'WireSymbol':
         if reg is None:
-            return Text(str(self))
+            return Text("")
         if reg.name == 'ctrl':
             return Circle()
         elif reg.name == 'x':


### PR DESCRIPTION
- Removes superfluous and redundant textboxes from arithmetic and basic gates where the operation should be fairly obvious.