### PR TITLE
Remove `_t_complexity_` on `MultiAnd` and support symbolic `cvs`

### DIFF
--- a/qualtran/bloqs/mcmt/and_bloq.py
+++ b/qualtran/bloqs/mcmt/and_bloq.py
@@ -355,7 +355,7 @@ class MultiAnd(Bloq):
         pre_post_cliffords = set()
         if not (
             is_symbolic(self.cvs)
-            or is_symbolic(*self.cvs)
+            or is_symbolic(*self.control_values)
             or (self.bitsize == sum(self.control_values))
         ):
             pre_post_cliffords = {(XGate(), 2 * (self.bitsize - sum(self.control_values)))}

--- a/qualtran/bloqs/mcmt/and_bloq.py
+++ b/qualtran/bloqs/mcmt/and_bloq.py
@@ -21,21 +21,10 @@ means that a bit value of '1' is logical true for the and operation. A control v
 The `Toffoli` bloq is similar to the `And` bloq. Toffoli will flip the target bit according
 to the and of its control registers. `And` will output the result into a fresh register.
 """
-
 import itertools
+import numbers
 from functools import cached_property
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    TYPE_CHECKING,
-    Union,
-)
+from typing import Any, Dict, Iterable, Iterator, Optional, Set, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import cirq
@@ -56,7 +45,7 @@ from qualtran import (
     Signature,
     Soquet,
 )
-from qualtran.bloqs.basic_gates import TGate
+from qualtran.bloqs.basic_gates import TGate, XGate
 from qualtran.bloqs.bookkeeping import ArbitraryClifford
 from qualtran.cirq_interop import decompose_from_cirq_style_method
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
@@ -70,6 +59,7 @@ from qualtran.resource_counting.generalizers import (
     ignore_cliffords,
 )
 from qualtran.simulation.classical_sim import ClassicalValT
+from qualtran.symbolics import is_symbolic, Length, SymbolicInt
 
 if TYPE_CHECKING:
     import quimb.tensor as qtn
@@ -249,7 +239,13 @@ _AND_DOC = BloqDocSpec(
 )
 
 
-def _to_tuple(x: Iterable[Union[int, sympy.Expr]]) -> Sequence[Union[int, sympy.Expr]]:
+def _to_tuple(
+    x: Union[SymbolicInt, Iterable[SymbolicInt]]
+) -> Union[Length, Tuple[SymbolicInt, ...]]:
+    if isinstance(x, sympy.Expr):
+        return Length(x)
+    if isinstance(x, (numbers.Integral, int)):
+        return (1,) * x
     return tuple(x)
 
 
@@ -260,6 +256,8 @@ class MultiAnd(Bloq):
     Args:
         cvs: A tuple of control variable settings. Each entry specifies whether that
             control line is a "positive" control (`cv[i]=1`) or a "negative" control `0`.
+            If a (symbolic) integer is passed, assumes the control values to be all 1's.
+
 
     Registers:
         ctrl: An n-bit control register.
@@ -267,19 +265,29 @@ class MultiAnd(Bloq):
         target [right]: The output bit.
     """
 
-    cvs: Tuple[Union[int, sympy.Expr], ...] = field(converter=_to_tuple)
+    cvs: Union[Length, Tuple[SymbolicInt, ...]] = field(converter=_to_tuple)
 
     @cvs.validator
     def _validate_cvs(self, field, val):
-        if len(val) < 3:
+        if not is_symbolic(val) and len(val) < 3:
             raise ValueError("MultiAnd must have at least 3 control values `cvs`.")
+
+    @property
+    def bitsize(self) -> SymbolicInt:
+        return self.cvs.bitsize if isinstance(self.cvs, Length) else len(self.cvs)
+
+    @property
+    def control_values(self) -> Tuple[SymbolicInt, ...]:
+        if isinstance(self.cvs, Length):
+            raise ValueError(f"{self.cvs} is symbolic")
+        return self.cvs
 
     @cached_property
     def signature(self) -> Signature:
         return Signature(
             [
-                Register('ctrl', QBit(), shape=(len(self.cvs),)),
-                Register('junk', QBit(), shape=(len(self.cvs) - 2,), side=Side.RIGHT),
+                Register('ctrl', QBit(), shape=(self.bitsize,)),
+                Register('junk', QBit(), shape=(self.bitsize - 2,), side=Side.RIGHT),
                 Register('target', QBit(), side=Side.RIGHT),
             ]
         )
