### PR TITLE
Symbolic bloq counts for `StatePreparationViaAliasSampling`

### DIFF
--- a/qualtran/bloqs/mcmt/and_bloq.ipynb
+++ b/qualtran/bloqs/mcmt/and_bloq.ipynb
@@ -154,7 +154,7 @@
     "A many-bit (multi-control) 'and' operation.\n",
     "\n",
     "#### Parameters\n",
-    " - `cvs`: A tuple of control variable settings. Each entry specifies whether that control line is a \"positive\" control (`cv[i]=1`) or a \"negative\" control `0`. \n",
+    " - `cvs`: A tuple of control variable settings. Each entry specifies whether that control line is a \"positive\" control (`cv[i]=1`) or a \"negative\" control `0`. If a HasLength object is passed, assumes the control values to be all 1's.  \n",
     "\n",
     "#### Registers\n",
     " - `ctrl`: An n-bit control register.\n",

--- a/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
+++ b/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Any, Dict, Iterator, Set, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Iterator, Set, Tuple, TYPE_CHECKING, Union
 
 import cirq
 import numpy as np
@@ -34,14 +34,14 @@ from qualtran import (
     SoquetT,
 )
 from qualtran.bloqs.basic_gates import CNOT, Toffoli, XGate
-from qualtran.bloqs.mcmt.and_bloq import And, MultiAnd
+from qualtran.bloqs.mcmt.and_bloq import _to_tuple_or_has_length, And, is_symbolic, MultiAnd
+from qualtran.symbolics import HasLength, SymbolicInt
 
 if TYPE_CHECKING:
     import quimb.tensor as qtn
 
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
-    from qualtran.symbolics import SymbolicInt
 
 
 @frozen
