### PR TITLE
Remove _t_complexity_ of CSwapApprox

### DIFF
--- a/qualtran/bloqs/swap_network/cswap_approx.py
+++ b/qualtran/bloqs/swap_network/cswap_approx.py
@@ -23,7 +23,6 @@ from qualtran import bloq_example, BloqDocSpec, GateWithRegisters, Signature
 from qualtran.bloqs.basic_gates import TGate
 from qualtran.bloqs.mcmt.multi_control_multi_target_pauli import MultiTargetCNOT
 from qualtran.bloqs.util_bloqs import ArbitraryClifford
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.resource_counting.generalizers import (
     cirq_to_bloqs,
     generalize_rotation_angle,
@@ -96,14 +95,6 @@ class CSwapApprox(GateWithRegisters):
 
     def pretty_name(self) -> str:
         return '~swap'
-
-    def _t_complexity_(self) -> TComplexity:
-        """TComplexity as explained in Appendix B.2.c of https://arxiv.org/abs/1812.00954"""
-        n = self.bitsize
-        # 4 * n: G gates, each wth 1 T and 4 single qubit cliffords
-        # 4 * n: CNOTs
-        # 2 * n - 1: CNOTs from 1 MultiTargetCNOT
-        return TComplexity(t=4 * n, clifford=22 * n - 1)
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
         if not args.use_unicode_characters:

--- a/qualtran/bloqs/swap_network/cswap_approx_test.py
+++ b/qualtran/bloqs/swap_network/cswap_approx_test.py
@@ -28,6 +28,7 @@ from qualtran.bloqs.swap_network.cswap_approx import (
     CSwapApprox,
 )
 from qualtran.bloqs.util_bloqs import ArbitraryClifford
+from qualtran.cirq_interop.t_complexity_protocol import t_complexity, TComplexity
 from qualtran.testing import assert_valid_bloq_decomposition, execute_notebook
 
 random.seed(12345)
@@ -62,7 +63,8 @@ def test_t_complexity_cswap(n):
 
 @pytest.mark.parametrize("n", [*range(1, 6)])
 def test_t_complexity_cswap_approx(n):
-    cq_testing.assert_decompose_is_consistent_with_t_complexity(CSwapApprox(n))
+    actual = t_complexity(CSwapApprox(n))
+    assert actual == TComplexity(t=4 * n, clifford=22 * n - 1)
 
 
 @pytest.mark.parametrize("n", [*range(2, 6)])


### PR DESCRIPTION
- Part of #905.
- Removed _t_complexity_ calculation and moved to assert since this has a call_graph, the T count can be inferred.