### PR TITLE
Add .gitattributes file to hide proto generated code in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Mark generated protobuf files to be collapsed by default in PRs
+# See: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
+*_pb2.py        linguist-generated=true
+*_pb2.pyi       linguist-generated=true


### PR DESCRIPTION
This will make the changes of the generated code in `*pb2.py` files
to be folded when reviewing PRs.