### PR TITLE
Update cirq version to latest stable release of 1.4

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -4,7 +4,7 @@ cachetools>=5.3
 networkx
 numpy
 sympy
-cirq-core==1.4.0.dev20240430031656
+cirq-core==1.4
 fxpmath
 
 # qualtran/testing.py

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -10,11 +10,11 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 alabaster==0.7.16
     # via sphinx
-anyio==4.3.0
+anyio==4.4.0
     # via
     #   httpx
     #   jupyter-server
-anywidget==0.9.10
+anywidget==0.9.12
     # via qsharp-widgets
 argon2-cffi==23.1.0
     # via jupyter-server
@@ -41,7 +41,7 @@ attrs==23.2.0
     #   jsonschema
     #   jupyter-cache
     #   referencing
-autoray==0.6.9
+autoray==0.6.12
     # via
     #   cotengra
     #   quimb
@@ -50,7 +50,7 @@ babel==2.15.0
     #   jupyterlab-server
     #   pydata-sphinx-theme
     #   sphinx
-backports-tarfile==1.1.1
+backports-tarfile==1.2.0
     # via jaraco-context
 beautifulsoup4==4.12.3
     # via
@@ -77,7 +77,7 @@ cffi==1.16.0
     #   cryptography
 charset-normalizer==3.3.2
     # via requests
-cirq-core==1.4.0.dev20240430031656
+cirq-core==1.4.0
     # via
     #   -r deps/runtime.txt
     #   openfermion
@@ -93,9 +93,9 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.2.1
     # via matplotlib
-cotengra==0.6.0
+cotengra==0.6.2
     # via quimb
-coverage[toml]==7.5.1
+coverage[toml]==7.5.3
     # via pytest-cov
 cryptography==42.0.7
     # via secretstorage
@@ -151,7 +151,7 @@ flask==3.0.3
     # via dash
 flynt==0.78
     # via -r deps/format.txt
-fonttools==4.51.0
+fonttools==4.52.4
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
@@ -159,9 +159,9 @@ fxpmath==0.4.9
     # via -r deps/runtime.txt
 greenlet==3.0.3
     # via sqlalchemy
-grpcio==1.63.0
+grpcio==1.64.0
     # via grpcio-tools
-grpcio-tools==1.63.0
+grpcio-tools==1.64.0
     # via -r deps/packaging.txt
 h11==0.14.0
     # via httpcore
@@ -201,7 +201,7 @@ ipython==8.24.0
     #   ipykernel
     #   ipywidgets
     #   myst-nb
-ipywidgets==8.1.2
+ipywidgets==8.1.3
     # via
     #   -r deps/docs.txt
     #   -r deps/runtime.txt
@@ -253,7 +253,7 @@ jsonschema-specifications==2023.12.1
     # via jsonschema
 jupyter-cache==1.0.0
     # via myst-nb
-jupyter-client==8.6.1
+jupyter-client==8.6.2
     # via
     #   ipykernel
     #   jupyter-server
@@ -280,17 +280,17 @@ jupyter-server==2.14.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.1.8
+jupyterlab==4.2.1
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.27.1
+jupyterlab-server==2.27.2
     # via
     #   jupyterlab
     #   notebook
-jupyterlab-widgets==3.0.10
+jupyterlab-widgets==3.0.11
     # via ipywidgets
-keyring==25.2.0
+keyring==25.2.1
     # via twine
 kiwisolver==1.4.5
     # via matplotlib
@@ -308,7 +308,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.8.4
+matplotlib==3.9.0
     # via
     #   -r deps/runtime.txt
     #   ase
@@ -319,7 +319,7 @@ matplotlib-inline==0.1.7
     #   ipython
 mccabe==0.7.0
     # via pylint
-mdit-py-plugins==0.4.0
+mdit-py-plugins==0.4.1
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
@@ -378,7 +378,7 @@ networkx==3.3
     #   openfermion
 nh3==0.2.17
     # via readme-renderer
-notebook==7.1.3
+notebook==7.2.0
     # via -r deps/dev-tools.txt
 notebook-shim==0.2.4
     # via