@@ -122,32 +122,42 @@ class MultiControlPauli(GateWithRegisters):
         [Constructing Large Controlled Nots](https://algassert.com/circuits/2015/06/05/Constructing-Large-Controlled-Nots.html)
     """
 
-    cvs: Tuple[int, ...] = field(converter=lambda v: (v,) if isinstance(v, int) else tuple(v))
+    cvs: Union[HasLength, Tuple[SymbolicInt, ...]] = field(converter=_to_tuple_or_has_length)
     target_gate: cirq.Pauli
 
     @cached_property
     def signature(self) -> 'Signature':
-        ctrl = Register('controls', QBit(), shape=(len(self.cvs),))
+        ctrl = Register('controls', QBit(), shape=(self.n_ctrls,))
         target = Register('target', QBit())
-        return Signature([ctrl, target] if len(self.cvs) > 0 else [target])
+        return Signature([ctrl, target] if self.n_ctrls > 0 else [target])
+
+    @property
+    def n_ctrls(self) -> SymbolicInt:
+        return self.cvs.n if isinstance(self.cvs, HasLength) else len(self.cvs)
+
+    @property
+    def concrete_cvs(self) -> Tuple[SymbolicInt, ...]:
+        if isinstance(self.cvs, HasLength):
+            raise ValueError(f"{self.cvs} is symbolic")
+        return self.cvs
 
     def decompose_from_registers(
         self, *, context: cirq.DecompositionContext, **quregs: NDArray['cirq.Qid']
     ) -> Iterator[cirq.OP_TREE]:
         controls, target = quregs.get('controls', np.array([])), quregs['target']
-        if len(self.cvs) < 2:
+        if len(self.concrete_cvs) < 2:
             controls = controls.flatten()
-            yield [cirq.X(q) for cv, q in zip(self.cvs, controls) if cv == 0]
+            yield [cirq.X(q) for cv, q in zip(self.concrete_cvs, controls) if cv == 0]
             yield self.target_gate.on(*target).controlled_by(*controls)
-            yield [cirq.X(q) for cv, q in zip(self.cvs, controls) if cv == 0]
+            yield [cirq.X(q) for cv, q in zip(self.concrete_cvs, controls) if cv == 0]
             return
         qm = context.qubit_manager
-        and_ancilla, and_target = np.array(qm.qalloc(len(self.cvs) - 2)), qm.qalloc(1)
-        if len(self.cvs) == 2:
-            and_op = And(*self.cvs).on(*controls.flatten(), *and_target)
-            and_op_inv = And(*self.cvs).adjoint()(*controls.flatten(), *and_target)
+        and_ancilla, and_target = np.array(qm.qalloc(len(self.concrete_cvs) - 2)), qm.qalloc(1)
+        if len(self.concrete_cvs) == 2:
+            and_op = And(*self.concrete_cvs).on(*controls.flatten(), *and_target)
+            and_op_inv = And(*self.concrete_cvs).adjoint()(*controls.flatten(), *and_target)
         else:
-            and_op = MultiAnd(self.cvs).on_registers(
+            and_op = MultiAnd(self.concrete_cvs).on_registers(
                 ctrl=controls, junk=and_ancilla[:, np.newaxis], target=and_target
             )
             and_op_inv = and_op**-1  # type: ignore[operator]
@@ -157,12 +167,12 @@ class MultiControlPauli(GateWithRegisters):
         qm.qfree([*and_ancilla, *and_target])
 
     def pretty_name(self) -> str:
-        n = len(self.cvs)
+        n = self.n_ctrls
         ctrl = f'C^{n}' if n > 2 else ['', 'C', 'CC'][n]
         return f'{ctrl}{self.target_gate!s}'
 
     def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
-        wire_symbols = ["@" if b else "@(0)" for b in self.cvs]
+        wire_symbols = ["@" if b else "@(0)" for b in self.concrete_cvs]
         wire_symbols += [str(self.target_gate)]
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
@@ -171,7 +181,7 @@ class MultiControlPauli(GateWithRegisters):
         if self.target_gate not in (cirq.X, XGate()):
             raise NotImplementedError(f"{self} is not classically simulatable.")
 
-        if np.all(self.cvs == controls):
+        if np.all(self.concrete_cvs == controls):
             target = (target + 1) % 2
 
         return {'controls': controls, 'target': target}
@@ -179,21 +189,28 @@ class MultiControlPauli(GateWithRegisters):
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         from qualtran.cirq_interop._cirq_to_bloq import _cirq_gate_to_bloq
 
-        n = len(self.cvs)
+        ret = {(_cirq_gate_to_bloq(self.target_gate.controlled(1)), 1)}
+
+        if is_symbolic(self.n_ctrls):
+            return ret | {(MultiAnd(self.cvs), 1), (MultiAnd(self.cvs).adjoint(), 1)}
+
+        n = self.n_ctrls
         if n >= 2:
-            and_gate = And(self.cvs[0], self.cvs[1]) if n == 2 else MultiAnd(self.cvs)
-            return {
-                (and_gate, 1),
-                (and_gate.adjoint(), 1),
-                (_cirq_gate_to_bloq(self.target_gate.controlled(1)), 1),
-            }
-        n_pre_post_x = 2 * (len(self.cvs) - sum(self.cvs))
+            and_gate = (
+                And(self.concrete_cvs[0], self.concrete_cvs[1])
+                if n == 2
+                else MultiAnd(self.concrete_cvs)
+            )
+            return {(and_gate, 1), (and_gate.adjoint(), 1)}
+        n_pre_post_x = 2 * (len(self.concrete_cvs) - sum(self.concrete_cvs))
         pre_post_graph = {(XGate(), n_pre_post_x)} if n_pre_post_x else set({})
         return {(_cirq_gate_to_bloq(self.target_gate.controlled(n)), 1)} | pre_post_graph
 
     def _apply_unitary_(self, args: 'cirq.ApplyUnitaryArgs') -> np.ndarray:
         cpauli = (
-            self.target_gate.controlled(control_values=self.cvs) if self.cvs else self.target_gate
+            self.target_gate.controlled(control_values=self.concrete_cvs)
+            if self.n_ctrls
+            else self.target_gate
         )
         return cirq.apply_unitary(cpauli, args)
 
@@ -212,7 +229,7 @@ class MultiControlPauli(GateWithRegisters):
         )
 
     def _has_unitary_(self) -> bool:
-        return True
+        return not is_symbolic(self.n_ctrls)
 
 
 @bloq_example

--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.ipynb
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.ipynb
@@ -124,6 +124,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5ada692-3bdb-4776-be94-fe05d5d5a2dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_coeffs, sum_coeff, eps = sympy.symbols(\"L S \\epsilon\")\n",
+    "state_prep_alias_symb = StatePreparationAliasSampling.from_n_coeff(\n",
+    "    n_coeffs, sum_coeff, probability_epsilon=eps\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "75ef3e40",
    "metadata": {
@@ -143,8 +156,8 @@
    "outputs": [],
    "source": [
     "from qualtran.drawing import show_bloqs\n",
-    "show_bloqs([state_prep_alias],\n",
-    "           ['`state_prep_alias`'])"
+    "show_bloqs([state_prep_alias, state_prep_alias_symb],\n",
+    "           ['`state_prep_alias`', '`state_prep_alias_symb`'])"
    ]
   },
   {
@@ -171,16 +184,47 @@
     "show_call_graph(state_prep_alias_g)\n",
     "show_counts_sigma(state_prep_alias_sigma)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8eb266e",
+   "metadata": {
+    "cq.autogen": "StatePreparationAliasSampling.state_prep_alias_symb"
+   },
+   "outputs": [],
+   "source": [
+    "state_prep_alias_symb_g, state_prep_alias_symb_sigma = state_prep_alias_symb.call_graph()\n",
+    "show_call_graph(state_prep_alias_symb_g)\n",
+    "show_counts_sigma(state_prep_alias_symb_sigma)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0283736-2ddc-4fef-9554-343ff8457a41",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
@@ -148,7 +148,7 @@ class StatePreparationAliasSampling(PrepareOracle):
                 for more information.
         """
         mu = sub_bit_prec_from_epsilon(n_coeff, probability_epsilon)
-        selection_bitsize = bit_length(n_coeff - 1)
+        selection_bitsize = bit_length(n_coeff)
         alt, keep = Shaped((n_coeff,)), Shaped((n_coeff,))
         return StatePreparationAliasSampling(
             selection_registers=Register('selection', BoundedQUInt(selection_bitsize, n_coeff)),

--- a/qualtran/bloqs/state_preparation/state_preparation_via_rotation.ipynb
+++ b/qualtran/bloqs/state_preparation/state_preparation_via_rotation.ipynb
@@ -213,7 +213,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -227,7 +227,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/qualtran/bloqs/state_preparation/state_preparation_via_rotation.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_via_rotation.py
@@ -73,7 +73,8 @@ References:
 
 """
 
-from typing import cast, Dict, Iterable, List, Sequence, Tuple
+from collections import defaultdict
+from typing import cast, Dict, Iterable, List, Sequence, Set, Tuple, Union
 
 import attrs
 import numpy as np
@@ -92,7 +93,9 @@ from qualtran import (
 from qualtran.bloqs.basic_gates import XGate
 from qualtran.bloqs.basic_gates.rotation import Rx
 from qualtran.bloqs.data_loading.qrom import QROM
+from qualtran.bloqs.mcmt.and_bloq import _to_tuple_or_has_length
 from qualtran.bloqs.rotations.phase_gradient import AddIntoPhaseGrad
+from qualtran.symbolics import bit_length, HasLength, is_symbolic, Shaped, slen, SymbolicInt
 
 
 def _to_tuple(x: Iterable[complex]) -> Sequence[complex]:
@@ -124,24 +127,28 @@ class StatePreparationViaRotations(GateWithRegisters):
         Low, Kliuchnikov, Schaeffer. 2018.
     """
 
+    state_coefficients: Union[HasLength, Tuple[complex, ...]] = attrs.field(
+        converter=_to_tuple_or_has_length
+    )
     phase_bitsize: int
-    state_coefficients: Tuple[complex, ...] = attrs.field(converter=_to_tuple)
     control_bitsize: int = 0
     uncompute: bool = False
 
     def __attrs_post_init__(self):
-        # a valid quantum state has a number of coefficients that is a power of two
-        assert len(self.state_coefficients) == 2**self.state_bitsize
-        # negative number of control bits is not allowed
-        assert self.control_bitsize >= 0
-        # the register to which the angle is written must be at least of size two
-        assert self.phase_bitsize > 1
-        # a valid quantum state must have norm one
-        assert np.isclose(np.linalg.norm(self.state_coefficients), 1)
+        if not is_symbolic(self.state_coefficients):
+            # a valid quantum state has a number of coefficients that is a power of two
+            assert slen(self.state_coefficients) == 2**self.state_bitsize
+            # negative number of control bits is not allowed
+            assert self.control_bitsize >= 0
+            # the register to which the angle is written must be at least of size two
+            assert self.phase_bitsize > 1
+            # a valid quantum state must have norm one
+            assert np.isclose(np.linalg.norm(self.state_coefficients), 1)
 
     @property
     def state_bitsize(self) -> int:
-        return (len(self.state_coefficients) - 1).bit_length()
+        L = slen(self.state_coefficients)
+        return bit_length(L) if is_symbolic(L) else (L - 1).bit_length()
 
     @property
     def signature(self) -> Signature:
@@ -151,43 +158,82 @@ class StatePreparationViaRotations(GateWithRegisters):
             phase_gradient=self.phase_bitsize,
         )
 
+    @property
+    def rotation_tree(self) -> 'RotationTree':
+        return RotationTree(np.asarray(self.state_coefficients), self.phase_bitsize, self.uncompute)
+
+    @property
+    def prga_prepare_amplitude(self) -> List['PRGAViaPhaseGradient']:
+        if is_symbolic(self.state_coefficients):
+            return [
+                PRGAViaPhaseGradient(
+                    self.state_bitsize,
+                    self.phase_bitsize,
+                    Shaped((self.state_coefficients.n,)),
+                    self.control_bitsize + 1,
+                )
+            ]
+        ret = []
+        ampl_rv, _ = self.rotation_tree.get_rom_vals()
+        for qi in range(self.state_bitsize):
+            ctrl_rot_q = PRGAViaPhaseGradient(
+                qi, self.phase_bitsize, tuple(ampl_rv[qi]), self.control_bitsize + 1
+            )
+            ret.append(ctrl_rot_q)
+        return ret
+
+    @property
+    def prga_prepare_phases(self) -> 'PRGAViaPhaseGradient':
+        data_or_shape = (
+            Shaped((self.state_coefficients.n,))
+            if isinstance(self.state_coefficients, HasLength)
+            else tuple(self.rotation_tree.get_rom_vals()[1])
+        )
+        return PRGAViaPhaseGradient(
+            self.state_bitsize, self.phase_bitsize, data_or_shape, self.control_bitsize + 1
+        )
+
     def build_composite_bloq(self, bb: BloqBuilder, **soqs: SoquetT) -> Dict[str, SoquetT]:
         r"""Parameters:
         * prepare_control: only if control_bitsize != 0
         * target_state: register where the state is written
         * phase_gradient: phase gradient state (will be left unaffected)
         """
-        rotation_tree = RotationTree(
-            np.asarray(self.state_coefficients), self.phase_bitsize, self.uncompute
-        )
-        ampl_rv, phase_rv = rotation_tree.get_rom_vals()
         if self.uncompute:
-            soqs = self._prepare_phases(phase_rv, bb, **soqs)
-            soqs = self._prepare_amplitudes(ampl_rv, bb, **soqs)
+            soqs = self._prepare_phases(bb, **soqs)
+            soqs = self._prepare_amplitudes(bb, **soqs)
         else:
-            soqs = self._prepare_amplitudes(ampl_rv, bb, **soqs)
-            soqs = self._prepare_phases(phase_rv, bb, **soqs)
+            soqs = self._prepare_amplitudes(bb, **soqs)
+            soqs = self._prepare_phases(bb, **soqs)
         return soqs
 
-    def _prepare_amplitudes(
-        self, rom_vals: List[List[int]], bb: BloqBuilder, **soqs: SoquetT
-    ) -> Dict[str, SoquetT]:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+        ret = defaultdict(lambda: 0)
+        ret |= {
+            Rx(angle=-np.pi / 2): self.state_bitsize,
+            Rx(angle=np.pi / 2): self.state_bitsize,
+            XGate(): 2,
+            self.prga_prepare_phases: 1,
+        }
+        for bloq in self.prga_prepare_amplitude:
+            ret[bloq] += 1
+        return set(ret.items())
+
+    def _prepare_amplitudes(self, bb: BloqBuilder, **soqs: SoquetT) -> Dict[str, SoquetT]:
         r"""Parameters into soqs:
         * prepare_control: only if control_bitsize != 0
         * target_state: register where the state is written
         * phase_gradient: phase gradient state (will be left unaffected)
         """
         state_qubits = bb.split(cast(Soquet, soqs.pop("target_state")))
-        for i in range(self.state_bitsize):
+        ctrl_rot_bloqs = (
+            reversed(list(enumerate(self.prga_prepare_amplitude)))
+            if self.uncompute
+            else enumerate(self.prga_prepare_amplitude)
+        )
+        for qi, ctrl_rot_q in ctrl_rot_bloqs:
             # for the normal gate loop from qubit 0 to state_bitsizes-1, if it is the adjoint
             # then the process is run backwards with the opposite turn angles
-            if self.uncompute:
-                qi = self.state_bitsize - i - 1
-            else:
-                qi = i
-            ctrl_rot_q = PRGAViaPhaseGradient(
-                qi, self.phase_bitsize, tuple(rom_vals[qi]), self.control_bitsize + 1
-            )
             state_qubits[qi] = bb.add(Rx(angle=np.pi / 2), q=state_qubits[qi])
             if qi:
                 # first qubit does not have selection registers, only controls
@@ -214,9 +260,7 @@ class StatePreparationViaRotations(GateWithRegisters):
         soqs["target_state"] = bb.join(state_qubits)
         return soqs
 
-    def _prepare_phases(
-        self, rom_vals: List[int], bb: BloqBuilder, **soqs: SoquetT
-    ) -> Dict[str, SoquetT]:
+    def _prepare_phases(self, bb: BloqBuilder, **soqs: SoquetT) -> Dict[str, SoquetT]:
         """Encodes the phase of each coefficient.
 
         Takes into account both the phase of the original coefficient and offsets caused by the
@@ -247,9 +291,7 @@ class StatePreparationViaRotations(GateWithRegisters):
             soqs["control"] = bb.join(np.array([soqs.pop("prepare_control"), rot_ancilla]))
         else:
             soqs["control"] = rot_ancilla
-        ctrl_rot = PRGAViaPhaseGradient(
-            self.state_bitsize, self.phase_bitsize, tuple(rom_vals), self.control_bitsize + 1
-        )
+        ctrl_rot = self.prga_prepare_phases
         # rename some registers to make them compatible with PRGAViaPhaseGradient
         soqs["selection"] = soqs.pop("target_state")
         soqs = bb.add_d(ctrl_rot, **soqs)
@@ -310,10 +352,10 @@ class PRGAViaPhaseGradient(Bloq):
         Low, Kliuchnikov, Schaeffer. 2018.
     """
 
-    selection_bitsize: int
-    phase_bitsize: int
-    rom_values: Tuple[int, ...]
-    control_bitsize: int
+    selection_bitsize: SymbolicInt
+    phase_bitsize: SymbolicInt
+    rom_values: Union[Shaped, Tuple[int, ...]]
+    control_bitsize: SymbolicInt
 
     @property
     def signature(self) -> Signature:
@@ -323,35 +365,52 @@ class PRGAViaPhaseGradient(Bloq):
             phase_gradient=self.phase_bitsize,
         )
 
