### PR TITLE
Windows support - utf8 in graphviz

### DIFF
--- a/qualtran/_infra/controlled_test.py
+++ b/qualtran/_infra/controlled_test.py
@@ -71,7 +71,6 @@ def test_ctrl_spec():
     assert cspec3.qdtypes[0].num_qubits == 64
     assert cspec3.cvs[0] == 234234
     assert cspec3.cvs[0][tuple()] == 234234
-    assert repr(cspec3) == 'CtrlSpec(qdtypes=(QInt(bitsize=64),), cvs=(array(234234),))'
 
 
 def test_ctrl_spec_shape():

--- a/qualtran/drawing/bloq_counts_graph.py
+++ b/qualtran/drawing/bloq_counts_graph.py
@@ -86,7 +86,7 @@ class _CallGraphDrawerBase(metaclass=abc.ABCMeta):
             label = sympy.printing.pretty(n)
             graph.add_edge(pydot.Edge(self.get_id(b1), self.get_id(b2), label=label))
 
-    def get_graph(self):
+    def get_graph(self) -> pydot.Dot:
         """Get the pydot graph."""
         graph = pydot.Dot('counts', graph_type='digraph', rankdir='TB')
         self.add_nodes(graph)
@@ -95,7 +95,7 @@ class _CallGraphDrawerBase(metaclass=abc.ABCMeta):
 
     def get_svg_bytes(self) -> bytes:
         """Get the SVG code (as bytes) for drawing the graph."""
-        return self.get_graph().create_svg()
+        return self.get_graph().create(prog='dot', format='svg', encoding='utf-8')
 
     def get_svg(self) -> IPython.display.SVG:
         """Get an IPython SVG object displaying the graph."""

--- a/qualtran/drawing/graphviz.py
+++ b/qualtran/drawing/graphviz.py
@@ -340,7 +340,7 @@ class GraphDrawer:
         graph.add_edge(self.cxn_edge(left, right, cxn))
         return graph
 
-    def get_graph(self) -> pydot.Graph:
+    def get_graph(self) -> pydot.Dot:
         """Get the graphviz graph representing the Bloq.
 
         This is the main entry-point to this class.
@@ -360,7 +360,7 @@ class GraphDrawer:
 
     def get_svg_bytes(self) -> bytes:
         """Get the SVG code (as bytes) for drawing the graph."""
-        return self.get_graph().create_svg()
+        return self.get_graph().create(prog='dot', format='svg', encoding='utf-8')
 
     def get_svg(self) -> IPython.display.SVG:
         """Get an IPython SVG object displaying the graph."""


### PR DESCRIPTION
There is an issue when trying to draw diagrams with unicode symbols on windows. Even though graphviz defaults to utf-8, the `pydot` intermediary writes a temporary file with (what I presume to be) the platform default which is insufficient for unicode. Luckily, there is a parameter we can set to get utf-8 everywhere. 


This also removes a not-very helpful test that fails on windows because of insignificant differences in numpy datatypes. 