### PR TITLE
Regenerate block encoding notebook after recent typo fix

### DIFF
--- a/qualtran/bloqs/block_encoding/block_encoding.ipynb
+++ b/qualtran/bloqs/block_encoding/block_encoding.ipynb
@@ -60,7 +60,7 @@
     "$$\n",
     "U = \\sum_l |l\\rangle\\langle l| \\otimes U_l\n",
     "$$\n",
-    "and $|G\\rangle = \\sum_l \\sqrt{\\frac{w_l}{\\alpha}}|0\\rangle_a$, which define the\n",
+    "and $|G\\rangle = \\sum_l \\sqrt{\\frac{w_l}{\\alpha}}|l\\rangle_a$, which define the\n",
     "usual SELECT and PREPARE oracles.\n",
     "\n",
     "Other ways of building block encodings exist so we define the abstract base\n",


### PR DESCRIPTION
Simply running `python dev_tools/autogenerate-bloqs-notebooks-v2.py` after recent typo fix in https://github.com/quantumlib/Qualtran/pull/1027