+    @property
+    def qrom_bloq(self) -> QROM:
+        return QROM(
+            (self.rom_values,),
+            selection_bitsizes=(self.selection_bitsize,),
+            target_bitsizes=(self.phase_bitsize,),
+            num_controls=self.control_bitsize,
+        )
+
+    @property
+    def add_into_phase_grad(self) -> AddIntoPhaseGrad:
+        return AddIntoPhaseGrad(self.phase_bitsize, self.phase_bitsize)
+
     def build_composite_bloq(self, bb: BloqBuilder, **soqs: SoquetT) -> Dict[str, SoquetT]:
         """Parameters:
         * control
         * selection (not necessary if selection_bitsize == 0)
         * phase_gradient
         """
-        qrom = QROM(
-            [np.array(self.rom_values)],
-            selection_bitsizes=(self.selection_bitsize,),
-            target_bitsizes=(self.phase_bitsize,),
-            num_controls=self.control_bitsize,
-        )
         # allocate a register to store the rotation angle
         soqs["target0_"] = bb.allocate(self.phase_bitsize)
         phase_grad = soqs.pop("phase_gradient")
         # load angles in rot_reg (line 1 of eq (8) in [1])
-        soqs = bb.add_d(qrom, **soqs)
+        soqs = bb.add_d(self.qrom_bloq, **soqs)
         # phase kickback via phase_grad += rot_reg (line 2 of eq (8) in [1])
         soqs["target0_"], phase_grad = bb.add(
-            AddIntoPhaseGrad(self.phase_bitsize, self.phase_bitsize),
-            x=soqs["target0_"],
-            phase_grad=phase_grad,
+            self.add_into_phase_grad, x=soqs["target0_"], phase_grad=phase_grad
         )
         # uncompute angle load in rot_reg to disentangle it from selection register
         # (line 1 of eq (8) in [1])
