### PR TITLE
2024-05 Docs upkeep

### DIFF
--- a/dev_tools/autogenerate-bloqs-notebooks-v2.py
+++ b/dev_tools/autogenerate-bloqs-notebooks-v2.py
@@ -372,6 +372,23 @@ ARITHMETIC = [
             qualtran.bloqs.arithmetic.conversions._TO_CONTG_INDX,
         ],
     ),
+]
+
+MOD_ARITHMETIC = [
+    NotebookSpecV2(
+        title='Modular Addition',
+        module=qualtran.bloqs.mod_arithmetic.mod_addition,
+        bloq_specs=[
+            qualtran.bloqs.mod_arithmetic.mod_addition._MOD_ADD_DOC,
+            qualtran.bloqs.mod_arithmetic.mod_addition._MOD_ADD_K_DOC,
+        ],
+    ),
+    NotebookSpecV2(
+        title='Modular Multiplication',
+        module=qualtran.bloqs.factoring.mod_mul,
+        bloq_specs=[qualtran.bloqs.factoring.mod_mul._MODMUL_DOC],
+        directory=f'{SOURCE_DIR}/bloqs/factoring',
+    ),
     NotebookSpecV2(
         title='Modular Exponentiation',
         module=qualtran.bloqs.factoring.mod_exp,
@@ -379,10 +396,9 @@ ARITHMETIC = [
         directory=f'{SOURCE_DIR}/bloqs/factoring',
     ),
     NotebookSpecV2(
-        title='Modular Multiplication',
-        module=qualtran.bloqs.factoring.mod_mul,
-        bloq_specs=[qualtran.bloqs.factoring.mod_mul._MODMUL_DOC],
-        directory=f'{SOURCE_DIR}/bloqs/factoring',
+        title='Elliptic Curve Addition',
+        module=qualtran.bloqs.factoring.ecc.ec_add,
+        bloq_specs=[qualtran.bloqs.factoring.ecc.ec_add._EC_ADD_DOC],
     ),
     NotebookSpecV2(
         title='Elliptic Curve Cryptography',
@@ -394,22 +410,6 @@ ARITHMETIC = [
             qualtran.bloqs.factoring.ecc.ec_add_r._EC_WINDOW_ADD_BLOQ_DOC,
         ],
     ),
-    NotebookSpecV2(
-        title='Elliptic Curve Addition',
-        module=qualtran.bloqs.factoring.ecc.ec_add,
-        bloq_specs=[qualtran.bloqs.factoring.ecc.ec_add._EC_ADD_DOC],
-    ),
-]
-
-MOD_ARITHMETIC = [
-    NotebookSpecV2(
-        title='Modular Addition',
-        module=qualtran.bloqs.mod_arithmetic.mod_addition,
-        bloq_specs=[
-            qualtran.bloqs.mod_arithmetic.mod_addition._MOD_ADD_DOC,
-            qualtran.bloqs.mod_arithmetic.mod_addition._MOD_ADD_K_DOC,
-        ],
-    )
 ]
 
 
@@ -608,6 +608,7 @@ CONCEPTS = [
     'arithmetic/error_analysis_for_fxp_arithmetic.ipynb',
     'phase_estimation/phase_estimation_of_quantum_walk.ipynb',
     'chemistry/trotter/grid_ham/trotter_costs.ipynb',
+    'chemistry/trotter/hubbard/qpe_cost_optimization.ipynb',
     'chemistry/resource_estimation.ipynb',
     'chemistry/writing_algorithms.ipynb',
     'factoring/factoring-via-modexp.ipynb',

--- a/docs/bloq_infra.rst
+++ b/docs/bloq_infra.rst
@@ -16,6 +16,7 @@ types (``Register``), and algorithms (``CompositeBloq``).
    simulation/classical_sim.ipynb
    simulation/tensor.ipynb
    resource_counting/call_graph.ipynb
+   resource_counting/qubit_counts.ipynb
    Adjoint.ipynb
    Controlled.ipynb
 

--- a/docs/bloqs/index.rst
+++ b/docs/bloqs/index.rst
@@ -16,6 +16,7 @@ Bloqs Library
     arithmetic/error_analysis_for_fxp_arithmetic.ipynb
     phase_estimation/phase_estimation_of_quantum_walk.ipynb
     chemistry/trotter/grid_ham/trotter_costs.ipynb
+    chemistry/trotter/hubbard/qpe_cost_optimization.ipynb
     chemistry/resource_estimation.ipynb
     chemistry/writing_algorithms.ipynb
     factoring/factoring-via-modexp.ipynb
@@ -63,16 +64,16 @@ Bloqs Library
     arithmetic/comparison.ipynb
     arithmetic/sorting.ipynb
     arithmetic/conversions.ipynb
-    factoring/mod_exp.ipynb
-    factoring/mod_mul.ipynb
-    factoring/ecc/ecc.ipynb
-    factoring/ecc/ec_add.ipynb
 
 .. toctree::
     :maxdepth: 2
     :caption: Modular Arithmetic:
 
     mod_arithmetic/mod_addition.ipynb
+    factoring/mod_mul.ipynb
+    factoring/mod_exp.ipynb
+    factoring/ecc/ec_add.ipynb
+    factoring/ecc/ecc.ipynb
 
 .. toctree::
     :maxdepth: 2

--- a/qualtran/bloqs/bookkeeping/bookkeeping.ipynb
+++ b/qualtran/bloqs/bookkeeping/bookkeeping.ipynb
@@ -657,7 +657,7 @@
    },
    "outputs": [],
    "source": [
-    "from qualtran import QInt, QFxp\n",
+    "from qualtran import QFxp, QInt\n",
     "\n",
     "cast = Cast(QInt(32), QFxp(32, 32))"
    ]

--- a/qualtran/bloqs/phase_estimation/lp_resource_state.ipynb
+++ b/qualtran/bloqs/phase_estimation/lp_resource_state.ipynb
@@ -205,9 +205,6 @@
    "source": [
     "import sympy\n",
     "\n",
-    "# Note: Symbolic callgraphs currently don't work due to\n",
-    "# https://github.com/quantumlib/Qualtran/issues/786\n",
-    "\n",
     "lp_resource_state_symbolic = LPResourceState(sympy.Symbol('n'))"
    ]
   },


### PR DESCRIPTION
 - pick up a couple of stale changes from bloqs autogen
 - include new notebooks in the TOC
 - document modular arithmetic bloqs in the modular arithmetic section. I have a sneaking suspicion that this change was done before and got reverted in a merge conflict resolution 