@@ -443,7 +443,7 @@ pip-tools==7.4.1
     # via -r deps/pip-tools.txt
 pkginfo==1.10.0
     # via twine
-platformdirs==4.2.1
+platformdirs==4.2.2
     # via
     #   black
     #   jupyter-core
@@ -457,9 +457,9 @@ pluggy==1.5.0
     # via pytest
 prometheus-client==0.20.0
     # via jupyter-server
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.45
     # via ipython
-protobuf==5.26.1
+protobuf==5.27.0
     # via
     #   -r deps/runtime.txt
     #   grpcio-tools
@@ -481,7 +481,7 @@ pure-eval==0.2.2
     # via stack-data
 pycparser==2.22
     # via cffi
-pydata-sphinx-theme==0.15.2
+pydata-sphinx-theme==0.15.3
     # via -r deps/docs.txt
 pydot==2.0.0
     # via -r deps/runtime.txt
@@ -506,14 +506,14 @@ pyproject-hooks==1.1.0
     #   pip-tools
 pyscf==2.5.0
     # via openfermion
-pytest==8.2.0
+pytest==8.2.1
     # via
     #   -r deps/pylint.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.6
+pytest-asyncio==0.23.7
     # via -r deps/pytest.txt
 pytest-cov==5.0.0
     # via -r deps/pytest.txt
@@ -541,9 +541,9 @@ pyzmq==26.0.3
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qsharp==1.4.0
+qsharp==1.5.0
     # via -r deps/runtime.txt
-qsharp-widgets==1.4.0
+qsharp-widgets==1.5.0
     # via -r deps/runtime.txt
 quimb==1.8.1
     # via -r deps/runtime.txt
@@ -554,7 +554,7 @@ referencing==0.35.1
     #   jsonschema
     #   jsonschema-specifications
     #   jupyter-events
-requests==2.32.0
+requests==2.32.3
     # via
     #   dash
     #   jupyterlab-server
@@ -582,7 +582,7 @@ rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
-scipy==1.12.0
+scipy==1.13.1
     # via
     #   ase
     #   cirq-core
@@ -635,7 +635,7 @@ sqlalchemy==2.0.30
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
-sympy==1.12
+sympy==1.12.1
     # via
     #   -r deps/runtime.txt
     #   cirq-core
@@ -697,13 +697,13 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-twine==5.0.0
+twine==5.1.0
     # via -r deps/packaging.txt
 types-protobuf==5.26.0.20240422
     # via mypy-protobuf
 types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.11.0
+typing-extensions==4.12.0
     # via
     #   anyio
     #   anywidget
@@ -724,7 +724,7 @@ urllib3==2.2.1
     # via
     #   requests
     #   twine
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via -r deps/packaging.txt
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -744,11 +744,11 @@ wheel==0.43.0
     # via
     #   -r deps/packaging.txt
     #   pip-tools
-widgetsnbextension==4.0.10
+widgetsnbextension==4.0.11
     # via ipywidgets
 wrapt==1.16.0
     # via astroid
-zipp==3.18.1
+zipp==3.19.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -16,7 +16,7 @@ alabaster==0.7.16
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-anywidget==0.9.10
+anywidget==0.9.12
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -36,7 +36,7 @@ attrs==23.2.0
     #   jsonschema
     #   jupyter-cache
     #   referencing
-autoray==0.6.9
+autoray==0.6.12
     # via
     #   -c envs/dev.env.txt
     #   cotengra
@@ -71,7 +71,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.0.dev20240430031656
+cirq-core==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -89,7 +89,7 @@ contourpy==1.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.6.0
+cotengra==0.6.2
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -155,7 +155,7 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.51.0
+fonttools==4.52.4
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -192,7 +192,7 @@ ipython==8.24.0
     #   ipykernel
     #   ipywidgets
     #   myst-nb
-ipywidgets==8.1.2
+ipywidgets==8.1.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
@@ -226,7 +226,7 @@ jupyter-cache==1.0.0
     # via
     #   -c envs/dev.env.txt
     #   myst-nb