-        soqs = bb.add_d(qrom, **soqs)
+        soqs = bb.add_d(self.qrom_bloq.adjoint(), **soqs)
         soqs["phase_gradient"] = phase_grad
         bb.free(cast(Soquet, soqs.pop("target0_")))
         return soqs
+
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+        return {(self.qrom_bloq, 1), (self.qrom_bloq.adjoint(), 1), (self.add_into_phase_grad, 1)}
+
+    def __repr__(self):
+        return (
+            f'PRGAViaPhaseGradient('
+            f'selection_bitsize={self.selection_bitsize}, '
+            f'phase_bitsize={self.phase_bitsize}, '
+            f'num_rom_values={slen(self.rom_values)}, '
+            f'control_bitsize={self.control_bitsize}, )'
+        )
 
 
 class RotationTree:

--- a/qualtran/linalg/lcu_util.py
+++ b/qualtran/linalg/lcu_util.py
@@ -158,7 +158,7 @@ def sub_bit_prec_from_epsilon(n: SymbolicInt, epsilon: SymbolicFloat) -> Symboli
 
 
 def sub_bit_prec_from_epsilon(n: SymbolicInt, epsilon: SymbolicFloat) -> SymbolicInt:
-    ret = ceil(-log2(epsilon * n))
+    ret = ceil(log2(1 / (n * epsilon)))
     return ret if is_symbolic(ret) else max(0, ret)
 
 