@@ -301,7 +309,7 @@ class MultiAnd(Bloq):
     def _decompose_via_tree(
         self,
         controls: NDArray[cirq.Qid],
-        control_values: Tuple[Union[int, sympy.Expr], ...],
+        control_values: Tuple[SymbolicInt, ...],
         ancillas: NDArray[cirq.Qid],
         target: cirq.Qid,
     ) -> cirq.ops.op_tree.OpTree:
@@ -325,25 +333,16 @@ class MultiAnd(Bloq):
             quregs.get('junk', np.array([])).flatten(),
             quregs['target'].flatten(),
         )
-        yield self._decompose_via_tree(control, self.cvs, ancilla, *target)
+        yield self._decompose_via_tree(control, self.control_values, ancilla, *target)
 
     def decompose_bloq(self) -> 'CompositeBloq':
         return decompose_from_cirq_style_method(self)
-
-    def _t_complexity_(self, adjoint: bool = False) -> TComplexity:
-        pre_post_cliffords = len(self.cvs) - sum(self.cvs)  # number of zeros in self.cv
-        num_single_and = len(self.cvs) - 1
-        if adjoint:
-            return TComplexity(clifford=4 * num_single_and + 2 * pre_post_cliffords)
-        return TComplexity(
-            t=4 * num_single_and, clifford=9 * num_single_and + 2 * pre_post_cliffords
-        )
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         if reg is None:
             return Text('And')
         if reg.name == 'ctrl':
-            return Circle(filled=self.cvs[idx[0]] == 1)
+            return Circle(filled=self.control_values[idx[0]] == 1)
         if reg.name == 'target':
             return directional_text_box('∧', side=reg.side)
         if len(idx) > 0:
@@ -353,13 +352,29 @@ class MultiAnd(Bloq):
         return directional_text_box(text=pretty_text, side=reg.side)
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(And(), len(self.cvs) - 1)}
+        pre_post_cliffords = set()
+        if not (
+            is_symbolic(self.cvs)
+            or is_symbolic(*self.cvs)
+            or (self.bitsize == sum(self.control_values))
+        ):
+            pre_post_cliffords = {(XGate(), 2 * (self.bitsize - sum(self.control_values)))}
+
+        return {(And(), self.bitsize - 1)} | pre_post_cliffords
 
 
 @bloq_example(generalizer=(ignore_cliffords, generalize_cvs))
 def _multi_and() -> MultiAnd:
     multi_and = MultiAnd(cvs=(1, 0, 1, 0, 1, 0))
     return multi_and