-jupyter-client==8.6.1
+jupyter-client==8.6.2
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -243,7 +243,7 @@ jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-jupyterlab-widgets==3.0.10
+jupyterlab-widgets==3.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -266,7 +266,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.8.4
+matplotlib==3.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -276,7 +276,7 @@ matplotlib-inline==0.1.7
     #   -c envs/dev.env.txt
     #   ipykernel
     #   ipython
-mdit-py-plugins==0.4.0
+mdit-py-plugins==0.4.1
     # via
     #   -c envs/dev.env.txt
     #   myst-parser
@@ -376,7 +376,7 @@ pillow==10.3.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.2.1
+platformdirs==4.2.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -385,11 +385,11 @@ plotly==5.22.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   dash
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.45
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.26.1
+protobuf==5.27.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -411,7 +411,7 @@ pure-eval==0.2.2
     # via
     #   -c envs/dev.env.txt
     #   stack-data
-pydata-sphinx-theme==0.15.2
+pydata-sphinx-theme==0.15.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
@@ -454,11 +454,11 @@ pyzmq==26.0.3
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
-qsharp==1.4.0
+qsharp==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.4.0
+qsharp-widgets==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -471,7 +471,7 @@ referencing==0.35.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.0
+requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -485,7 +485,7 @@ rpds-py==0.18.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.12.0
+scipy==1.13.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -548,7 +548,7 @@ stack-data==0.6.3
     # via
     #   -c envs/dev.env.txt
     #   ipython
-sympy==1.12
+sympy==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -600,7 +600,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-typing-extensions==4.11.0
+typing-extensions==4.12.0
     # via
     #   -c envs/dev.env.txt
     #   anywidget
@@ -632,11 +632,11 @@ werkzeug==3.0.3
     #   -c envs/dev.env.txt
     #   dash
     #   flask
-widgetsnbextension==4.0.10
+widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-zipp==3.18.1
+zipp==3.19.0
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/format.env.txt deps/format.txt deps/runtime.txt
 #
-anywidget==0.9.10
+anywidget==0.9.12
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -23,7 +23,7 @@ attrs==23.2.0
     #   cirq-core
     #   jsonschema
     #   referencing
-autoray==0.6.9
+autoray==0.6.12
     # via
     #   -c envs/dev.env.txt
     #   cotengra
@@ -56,7 +56,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.0.dev20240430031656
+cirq-core==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -73,7 +73,7 @@ contourpy==1.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.6.0
+cotengra==0.6.2
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -133,7 +133,7 @@ flynt==0.78
     # via
     #   -c envs/dev.env.txt
     #   -r deps/format.txt
-fonttools==4.51.0
+fonttools==4.52.4
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -154,7 +154,7 @@ ipython==8.24.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   ipywidgets
-ipywidgets==8.1.2
+ipywidgets==8.1.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -184,7 +184,7 @@ jsonschema-specifications==2023.12.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-client==8.6.1
+jupyter-client==8.6.2
     # via
     #   -c envs/dev.env.txt
     #   nbclient
@@ -199,7 +199,7 @@ jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-jupyterlab-widgets==3.0.10
+jupyterlab-widgets==3.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -217,7 +217,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.8.4
+matplotlib==3.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -307,7 +307,7 @@ pillow==10.3.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.2.1
+platformdirs==4.2.2
     # via
     #   -c envs/dev.env.txt
     #   black
@@ -317,11 +317,11 @@ plotly==5.22.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   dash
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.45
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.26.1
+protobuf==5.27.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -369,11 +369,11 @@ pyzmq==26.0.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
-qsharp==1.4.0
+qsharp==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.4.0
+qsharp-widgets==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -386,7 +386,7 @@ referencing==0.35.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.0
+requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -399,7 +399,7 @@ rpds-py==0.18.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.12.0
+scipy==1.13.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -423,7 +423,7 @@ stack-data==0.6.3
     # via
     #   -c envs/dev.env.txt
     #   ipython
