### PR TITLE
[WIP] replace `bit_tools.iter_bits` with `classical_sim.ints_to_bits`

### DIFF
--- a/qualtran/cirq_interop/bit_tools.py
+++ b/qualtran/cirq_interop/bit_tools.py
@@ -26,12 +26,11 @@ def iter_bits(val: int, width: int) -> Iterator[int]:
     Args:
         val: The integer value. Its bitsize must fit within `width`
         width: The number of output bits.
-        signed: If True, the most significant bit represents the sign of
-            the number (ones complement) which is 1 if val < 0 else 0.
     Raises:
         ValueError: If `val` is negative or if `val.bit_length()` exceeds `width`.
     """
     from qualtran.simulation.classical_sim import ints_to_bits
+
     return iter(ints_to_bits(val, width).flatten().tolist())
 
 

--- a/qualtran/cirq_interop/bit_tools.py
+++ b/qualtran/cirq_interop/bit_tools.py
@@ -17,7 +17,7 @@ from typing import Iterator, Tuple
 import numpy as np
 
 
-def iter_bits(val: int, width: int, *, signed: bool = False) -> Iterator[int]:
+def iter_bits(val: int, width: int) -> Iterator[int]:
     """Iterate over the bits in a binary representation of `val`.
 
     This uses a big-endian convention where the most significant bit
@@ -31,15 +31,8 @@ def iter_bits(val: int, width: int, *, signed: bool = False) -> Iterator[int]:
     Raises:
         ValueError: If `val` is negative or if `val.bit_length()` exceeds `width`.
     """
-    if val.bit_length() + int(val < 0) > width:
-        raise ValueError(f"{val} exceeds width {width}.")
-    if val < 0 and not signed:
-        raise ValueError(f"{val} is negative.")
-    if signed:
-        yield 1 if val < 0 else 0
-        width -= 1
-    for b in f'{abs(val):0{width}b}':
-        yield int(b)
+    from qualtran.simulation.classical_sim import ints_to_bits
+    return iter(ints_to_bits(val, width).flatten().tolist())
 
 
 def iter_bits_twos_complement(val: int, width: int) -> Iterator[int]:

--- a/qualtran/cirq_interop/bit_tools_test.py
+++ b/qualtran/cirq_interop/bit_tools_test.py
@@ -30,7 +30,7 @@ def test_iter_bits():
     assert list(iter_bits(1, 2)) == [0, 1]
     assert list(iter_bits(2, 2)) == [1, 0]
     assert list(iter_bits(3, 2)) == [1, 1]
-    
+
 
 def test_iter_bits_twos():
     assert list(iter_bits_twos_complement(0, 4)) == [0, 0, 0, 0]
@@ -62,5 +62,7 @@ def test_iter_bits_fixed_point(val, width, signed):
         assert math.isclose(
             val, approx_val, abs_tol=1 / 2**unsigned_width
         ), f'{val}:{approx_val}:{width}'
-        bits_from_int = list(iter_bits(float_as_fixed_width_int(val, unsigned_width + 1)[1], unsigned_width))
+        bits_from_int = list(
+            iter_bits(float_as_fixed_width_int(val, unsigned_width + 1)[1], unsigned_width)
+        )
         assert bits == bits_from_int

--- a/qualtran/cirq_interop/bit_tools_test.py
+++ b/qualtran/cirq_interop/bit_tools_test.py
@@ -27,19 +27,10 @@ from qualtran.cirq_interop.bit_tools import (
 
 def test_iter_bits():
     assert list(iter_bits(0, 2)) == [0, 0]
-    assert list(iter_bits(0, 3, signed=True)) == [0, 0, 0]
     assert list(iter_bits(1, 2)) == [0, 1]
-    assert list(iter_bits(1, 2, signed=True)) == [0, 1]
-    assert list(iter_bits(-1, 2, signed=True)) == [1, 1]
     assert list(iter_bits(2, 2)) == [1, 0]
-    assert list(iter_bits(2, 3, signed=True)) == [0, 1, 0]
-    assert list(iter_bits(-2, 3, signed=True)) == [1, 1, 0]
     assert list(iter_bits(3, 2)) == [1, 1]
-    with pytest.raises(ValueError):
-        assert list(iter_bits(4, 2)) == [1, 0, 0]
-    with pytest.raises(ValueError):
-        _ = list(iter_bits(-3, 4))
-
+    
 
 def test_iter_bits_twos():
     assert list(iter_bits_twos_complement(0, 4)) == [0, 0, 0, 0]
@@ -71,7 +62,5 @@ def test_iter_bits_fixed_point(val, width, signed):
         assert math.isclose(
             val, approx_val, abs_tol=1 / 2**unsigned_width
         ), f'{val}:{approx_val}:{width}'
-        bits_from_int = [
-            *iter_bits(float_as_fixed_width_int(val, unsigned_width + 1)[1], unsigned_width)
-        ]
+        bits_from_int = list(iter_bits(float_as_fixed_width_int(val, unsigned_width + 1)[1], unsigned_width))
         assert bits == bits_from_int


### PR DESCRIPTION
This is just a first attempt at #811 to gather feedback and to see what tests fail.

Known issues:
- `iter_bits` still exists even though it is entirely redundant.
- `iter_bits` no longer supports sign.
- `iter_bits` no longer raises `ValueError` for too-wide inputs.