+
+
+@bloq_example
+def _multi_and_symb() -> MultiAnd:
+    import sympy
+
+    multi_and_symb = MultiAnd(cvs=sympy.Symbol("n"))
+    return multi_and_symb
 
 
 _MULTI_AND_DOC = BloqDocSpec(

--- a/qualtran/bloqs/mcmt/and_bloq_test.py
+++ b/qualtran/bloqs/mcmt/and_bloq_test.py
@@ -271,7 +271,7 @@ def test_multi_and_t_complexity(gate):
         pre_post_cliffords = len(gate.concrete_cvs) - sum(
             gate.concrete_cvs
         )  # number of zeros in self.cv
-        num_single_and = len(gate.cvs) - 1
+        num_single_and = len(gate.concrete_cvs) - 1
         if adjoint:
             return TComplexity(clifford=4 * num_single_and + 2 * pre_post_cliffords)
         return TComplexity(

--- a/qualtran/bloqs/mcmt/and_bloq_test.py
+++ b/qualtran/bloqs/mcmt/and_bloq_test.py
@@ -24,7 +24,8 @@ from attrs import frozen
 import qualtran.testing as qlt_testing
 from qualtran import Bloq, BloqBuilder, Signature, Soquet, SoquetT
 from qualtran.bloqs.basic_gates import OneEffect, OneState, ZeroEffect, ZeroState
-from qualtran.bloqs.mcmt.and_bloq import _and_bloq, _multi_and, And, MultiAnd
+from qualtran.bloqs.mcmt.and_bloq import _and_bloq, _multi_and, _multi_and_symb, And, MultiAnd
+from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, get_musical_score_data
 
 
@@ -34,6 +35,12 @@ def test_and_bloq(bloq_autotester):
 
 def test_multi_and(bloq_autotester):
     bloq_autotester(_multi_and)
+
+
+def test_multi_and_symb():
+    # bloq-autotester will fail since `shape` cannot be symbolic right now.
+    bloq = _multi_and_symb.make()
+    assert bloq.t_complexity().t == 4 * bloq.bitsize - 4
 
 
 def _iter_and_truth_table(cv1: int, cv2: int):
@@ -253,3 +260,20 @@ def test_multiand_diagram():
       │
 4: ───∧─────────""",
     )
+
+
+@pytest.mark.parametrize('gate', [MultiAnd(cvs=[0] * 10), MultiAnd(cvs=[1, 0] * 10), MultiAnd(10)])
+def test_multi_and_t_complexity(gate):
+    def expected_complexity(gate: MultiAnd, adjoint: bool = False) -> TComplexity:
+        pre_post_cliffords = len(gate.control_values) - sum(
+            gate.control_values
+        )  # number of zeros in self.cv
+        num_single_and = len(gate.cvs) - 1
+        if adjoint:
+            return TComplexity(clifford=4 * num_single_and + 2 * pre_post_cliffords)
+        return TComplexity(
+            t=4 * num_single_and, clifford=9 * num_single_and + 2 * pre_post_cliffords
+        )
+
+    assert gate.t_complexity() == expected_complexity(gate)
+    assert gate.adjoint().t_complexity() == expected_complexity(gate, adjoint=True)

--- a/qualtran/bloqs/mcmt/and_bloq_test.py
+++ b/qualtran/bloqs/mcmt/and_bloq_test.py
@@ -27,6 +27,7 @@ from qualtran.bloqs.basic_gates import OneEffect, OneState, ZeroEffect, ZeroStat
 from qualtran.bloqs.mcmt.and_bloq import _and_bloq, _multi_and, _multi_and_symb, And, MultiAnd
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, get_musical_score_data
+from qualtran.symbolics.types import HasLength
 
 
 def test_and_bloq(bloq_autotester):
@@ -40,7 +41,7 @@ def test_multi_and(bloq_autotester):
 def test_multi_and_symb():
     # bloq-autotester will fail since `shape` cannot be symbolic right now.
     bloq = _multi_and_symb.make()
-    assert bloq.t_complexity().t == 4 * bloq.bitsize - 4
+    assert bloq.t_complexity().t == 4 * bloq.n_ctrls - 4
 
 
 def _iter_and_truth_table(cv1: int, cv2: int):
@@ -262,11 +263,13 @@ def test_multiand_diagram():
     )
 
 
-@pytest.mark.parametrize('gate', [MultiAnd(cvs=[0] * 10), MultiAnd(cvs=[1, 0] * 10), MultiAnd(10)])
+@pytest.mark.parametrize(
+    'gate', [MultiAnd(cvs=[0] * 10), MultiAnd(cvs=[1, 0] * 10), MultiAnd(cvs=HasLength(10))]
+)
 def test_multi_and_t_complexity(gate):
     def expected_complexity(gate: MultiAnd, adjoint: bool = False) -> TComplexity:
-        pre_post_cliffords = len(gate.control_values) - sum(
-            gate.control_values
+        pre_post_cliffords = len(gate.concrete_cvs) - sum(
+            gate.concrete_cvs
         )  # number of zeros in self.cv
         num_single_and = len(gate.cvs) - 1
         if adjoint:

--- a/qualtran/resource_counting/generalizers.py
+++ b/qualtran/resource_counting/generalizers.py
@@ -25,6 +25,7 @@ import attrs
 import sympy
 
 from qualtran import Adjoint, Bloq
+from qualtran.symbolics import HasLength
 
 PHI = sympy.Symbol(r'\phi')
 CV = sympy.Symbol("cv")
@@ -72,7 +73,7 @@ def generalize_cvs(b: Bloq) -> Optional[Bloq]:
     if isinstance(b, And):
         return attrs.evolve(b, cv1=CV, cv2=CV)
     if isinstance(b, MultiAnd):
-        return attrs.evolve(b, cvs=(CV,) * len(b.cvs))
+        return attrs.evolve(b, cvs=HasLength(b.n_ctrls))
 
     return b
 

--- a/qualtran/resource_counting/generalizers_test.py
+++ b/qualtran/resource_counting/generalizers_test.py
@@ -113,7 +113,7 @@ def test_generalize_cvs():
         Join(QAny(bitsize=5)),
         TwoBitSwap(),
         And(CV, CV),  # changed
-        MultiAnd((CV,) * 4),  # changed
+        MultiAnd((1,) * 4),  # changed
         Rx(0.123),
         Allocate(QAny(bitsize=5)),
         Free(QAny(bitsize=5)),
@@ -180,7 +180,7 @@ def test_many_generalizers():
         # Join(QAny(n=5)),
         # TwoBitSwap(),
         And(CV, CV),
-        MultiAnd((CV,) * 4),
+        MultiAnd((1,) * 4),  # changed
         Rx(PHI),
         # Allocate(QAny(n=5)),
         # Free(QAny(n=5)),

--- a/qualtran/symbolics/__init__.py
+++ b/qualtran/symbolics/__init__.py
@@ -30,6 +30,7 @@ from qualtran.symbolics.math_funcs import (
 )
 from qualtran.symbolics.types import (
     is_symbolic,
+    Length,
     Shaped,
     SymbolicComplex,
     SymbolicFloat,

--- a/qualtran/symbolics/__init__.py
+++ b/qualtran/symbolics/__init__.py
@@ -29,8 +29,8 @@ from qualtran.symbolics.math_funcs import (
     smin,
 )
 from qualtran.symbolics.types import (
+    HasLength,
     is_symbolic,
-    Length,
     Shaped,
     SymbolicComplex,
     SymbolicFloat,

--- a/qualtran/symbolics/types.py
+++ b/qualtran/symbolics/types.py
@@ -46,6 +46,19 @@ class Shaped:
         return True
 
 
+@frozen
+class Length:
+    """Symbolic value for an object that has a length."""
+
+    bitsize: SymbolicInt
+
+    def is_symbolic(self):
+        return True
+
+    def __len__(self):
+        return self.bitsize
+
+
 def is_symbolic(*args) -> bool:
     """Returns whether the inputs contain any symbolic object.
 

--- a/qualtran/symbolics/types.py
+++ b/qualtran/symbolics/types.py
@@ -47,16 +47,20 @@ class Shaped:
 
 
 @frozen
-class Length:
-    """Symbolic value for an object that has a length."""
+class HasLength:
+    """Symbolic value for an object that has a length.
 
-    bitsize: SymbolicInt
+
+    Note that we cannot override __len__ and return a sympy symbol because Python has
+    special treatment for __len__ and expects you to return a non-negative integers.
+
+    See https://docs.python.org/3/reference/datamodel.html#object.__len__ for more details.
+    """
+
+    n: SymbolicInt
 
     def is_symbolic(self):
         return True
-
-    def __len__(self):
-        return self.bitsize
 
 
 def is_symbolic(*args) -> bool:


### PR DESCRIPTION
Part of a larger effort to better support symbolic resource estimation across bloqs. I will update the `cvs` parameter on other bloqs in follow-up PRs. 