-sympy==1.12
+sympy==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -466,7 +466,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-typing-extensions==4.11.0
+typing-extensions==4.12.0
     # via
     #   -c envs/dev.env.txt
     #   anywidget
@@ -495,11 +495,11 @@ werkzeug==3.0.3
     #   -c envs/dev.env.txt
     #   dash
     #   flask
-widgetsnbextension==4.0.10
+widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-zipp==3.18.1
+zipp==3.19.0
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -12,7 +12,7 @@ alabaster==0.7.16
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-anywidget==0.9.10
+anywidget==0.9.12
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -39,7 +39,7 @@ attrs==23.2.0
     #   cirq-core
     #   jsonschema
     #   referencing
-autoray==0.6.9
+autoray==0.6.12
     # via
     #   -c envs/dev.env.txt
     #   cotengra
@@ -72,7 +72,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.0.dev20240430031656
+cirq-core==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -89,7 +89,7 @@ contourpy==1.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.6.0
+cotengra==0.6.2
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -162,7 +162,7 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.51.0
+fonttools==4.52.4
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -196,7 +196,7 @@ ipython==8.24.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   ipywidgets
-ipywidgets==8.1.2
+ipywidgets==8.1.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -236,7 +236,7 @@ jsonschema-specifications==2023.12.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-client==8.6.1
+jupyter-client==8.6.2
     # via
     #   -c envs/dev.env.txt
     #   nbclient
@@ -251,7 +251,7 @@ jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-jupyterlab-widgets==3.0.10
+jupyterlab-widgets==3.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -273,7 +273,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.8.4
+matplotlib==3.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -386,7 +386,7 @@ pillow==10.3.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.2.1
+platformdirs==4.2.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -400,11 +400,11 @@ pluggy==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.45
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.26.1
+protobuf==5.27.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -452,7 +452,7 @@ pyscf==2.5.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-pytest==8.2.0
+pytest==8.2.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
@@ -474,11 +474,11 @@ pyzmq==26.0.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
-qsharp==1.4.0
+qsharp==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.4.0
+qsharp-widgets==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -491,7 +491,7 @@ referencing==0.35.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.0
+requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -506,7 +506,7 @@ rpds-py==0.18.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.12.0
+scipy==1.13.1
     # via
     #   -c envs/dev.env.txt
     #   ase
@@ -567,7 +567,7 @@ stack-data==0.6.3
     # via
     #   -c envs/dev.env.txt
     #   ipython
-sympy==1.12
+sympy==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -620,7 +620,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-typing-extensions==4.11.0
+typing-extensions==4.12.0
     # via
     #   -c envs/dev.env.txt
     #   anywidget
@@ -650,7 +650,7 @@ werkzeug==3.0.3
     #   -c envs/dev.env.txt
     #   dash
     #   flask
-widgetsnbextension==4.0.10
+widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -658,7 +658,7 @@ wrapt==1.16.0
     # via
     #   -c envs/dev.env.txt
     #   astroid
-zipp==3.18.1
+zipp==3.19.0
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/pytest.env.txt deps/pytest.txt deps/runtime.txt
 #
-anywidget==0.9.10
+anywidget==0.9.12
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -23,7 +23,7 @@ attrs==23.2.0
     #   cirq-core
     #   jsonschema
     #   referencing
-autoray==0.6.9
+autoray==0.6.12
     # via
     #   -c envs/dev.env.txt
     #   cotengra
@@ -52,7 +52,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.0.dev20240430031656
+cirq-core==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -70,11 +70,11 @@ contourpy==1.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.6.0
+cotengra==0.6.2
     # via
     #   -c envs/dev.env.txt
     #   quimb
-coverage[toml]==7.5.1
+coverage[toml]==7.5.3
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -147,7 +147,7 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.51.0
+fonttools==4.52.4
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -182,7 +182,7 @@ ipython==8.24.0
     #   -r deps/runtime.txt
     #   ipykernel
     #   ipywidgets
