### PR TITLE
Fix SelectSwapQROM error when selection bitsize is 0

### DIFF
--- a/qualtran/bloqs/chemistry/thc/thc.ipynb
+++ b/qualtran/bloqs/chemistry/thc/thc.ipynb
@@ -433,7 +433,7 @@
     "    print(f\"{k+':':20s} qualtran = {binned_counts[k]:5d} vs paper cost = {v:5d}.\")\n",
     "\n",
     "print(f\"Total cost = {sum(v for v in binned_counts.values())}\")\n",
-    "assert binned_counts['data_loading'] == 432"
+    "assert binned_counts['data_loading'] == 304"
    ]
   },
   {

--- a/qualtran/bloqs/data_loading/qrom_base.py
+++ b/qualtran/bloqs/data_loading/qrom_base.py
@@ -269,7 +269,7 @@ class QROMBase(metaclass=abc.ABCMeta):
         types = [
             BoundedQUInt(sb, l)
             for l, sb in zip(self.data_shape, self.selection_bitsizes)
-            if is_symbolic(sb) or sb > 0
+            if is_symbolic(l) or l > 0
         ]
         if len(types) == 1:
             return (Register('selection', types[0]),)

--- a/qualtran/bloqs/data_loading/select_swap_qrom_test.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom_test.py
@@ -36,8 +36,9 @@ from qualtran.testing import assert_valid_bloq_decomposition
             id=f"{block_size}-data{didx}",
             marks=pytest.mark.slow if block_size == 2 and didx == 0 else (),
         )
-        for didx, data in enumerate([[[1, 2, 3, 4, 5]], [[1, 2, 3], [3, 2, 1]]])
+        for didx, data in enumerate([[[1, 2, 3, 4, 5]], [[1, 2, 3], [3, 2, 1]], [[1], [2], [3]]])
         for block_size in [None, 0, 1]
+        if block_size is None or 2**block_size <= len(data[0])
     ],
 )
 def test_select_swap_qrom(data, block_size):
@@ -45,7 +46,7 @@ def test_select_swap_qrom(data, block_size):
     assert_valid_bloq_decomposition(qrom)
 
     qubit_regs = get_named_qubits(qrom.signature)
-    selection = qubit_regs["selection"]
+    selection = qubit_regs.get("selection", ())
     q_len = qrom.batched_qrom_selection_bitsizes[0]
     assert isinstance(q_len, int)
     selection_q, selection_r = (selection[:q_len], selection[q_len:])

--- a/qualtran/bloqs/data_loading/select_swap_qrom_test.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom_test.py
@@ -95,7 +95,6 @@ def test_select_swap_qrom(data, block_size):
 
 def test_qroam_diagram():
     data = [[1, 2, 3], [4, 5, 6]]
-    blocksize = 2
     qrom = SelectSwapQROM.build_from_data(*data, log_block_sizes=(1,))
     q = cirq.LineQubit.range(cirq.num_qubits(qrom))
     circuit = cirq.Circuit(qrom.on_registers(**split_qubits(qrom.signature, q)))

--- a/qualtran/bloqs/state_preparation/state_preparation_via_rotation.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_via_rotation.py
@@ -191,7 +191,6 @@ class StatePreparationViaRotations(GateWithRegisters):
                 qi, self.phase_bitsize, tuple(rom_vals[qi]), self.control_bitsize + 1
             )
             state_qubits[qi] = bb.add(Rx(angle=np.pi / 2), q=state_qubits[qi])
-            # first qubit does not have selection registers, only controls
             soqs["selection"] = bb.join(state_qubits[:qi])
             if self.control_bitsize > 1:
                 soqs["control"] = bb.join(

--- a/qualtran/bloqs/state_preparation/state_preparation_via_rotation.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_via_rotation.py
@@ -85,6 +85,8 @@ from qualtran import (
     BloqBuilder,
     BloqDocSpec,
     GateWithRegisters,
+    QAny,
+    Register,
     Signature,
     Soquet,
     SoquetT,
@@ -189,9 +191,8 @@ class StatePreparationViaRotations(GateWithRegisters):
                 qi, self.phase_bitsize, tuple(rom_vals[qi]), self.control_bitsize + 1
             )
             state_qubits[qi] = bb.add(Rx(angle=np.pi / 2), q=state_qubits[qi])
-            if qi:
-                # first qubit does not have selection registers, only controls
-                soqs["selection"] = bb.join(state_qubits[:qi])
+            # first qubit does not have selection registers, only controls
+            soqs["selection"] = bb.join(state_qubits[:qi])
             if self.control_bitsize > 1:
                 soqs["control"] = bb.join(
                     np.array(
@@ -207,8 +208,7 @@ class StatePreparationViaRotations(GateWithRegisters):
             if self.control_bitsize != 0:
                 soqs["prepare_control"] = bb.join(separated[:-1])
             state_qubits[qi] = separated[-1]
-            if qi:
-                state_qubits[:qi] = bb.split(cast(Soquet, soqs.pop("selection")))
+            state_qubits[:qi] = bb.split(cast(Soquet, soqs.pop("selection")))
             state_qubits[qi] = bb.add(Rx(angle=-np.pi / 2), q=state_qubits[qi])
 
         soqs["target_state"] = bb.join(state_qubits)
@@ -317,10 +317,12 @@ class PRGAViaPhaseGradient(Bloq):
 
     @property
     def signature(self) -> Signature:
-        return Signature.build(
-            control=self.control_bitsize,
-            selection=self.selection_bitsize,
-            phase_gradient=self.phase_bitsize,
+        return Signature(
+            [
+                Register("control", QAny(self.control_bitsize)),
+                Register("selection", QAny(self.selection_bitsize)),
+                Register("phase_gradient", QAny(self.phase_bitsize)),
+            ]
         )
 
     def build_composite_bloq(self, bb: BloqBuilder, **soqs: SoquetT) -> Dict[str, SoquetT]:


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Qualtran/issues/1019

Also fixes a bug in computation of `find_optimal_log_block_size` which was being called with `selection_bitsize` instead of `target_bitsize`. 