--- a/qualtran/linalg/lcu_util.py
+++ b/qualtran/linalg/lcu_util.py
@@ -158,7 +158,7 @@ def sub_bit_prec_from_epsilon(n: SymbolicInt, epsilon: SymbolicFloat) -> Symboli
 
 
 def sub_bit_prec_from_epsilon(n: SymbolicInt, epsilon: SymbolicFloat) -> SymbolicInt:
-    ret = ceil(log2(1 / (n * epsilon)))
+    ret = ceil(log2(n / (epsilon)))
     return ret if is_symbolic(ret) else max(0, ret)
 
 

--- a/qualtran/symbolics/math_funcs.py
+++ b/qualtran/symbolics/math_funcs.py
@@ -17,6 +17,7 @@ import numpy as np
 import sympy
 
 from qualtran.symbolics.types import (
+    HasLength,
     is_symbolic,
     Shaped,
     SymbolicComplex,
@@ -102,6 +103,8 @@ def sconj(x: SymbolicComplex) -> SymbolicComplex:
 def slen(x: Union[Sized, Shaped]) -> SymbolicInt:
     if isinstance(x, Shaped):
         return x.shape[0]
+    if isinstance(x, HasLength):
+        return x.n
     return len(x)
 
 


### PR DESCRIPTION
<img width="583" alt="image" src="https://github.com/quantumlib/Qualtran/assets/7863287/3a00bbba-e69a-4ed9-8636-a9937ba57dc3">

<img width="587" alt="image" src="https://github.com/quantumlib/Qualtran/assets/7863287/cd2b8868-4d13-4854-a5fd-26c6fad55726">


Also added symbolic anlaysis for state prep via rotations

<img width="462" alt="image" src="https://github.com/quantumlib/Qualtran/assets/7863287/15b92857-91e1-4bd6-8661-df23f68877b2">


I'll pull out incremental changes into smaller PRs so they are easier to review. 