-ipywidgets==8.1.2
+ipywidgets==8.1.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -216,7 +216,7 @@ jsonschema-specifications==2023.12.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-client==8.6.1
+jupyter-client==8.6.2
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -233,7 +233,7 @@ jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-jupyterlab-widgets==3.0.10
+jupyterlab-widgets==3.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -251,7 +251,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.8.4
+matplotlib==3.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -361,7 +361,7 @@ pillow==10.3.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.2.1
+platformdirs==4.2.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -374,11 +374,11 @@ pluggy==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.45
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.26.1
+protobuf==5.27.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -421,14 +421,14 @@ pyscf==2.5.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-pytest==8.2.0
+pytest==8.2.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.23.6
+pytest-asyncio==0.23.7
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -455,11 +455,11 @@ pyzmq==26.0.3
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
-qsharp==1.4.0
+qsharp==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.4.0
+qsharp-widgets==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -472,7 +472,7 @@ referencing==0.35.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.0
+requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -486,7 +486,7 @@ rpds-py==0.18.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.12.0
+scipy==1.13.1
     # via
     #   -c envs/dev.env.txt
     #   ase
@@ -515,7 +515,7 @@ stack-data==0.6.3
     # via
     #   -c envs/dev.env.txt
     #   ipython
-sympy==1.12
+sympy==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -561,7 +561,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-typing-extensions==4.11.0
+typing-extensions==4.12.0
     # via
     #   -c envs/dev.env.txt
     #   anywidget
@@ -590,11 +590,11 @@ werkzeug==3.0.3
     #   -c envs/dev.env.txt
     #   dash
     #   flask
-widgetsnbextension==4.0.10
+widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-zipp==3.18.1
+zipp==3.19.0
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/runtime.env.txt deps/runtime.txt
 #
-anywidget==0.9.10
+anywidget==0.9.12
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -19,7 +19,7 @@ attrs==23.2.0
     #   cirq-core
     #   jsonschema
     #   referencing
-autoray==0.6.9
+autoray==0.6.12
     # via
     #   -c envs/dev.env.txt
     #   cotengra
@@ -48,7 +48,7 @@ charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
     #   requests
-cirq-core==1.4.0.dev20240430031656
+cirq-core==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -64,7 +64,7 @@ contourpy==1.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.6.0
+cotengra==0.6.2
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -120,7 +120,7 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.51.0
+fonttools==4.52.4
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -141,7 +141,7 @@ ipython==8.24.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   ipywidgets
-ipywidgets==8.1.2
+ipywidgets==8.1.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -167,7 +167,7 @@ jsonschema-specifications==2023.12.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-jupyter-client==8.6.1
+jupyter-client==8.6.2
     # via
     #   -c envs/dev.env.txt
     #   nbclient
@@ -182,7 +182,7 @@ jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-jupyterlab-widgets==3.0.10
+jupyterlab-widgets==3.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -200,7 +200,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.8.4
+matplotlib==3.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -282,7 +282,7 @@ pillow==10.3.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.2.1
+platformdirs==4.2.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
@@ -291,11 +291,11 @@ plotly==5.22.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   dash
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.45
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.26.1
+protobuf==5.27.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -343,11 +343,11 @@ pyzmq==26.0.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-client
-qsharp==1.4.0
+qsharp==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.4.0
+qsharp-widgets==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -360,7 +360,7 @@ referencing==0.35.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.0
+requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -373,7 +373,7 @@ rpds-py==0.18.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.12.0
+scipy==1.13.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -397,7 +397,7 @@ stack-data==0.6.3
     # via
     #   -c envs/dev.env.txt
     #   ipython
-sympy==1.12
+sympy==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -435,7 +435,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-typing-extensions==4.11.0
+typing-extensions==4.12.0
     # via
     #   -c envs/dev.env.txt
     #   anywidget
@@ -464,11 +464,11 @@ werkzeug==3.0.3
     #   -c envs/dev.env.txt
     #   dash
     #   flask
-widgetsnbextension==4.0.10
+widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-zipp==3.18.1
+zipp==3.19.0
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata


### PR DESCRIPTION
Cirq release v1.4 last night. This PR updates the cirq dependence to the latest stable release instead of a pre-release version. 