### PR TITLE
Handle overflow in addition plus k classical function

### DIFF
--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -441,13 +441,14 @@ class AddK(Bloq):
     def on_classical_vals(
         self, x: 'ClassicalValT', **vals: 'ClassicalValT'
     ) -> Dict[str, 'ClassicalValT']:
+        N = 2**self.bitsize
         if len(self.cvs) > 0:
             ctrls = vals['ctrls']
         else:
-            return {'x': x + self.k}
+            return {'x': int(math.fmod(x + self.k, N))}
 
         if np.all(self.cvs == ctrls):
-            x = x + self.k
+            x = int(math.fmod(x + self.k, N))
 
         return {'ctrls': ctrls, 'x': x}
 

--- a/qualtran/bloqs/arithmetic/addition_test.py
+++ b/qualtran/bloqs/arithmetic/addition_test.py
@@ -198,6 +198,12 @@ def test_add_call_classically(a: int, b: int, num_bits: int):
     assert ret == (a, a + b)
 
 
+def test_add_call_classically_overflow():
+    bloq = Add(QUInt(3))
+    ret = bloq.call_classically(a=5, b=6)
+    assert ret == (5, 3)  # 3 = 5+6 mod 8
+
+
 def test_add_truth_table():
     bloq = Add(QUInt(2))
     classical_truth_table = format_classical_truth_table(*get_classical_truth_table(bloq))


### PR DESCRIPTION
- Handle bitwise overflow in addition plus k.
- All other arithmetic functions either handle overflow correctly or have enough bits in the output to avoid overflow.

Fixes: #607