### PR TITLE
Add jupyter notebook to runtime requirements

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -12,6 +12,7 @@ nbconvert
 nbformat
 
 # drawing
+notebook
 pydot
 ipython
 matplotlib

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -22,7 +22,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-ase==3.22.1
+ase==3.23.0
     # via openfermion
 astor==0.8.1
     # via
@@ -151,7 +151,7 @@ flask==3.0.3
     # via dash
 flynt==0.78
     # via -r deps/format.txt
-fonttools==4.52.4
+fonttools==4.53.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
@@ -195,7 +195,7 @@ ipykernel==6.29.4
     #   -r deps/pytest.txt
     #   jupyterlab
     #   myst-nb
-ipython==8.24.0
+ipython==8.25.0
     # via
     #   -r deps/runtime.txt
     #   ipykernel
@@ -271,7 +271,7 @@ jupyter-events==0.10.0
     # via jupyter-server
 jupyter-lsp==2.2.5
     # via jupyterlab
-jupyter-server==2.14.0
+jupyter-server==2.14.1
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -379,7 +379,9 @@ networkx==3.3
 nh3==0.2.17
     # via readme-renderer
 notebook==7.2.0
-    # via -r deps/dev-tools.txt
+    # via
+    #   -r deps/dev-tools.txt
+    #   -r deps/runtime.txt
 notebook-shim==0.2.4
     # via
     #   jupyterlab
@@ -441,7 +443,7 @@ pillow==10.3.0
     # via matplotlib
 pip-tools==7.4.1
     # via -r deps/pip-tools.txt
-pkginfo==1.10.0
+pkginfo==1.11.0
     # via twine
 platformdirs==4.2.2
     # via
@@ -748,7 +750,7 @@ widgetsnbextension==4.0.11
     # via ipywidgets
 wrapt==1.16.0
     # via astroid
-zipp==3.19.0
+zipp==3.19.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -16,10 +16,27 @@ alabaster==0.7.16
     # via
     #   -c envs/dev.env.txt
     #   sphinx
+anyio==4.4.0
+    # via
+    #   -c envs/dev.env.txt
+    #   httpx
+    #   jupyter-server
 anywidget==0.9.12
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
+argon2-cffi==23.1.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+argon2-cffi-bindings==21.2.0
+    # via
+    #   -c envs/dev.env.txt
+    #   argon2-cffi
+arrow==1.3.0
+    # via
+    #   -c envs/dev.env.txt
+    #   isoduration
 astor==0.8.1
     # via
     #   -c envs/dev.env.txt
@@ -28,6 +45,10 @@ asttokens==2.4.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
+async-lru==2.0.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
 attrs==23.2.0
     # via
     #   -c envs/dev.env.txt
@@ -44,6 +65,7 @@ autoray==0.6.12
 babel==2.15.0
     # via
     #   -c envs/dev.env.txt
+    #   jupyterlab-server
     #   pydata-sphinx-theme
     #   sphinx
 beautifulsoup4==4.12.3
@@ -66,7 +88,13 @@ cachetools==5.3.3
 certifi==2024.2.2
     # via
     #   -c envs/dev.env.txt
+    #   httpcore
+    #   httpx
     #   requests
+cffi==1.16.0
+    # via
+    #   -c envs/dev.env.txt
+    #   argon2-cffi-bindings
 charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
@@ -142,6 +170,7 @@ duet==0.2.9
 exceptiongroup==1.2.1
     # via
     #   -c envs/dev.env.txt
+    #   anyio
     #   ipython
 executing==2.0.1
     # via
@@ -155,10 +184,14 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.52.4
+fonttools==4.53.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
+fqdn==1.5.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
@@ -167,9 +200,24 @@ greenlet==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   sqlalchemy
+h11==0.14.0
+    # via
+    #   -c envs/dev.env.txt
+    #   httpcore
+httpcore==1.0.5
+    # via
+    #   -c envs/dev.env.txt
+    #   httpx
+httpx==0.27.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
 idna==3.7
     # via
     #   -c envs/dev.env.txt
+    #   anyio
+    #   httpx
+    #   jsonschema
     #   requests
 imagesize==1.4.1
     # via
@@ -184,8 +232,9 @@ importlib-metadata==7.1.0
 ipykernel==6.29.4
     # via
     #   -c envs/dev.env.txt
+    #   jupyterlab
     #   myst-nb
-ipython==8.24.0
+ipython==8.25.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -198,6 +247,10 @@ ipywidgets==8.1.3
     #   -r deps/docs.txt
     #   -r deps/runtime.txt
     #   anywidget
+isoduration==20.11.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 itsdangerous==2.2.0
     # via
     #   -c envs/dev.env.txt
@@ -210,13 +263,26 @@ jinja2==3.1.4
     # via
     #   -c envs/dev.env.txt
     #   flask
+    #   jupyter-server
+    #   jupyterlab
+    #   jupyterlab-server
     #   myst-parser
     #   nbconvert
     #   sphinx
     #   tensorflow-docs
-jsonschema==4.22.0
+json5==0.9.25
     # via
     #   -c envs/dev.env.txt
+    #   jupyterlab-server
+jsonpointer==2.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+jsonschema[format-nongpl]==4.22.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
+    #   jupyterlab-server
     #   nbformat
 jsonschema-specifications==2023.12.1
     # via
@@ -230,19 +296,51 @@ jupyter-client==8.6.2
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
+    #   jupyter-server
     #   nbclient
 jupyter-core==5.7.2
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
+    #   jupyter-server
+    #   jupyterlab
     #   nbclient
     #   nbconvert
     #   nbformat
+jupyter-events==0.10.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+jupyter-lsp==2.2.5
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+jupyter-server==2.14.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-lsp
+    #   jupyterlab
+    #   jupyterlab-server
+    #   notebook
+    #   notebook-shim
+jupyter-server-terminals==0.5.3
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+jupyterlab==4.2.1
+    # via
+    #   -c envs/dev.env.txt
+    #   notebook
 jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
+jupyterlab-server==2.27.2
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+    #   notebook
 jupyterlab-widgets==3.0.11
     # via
     #   -c envs/dev.env.txt
@@ -311,12 +409,14 @@ nbconvert==7.16.4
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
     #   -r deps/runtime.txt
+    #   jupyter-server
 nbformat==5.10.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
     #   -r deps/runtime.txt
     #   jupyter-cache
+    #   jupyter-server
     #   myst-nb
     #   nbclient
     #   nbconvert
@@ -331,6 +431,15 @@ networkx==3.3
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
+notebook==7.2.0
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
+notebook-shim==0.2.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+    #   notebook
 numba==0.59.1
     # via
     #   -c envs/dev.env.txt
@@ -347,10 +456,17 @@ numpy==1.26.4
     #   pandas
     #   quimb
     #   scipy
+overrides==7.7.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 packaging==24.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
+    #   jupyter-server
+    #   jupyterlab
+    #   jupyterlab-server
     #   matplotlib
     #   nbconvert
     #   plotly
@@ -385,6 +501,10 @@ plotly==5.22.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   dash
+prometheus-client==0.20.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 prompt-toolkit==3.0.45
     # via
     #   -c envs/dev.env.txt
@@ -407,10 +527,15 @@ ptyprocess==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pexpect
+    #   terminado
 pure-eval==0.2.2
     # via
     #   -c envs/dev.env.txt
     #   stack-data
+pycparser==2.22
+    # via
+    #   -c envs/dev.env.txt
+    #   cffi
 pydata-sphinx-theme==0.15.3
     # via
     #   -c envs/dev.env.txt
@@ -435,9 +560,14 @@ pyparsing==3.1.2
 python-dateutil==2.9.0.post0
     # via
     #   -c envs/dev.env.txt
+    #   arrow
     #   jupyter-client
     #   matplotlib
     #   pandas
+python-json-logger==2.0.7
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
 pytz==2024.1
     # via
     #   -c envs/dev.env.txt
@@ -446,6 +576,7 @@ pyyaml==6.0.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-cache
+    #   jupyter-events
     #   myst-nb
     #   myst-parser
     #   tensorflow-docs
@@ -454,6 +585,7 @@ pyzmq==26.0.3
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
+    #   jupyter-server
 qsharp==1.5.0
     # via
     #   -c envs/dev.env.txt
@@ -471,15 +603,27 @@ referencing==0.35.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
+    #   jupyter-events
 requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   dash
+    #   jupyterlab-server
     #   sphinx
 retrying==1.3.4
     # via
     #   -c envs/dev.env.txt
     #   dash
+rfc3339-validator==0.1.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+    #   jupyter-events
+rfc3986-validator==0.1.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+    #   jupyter-events
 rpds-py==0.18.1
     # via
     #   -c envs/dev.env.txt
@@ -490,6 +634,10 @@ scipy==1.13.1
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
+send2trash==1.8.3
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 six==1.16.0
     # via
     #   -c envs/dev.env.txt
@@ -497,6 +645,12 @@ six==1.16.0
     #   bleach
     #   python-dateutil
     #   retrying
+    #   rfc3339-validator
+sniffio==1.3.1
+    # via
+    #   -c envs/dev.env.txt
+    #   anyio
+    #   httpx
 snowballstemmer==2.2.0
     # via
     #   -c envs/dev.env.txt
@@ -565,6 +719,11 @@ tensorflow-docs==2023.5.24.56664
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
+terminado==0.18.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+    #   jupyter-server-terminals
 tinycss2==1.3.0
     # via
     #   -c envs/dev.env.txt
@@ -572,6 +731,7 @@ tinycss2==1.3.0
 tomli==2.0.1
     # via
     #   -c envs/dev.env.txt
+    #   jupyterlab
     #   sphinx
 toolz==0.12.1
     # via
@@ -582,6 +742,10 @@ tornado==6.4
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
+    #   jupyter-server
+    #   jupyterlab
+    #   notebook
+    #   terminado
 tqdm==4.66.4
     # via
     #   -c envs/dev.env.txt
@@ -596,14 +760,23 @@ traitlets==5.14.3
     #   ipywidgets
     #   jupyter-client
     #   jupyter-core
+    #   jupyter-events
+    #   jupyter-server
+    #   jupyterlab
     #   matplotlib-inline
     #   nbclient
     #   nbconvert
     #   nbformat
+types-python-dateutil==2.9.0.20240316
+    # via
+    #   -c envs/dev.env.txt
+    #   arrow
 typing-extensions==4.12.0
     # via
     #   -c envs/dev.env.txt
+    #   anyio
     #   anywidget
+    #   async-lru
     #   cirq-core
     #   dash
     #   ipython
@@ -614,6 +787,10 @@ tzdata==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
+uri-template==1.3.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 urllib3==2.2.1
     # via
     #   -c envs/dev.env.txt
@@ -622,11 +799,19 @@ wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit
+webcolors==1.13
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 webencodings==0.5.1
     # via
     #   -c envs/dev.env.txt
     #   bleach
     #   tinycss2
+websocket-client==1.8.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 werkzeug==3.0.3
     # via
     #   -c envs/dev.env.txt
@@ -636,7 +821,7 @@ widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-zipp==3.19.0
+zipp==3.19.1
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -4,10 +4,27 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/format.env.txt deps/format.txt deps/runtime.txt
 #
+anyio==4.4.0
+    # via
+    #   -c envs/dev.env.txt
+    #   httpx
+    #   jupyter-server
 anywidget==0.9.12
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
+argon2-cffi==23.1.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+argon2-cffi-bindings==21.2.0
+    # via
+    #   -c envs/dev.env.txt
+    #   argon2-cffi
+arrow==1.3.0
+    # via
+    #   -c envs/dev.env.txt
+    #   isoduration
 astor==0.8.1
     # via
     #   -c envs/dev.env.txt
@@ -16,6 +33,10 @@ asttokens==2.4.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
+async-lru==2.0.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
 attrs==23.2.0
     # via
     #   -c envs/dev.env.txt
@@ -28,6 +49,10 @@ autoray==0.6.12
     #   -c envs/dev.env.txt
     #   cotengra
     #   quimb
+babel==2.15.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab-server
 beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
@@ -51,7 +76,13 @@ cachetools==5.3.3
 certifi==2024.2.2
     # via
     #   -c envs/dev.env.txt
+    #   httpcore
+    #   httpx
     #   requests
+cffi==1.16.0
+    # via
+    #   -c envs/dev.env.txt
+    #   argon2-cffi-bindings
 charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
@@ -68,6 +99,7 @@ click==8.1.7
 comm==0.2.2
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   ipywidgets
 contourpy==1.2.1
     # via
@@ -101,6 +133,10 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
+debugpy==1.8.1
+    # via
+    #   -c envs/dev.env.txt
+    #   ipykernel
 decorator==5.1.1
     # via
     #   -c envs/dev.env.txt
@@ -116,6 +152,7 @@ duet==0.2.9
 exceptiongroup==1.2.1
     # via
     #   -c envs/dev.env.txt
+    #   anyio
     #   ipython
 executing==2.0.1
     # via
@@ -133,32 +170,60 @@ flynt==0.78
     # via
     #   -c envs/dev.env.txt
     #   -r deps/format.txt
-fonttools==4.52.4
+fonttools==4.53.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
+fqdn==1.5.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+h11==0.14.0
+    # via
+    #   -c envs/dev.env.txt
+    #   httpcore
+httpcore==1.0.5
+    # via
+    #   -c envs/dev.env.txt
+    #   httpx
+httpx==0.27.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
 idna==3.7
     # via
     #   -c envs/dev.env.txt
+    #   anyio
+    #   httpx
+    #   jsonschema
     #   requests
 importlib-metadata==7.1.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-ipython==8.24.0
+ipykernel==6.29.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+ipython==8.25.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   ipykernel
     #   ipywidgets
 ipywidgets==8.1.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   anywidget
+isoduration==20.11.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 isort==5.10.1
     # via
     #   -c envs/dev.env.txt
@@ -175,10 +240,23 @@ jinja2==3.1.4
     # via
     #   -c envs/dev.env.txt
     #   flask
+    #   jupyter-server
+    #   jupyterlab
+    #   jupyterlab-server
     #   nbconvert
-jsonschema==4.22.0
+json5==0.9.25
     # via
     #   -c envs/dev.env.txt
+    #   jupyterlab-server
+jsonpointer==2.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+jsonschema[format-nongpl]==4.22.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
+    #   jupyterlab-server
     #   nbformat
 jsonschema-specifications==2023.12.1
     # via
@@ -187,18 +265,52 @@ jsonschema-specifications==2023.12.1
 jupyter-client==8.6.2
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
+    #   jupyter-server
     #   nbclient
 jupyter-core==5.7.2
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   jupyter-client
+    #   jupyter-server
+    #   jupyterlab
     #   nbclient
     #   nbconvert
     #   nbformat
+jupyter-events==0.10.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+jupyter-lsp==2.2.5
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+jupyter-server==2.14.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-lsp
+    #   jupyterlab
+    #   jupyterlab-server
+    #   notebook
+    #   notebook-shim
+jupyter-server-terminals==0.5.3
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+jupyterlab==4.2.1
+    # via
+    #   -c envs/dev.env.txt
+    #   notebook
 jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
+jupyterlab-server==2.27.2
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+    #   notebook
 jupyterlab-widgets==3.0.11
     # via
     #   -c envs/dev.env.txt
@@ -225,6 +337,7 @@ matplotlib==3.9.0
 matplotlib-inline==0.1.7
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   ipython
 mistune==3.0.2
     # via
@@ -246,21 +359,33 @@ nbconvert==7.16.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   jupyter-server
 nbformat==5.10.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   jupyter-server
     #   nbclient
     #   nbconvert
 nest-asyncio==1.6.0
     # via
     #   -c envs/dev.env.txt
     #   dash
+    #   ipykernel
 networkx==3.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
+notebook==7.2.0
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
+notebook-shim==0.2.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+    #   notebook
 numba==0.59.1
     # via
     #   -c envs/dev.env.txt
@@ -277,9 +402,17 @@ numpy==1.26.4
     #   pandas
     #   quimb
     #   scipy
+overrides==7.7.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 packaging==24.0
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
+    #   jupyter-server
+    #   jupyterlab
+    #   jupyterlab-server
     #   matplotlib
     #   nbconvert
     #   plotly
@@ -317,6 +450,10 @@ plotly==5.22.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   dash
+prometheus-client==0.20.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 prompt-toolkit==3.0.45
     # via
     #   -c envs/dev.env.txt
@@ -328,6 +465,7 @@ protobuf==5.27.0
 psutil==5.9.8
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   quimb
 psygnal==0.11.1
     # via
@@ -337,10 +475,15 @@ ptyprocess==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pexpect
+    #   terminado
 pure-eval==0.2.2
     # via
     #   -c envs/dev.env.txt
     #   stack-data
+pycparser==2.22
+    # via
+    #   -c envs/dev.env.txt
+    #   cffi
 pydot==2.0.0
     # via
     #   -c envs/dev.env.txt
@@ -358,17 +501,28 @@ pyparsing==3.1.2
 python-dateutil==2.9.0.post0
     # via
     #   -c envs/dev.env.txt
+    #   arrow
     #   jupyter-client
     #   matplotlib
     #   pandas
+python-json-logger==2.0.7
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
 pytz==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
+pyyaml==6.0.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
 pyzmq==26.0.3
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   jupyter-client
+    #   jupyter-server
 qsharp==1.5.0
     # via
     #   -c envs/dev.env.txt
@@ -386,14 +540,26 @@ referencing==0.35.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
+    #   jupyter-events
 requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   dash
+    #   jupyterlab-server
 retrying==1.3.4
     # via
     #   -c envs/dev.env.txt
     #   dash
+rfc3339-validator==0.1.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+    #   jupyter-events
+rfc3986-validator==0.1.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+    #   jupyter-events
 rpds-py==0.18.1
     # via
     #   -c envs/dev.env.txt
@@ -404,6 +570,10 @@ scipy==1.13.1
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
+send2trash==1.8.3
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 six==1.16.0
     # via
     #   -c envs/dev.env.txt
@@ -411,6 +581,12 @@ six==1.16.0
     #   bleach
     #   python-dateutil
     #   retrying
+    #   rfc3339-validator
+sniffio==1.3.1
+    # via
+    #   -c envs/dev.env.txt
+    #   anyio
+    #   httpx
 sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
@@ -432,6 +608,11 @@ tenacity==8.3.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
+terminado==0.18.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+    #   jupyter-server-terminals
 tinycss2==1.3.0
     # via
     #   -c envs/dev.env.txt
@@ -441,6 +622,7 @@ tomli==2.0.1
     #   -c envs/dev.env.txt
     #   black
     #   flynt
+    #   jupyterlab
 toolz==0.12.1
     # via
     #   -c envs/dev.env.txt
@@ -448,7 +630,12 @@ toolz==0.12.1
 tornado==6.4
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   jupyter-client
+    #   jupyter-server
+    #   jupyterlab
+    #   notebook
+    #   terminado
 tqdm==4.66.4
     # via
     #   -c envs/dev.env.txt
@@ -458,18 +645,28 @@ traitlets==5.14.3
     # via
     #   -c envs/dev.env.txt
     #   comm
+    #   ipykernel
     #   ipython
     #   ipywidgets
     #   jupyter-client
     #   jupyter-core
+    #   jupyter-events
+    #   jupyter-server
+    #   jupyterlab
     #   matplotlib-inline
     #   nbclient
     #   nbconvert
     #   nbformat
+types-python-dateutil==2.9.0.20240316
+    # via
+    #   -c envs/dev.env.txt
+    #   arrow
 typing-extensions==4.12.0
     # via
     #   -c envs/dev.env.txt
+    #   anyio
     #   anywidget
+    #   async-lru
     #   cirq-core
     #   dash
     #   ipython
@@ -477,6 +674,10 @@ tzdata==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
+uri-template==1.3.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 urllib3==2.2.1
     # via
     #   -c envs/dev.env.txt
@@ -485,11 +686,19 @@ wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit
+webcolors==1.13
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 webencodings==0.5.1
     # via
     #   -c envs/dev.env.txt
     #   bleach
     #   tinycss2
+websocket-client==1.8.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 werkzeug==3.0.3
     # via
     #   -c envs/dev.env.txt
@@ -499,7 +708,7 @@ widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-zipp==3.19.0
+zipp==3.19.1
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -12,11 +12,28 @@ alabaster==0.7.16
     # via
     #   -c envs/dev.env.txt
     #   sphinx
+anyio==4.4.0
+    # via
+    #   -c envs/dev.env.txt
+    #   httpx
+    #   jupyter-server
 anywidget==0.9.12
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
-ase==3.22.1
+argon2-cffi==23.1.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+argon2-cffi-bindings==21.2.0
+    # via
+    #   -c envs/dev.env.txt
+    #   argon2-cffi
+arrow==1.3.0
+    # via
+    #   -c envs/dev.env.txt
+    #   isoduration
+ase==3.23.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
@@ -32,6 +49,10 @@ asttokens==2.4.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
+async-lru==2.0.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
 attrs==23.2.0
     # via
     #   -c envs/dev.env.txt
@@ -47,6 +68,7 @@ autoray==0.6.12
 babel==2.15.0
     # via
     #   -c envs/dev.env.txt
+    #   jupyterlab-server
     #   sphinx
 beautifulsoup4==4.12.3
     # via
@@ -67,7 +89,13 @@ cachetools==5.3.3
 certifi==2024.2.2
     # via
     #   -c envs/dev.env.txt
+    #   httpcore
+    #   httpx
     #   requests
+cffi==1.16.0
+    # via
+    #   -c envs/dev.env.txt
+    #   argon2-cffi-bindings
 charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
@@ -84,6 +112,7 @@ click==8.1.7
 comm==0.2.2
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   ipywidgets
 contourpy==1.2.1
     # via
@@ -117,6 +146,10 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
+debugpy==1.8.1
+    # via
+    #   -c envs/dev.env.txt
+    #   ipykernel
 decorator==5.1.1
     # via
     #   -c envs/dev.env.txt
@@ -144,6 +177,7 @@ duet==0.2.9
 exceptiongroup==1.2.1
     # via
     #   -c envs/dev.env.txt
+    #   anyio
     #   ipython
     #   pytest
 executing==2.0.1
@@ -162,22 +196,41 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.52.4
+fonttools==4.53.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
+fqdn==1.5.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+h11==0.14.0
+    # via
+    #   -c envs/dev.env.txt
+    #   httpcore
 h5py==3.11.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
     #   pyscf
+httpcore==1.0.5
+    # via
+    #   -c envs/dev.env.txt
+    #   httpx
+httpx==0.27.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
 idna==3.7
     # via
     #   -c envs/dev.env.txt
+    #   anyio
+    #   httpx
+    #   jsonschema
     #   requests
 imagesize==1.4.1
     # via
@@ -191,16 +244,25 @@ iniconfig==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
-ipython==8.24.0
+ipykernel==6.29.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+ipython==8.25.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   ipykernel
     #   ipywidgets
 ipywidgets==8.1.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   anywidget
+isoduration==20.11.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 isort==5.10.1
     # via
     #   -c envs/dev.env.txt
@@ -225,12 +287,25 @@ jinja2==3.1.4
     # via
     #   -c envs/dev.env.txt
     #   flask
+    #   jupyter-server
+    #   jupyterlab
+    #   jupyterlab-server
     #   nbconvert
     #   sphinx
     #   tensorflow-docs
-jsonschema==4.22.0
+json5==0.9.25
     # via
     #   -c envs/dev.env.txt
+    #   jupyterlab-server
+jsonpointer==2.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+jsonschema[format-nongpl]==4.22.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
+    #   jupyterlab-server
     #   nbformat
 jsonschema-specifications==2023.12.1
     # via
@@ -239,18 +314,52 @@ jsonschema-specifications==2023.12.1
 jupyter-client==8.6.2
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
+    #   jupyter-server
     #   nbclient
 jupyter-core==5.7.2
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   jupyter-client
+    #   jupyter-server
+    #   jupyterlab
     #   nbclient
     #   nbconvert
     #   nbformat
+jupyter-events==0.10.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+jupyter-lsp==2.2.5
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+jupyter-server==2.14.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-lsp
+    #   jupyterlab
+    #   jupyterlab-server
+    #   notebook
+    #   notebook-shim
+jupyter-server-terminals==0.5.3
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+jupyterlab==4.2.1
+    # via
+    #   -c envs/dev.env.txt
+    #   notebook
 jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
+jupyterlab-server==2.27.2
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+    #   notebook
 jupyterlab-widgets==3.0.11
     # via
     #   -c envs/dev.env.txt
@@ -282,6 +391,7 @@ matplotlib==3.9.0
 matplotlib-inline==0.1.7
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   ipython
 mccabe==0.7.0
     # via
@@ -308,10 +418,12 @@ nbconvert==7.16.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   jupyter-server
 nbformat==5.10.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   jupyter-server
     #   nbclient
     #   nbconvert
     #   tensorflow-docs
@@ -319,12 +431,22 @@ nest-asyncio==1.6.0
     # via
     #   -c envs/dev.env.txt
     #   dash
+    #   ipykernel
 networkx==3.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
     #   openfermion
+notebook==7.2.0
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
+notebook-shim==0.2.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+    #   notebook
 numba==0.59.1
     # via
     #   -c envs/dev.env.txt
@@ -357,10 +479,18 @@ opt-einsum==3.3.0
     # via
     #   -c envs/dev.env.txt
     #   jax
+overrides==7.7.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 packaging==24.0
     # via
     #   -c envs/dev.env.txt
     #   deprecation
+    #   ipykernel
+    #   jupyter-server
+    #   jupyterlab
+    #   jupyterlab-server
     #   matplotlib
     #   nbconvert
     #   plotly
@@ -400,6 +530,10 @@ pluggy==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
+prometheus-client==0.20.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 prompt-toolkit==3.0.45
     # via
     #   -c envs/dev.env.txt
@@ -412,6 +546,7 @@ protobuf==5.27.0
 psutil==5.9.8
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   quimb
 psygnal==0.11.1
     # via
@@ -421,6 +556,7 @@ ptyprocess==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pexpect
+    #   terminado
 pubchempy==1.0.4
     # via
     #   -c envs/dev.env.txt
@@ -429,6 +565,10 @@ pure-eval==0.2.2
     # via
     #   -c envs/dev.env.txt
     #   stack-data
+pycparser==2.22
+    # via
+    #   -c envs/dev.env.txt
+    #   cffi
 pydot==2.0.0
     # via
     #   -c envs/dev.env.txt
@@ -459,9 +599,14 @@ pytest==8.2.1
 python-dateutil==2.9.0.post0
     # via
     #   -c envs/dev.env.txt
+    #   arrow
     #   jupyter-client
     #   matplotlib
     #   pandas
+python-json-logger==2.0.7
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
 pytz==2024.1
     # via
     #   -c envs/dev.env.txt
@@ -469,11 +614,14 @@ pytz==2024.1
 pyyaml==6.0.1
     # via
     #   -c envs/dev.env.txt
+    #   jupyter-events
     #   tensorflow-docs
 pyzmq==26.0.3
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   jupyter-client
+    #   jupyter-server
 qsharp==1.5.0
     # via
     #   -c envs/dev.env.txt
@@ -491,16 +639,28 @@ referencing==0.35.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
+    #   jupyter-events
 requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   dash
+    #   jupyterlab-server
     #   openfermion
     #   sphinx
 retrying==1.3.4
     # via
     #   -c envs/dev.env.txt
     #   dash
+rfc3339-validator==0.1.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+    #   jupyter-events
+rfc3986-validator==0.1.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+    #   jupyter-events
 rpds-py==0.18.1
     # via
     #   -c envs/dev.env.txt
@@ -516,6 +676,10 @@ scipy==1.13.1
     #   openfermion
     #   pyscf
     #   quimb
+send2trash==1.8.3
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 six==1.16.0
     # via
     #   -c envs/dev.env.txt
@@ -523,6 +687,12 @@ six==1.16.0
     #   bleach
     #   python-dateutil
     #   retrying
+    #   rfc3339-validator
+sniffio==1.3.1
+    # via
+    #   -c envs/dev.env.txt
+    #   anyio
+    #   httpx
 snowballstemmer==2.2.0
     # via
     #   -c envs/dev.env.txt
@@ -581,6 +751,11 @@ tensorflow-docs==2023.5.24.56664
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
+terminado==0.18.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+    #   jupyter-server-terminals
 tinycss2==1.3.0
     # via
     #   -c envs/dev.env.txt
@@ -588,6 +763,7 @@ tinycss2==1.3.0
 tomli==2.0.1
     # via
     #   -c envs/dev.env.txt
+    #   jupyterlab
     #   pylint
     #   pytest
     #   sphinx
@@ -602,7 +778,12 @@ toolz==0.12.1
 tornado==6.4
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   jupyter-client
+    #   jupyter-server
+    #   jupyterlab
+    #   notebook
+    #   terminado
 tqdm==4.66.4
     # via
     #   -c envs/dev.env.txt
@@ -612,19 +793,29 @@ traitlets==5.14.3
     # via
     #   -c envs/dev.env.txt
     #   comm
+    #   ipykernel
     #   ipython
     #   ipywidgets
     #   jupyter-client
     #   jupyter-core
+    #   jupyter-events
+    #   jupyter-server
+    #   jupyterlab
     #   matplotlib-inline
     #   nbclient
     #   nbconvert
     #   nbformat
+types-python-dateutil==2.9.0.20240316
+    # via
+    #   -c envs/dev.env.txt
+    #   arrow
 typing-extensions==4.12.0
     # via
     #   -c envs/dev.env.txt
+    #   anyio
     #   anywidget
     #   astroid
+    #   async-lru
     #   cirq-core
     #   dash
     #   ipython
@@ -632,6 +823,10 @@ tzdata==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
+uri-template==1.3.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 urllib3==2.2.1
     # via
     #   -c envs/dev.env.txt
@@ -640,11 +835,19 @@ wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit
+webcolors==1.13
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 webencodings==0.5.1
     # via
     #   -c envs/dev.env.txt
     #   bleach
     #   tinycss2
+websocket-client==1.8.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 werkzeug==3.0.3
     # via
     #   -c envs/dev.env.txt
@@ -658,7 +861,7 @@ wrapt==1.16.0
     # via
     #   -c envs/dev.env.txt
     #   astroid
-zipp==3.19.0
+zipp==3.19.1
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -4,11 +4,28 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/pytest.env.txt deps/pytest.txt deps/runtime.txt
 #
+anyio==4.4.0
+    # via
+    #   -c envs/dev.env.txt
+    #   httpx
+    #   jupyter-server
 anywidget==0.9.12
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
-ase==3.22.1
+argon2-cffi==23.1.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+argon2-cffi-bindings==21.2.0
+    # via
+    #   -c envs/dev.env.txt
+    #   argon2-cffi
+arrow==1.3.0
+    # via
+    #   -c envs/dev.env.txt
+    #   isoduration
+ase==3.23.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
@@ -16,6 +33,10 @@ asttokens==2.4.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
+async-lru==2.0.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
 attrs==23.2.0
     # via
     #   -c envs/dev.env.txt
@@ -28,6 +49,10 @@ autoray==0.6.12
     #   -c envs/dev.env.txt
     #   cotengra
     #   quimb
+babel==2.15.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab-server
 beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
@@ -47,7 +72,13 @@ cachetools==5.3.3
 certifi==2024.2.2
     # via
     #   -c envs/dev.env.txt
+    #   httpcore
+    #   httpx
     #   requests
+cffi==1.16.0
+    # via
+    #   -c envs/dev.env.txt
+    #   argon2-cffi-bindings
 charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
@@ -125,6 +156,7 @@ duet==0.2.9
 exceptiongroup==1.2.1
     # via
     #   -c envs/dev.env.txt
+    #   anyio
     #   ipython
     #   pytest
 execnet==2.1.1
@@ -147,22 +179,41 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.52.4
+fonttools==4.53.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
+fqdn==1.5.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+h11==0.14.0
+    # via
+    #   -c envs/dev.env.txt
+    #   httpcore
 h5py==3.11.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
     #   pyscf
+httpcore==1.0.5
+    # via
+    #   -c envs/dev.env.txt
+    #   httpx
+httpx==0.27.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
 idna==3.7
     # via
     #   -c envs/dev.env.txt
+    #   anyio
+    #   httpx
+    #   jsonschema
     #   requests
 importlib-metadata==7.1.0
     # via
@@ -176,7 +227,8 @@ ipykernel==6.29.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-ipython==8.24.0
+    #   jupyterlab
+ipython==8.25.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -187,6 +239,10 @@ ipywidgets==8.1.3
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   anywidget
+isoduration==20.11.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 itsdangerous==2.2.0
     # via
     #   -c envs/dev.env.txt
@@ -207,10 +263,23 @@ jinja2==3.1.4
     # via
     #   -c envs/dev.env.txt
     #   flask
+    #   jupyter-server
+    #   jupyterlab
+    #   jupyterlab-server
     #   nbconvert
-jsonschema==4.22.0
+json5==0.9.25
     # via
     #   -c envs/dev.env.txt
+    #   jupyterlab-server
+jsonpointer==2.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+jsonschema[format-nongpl]==4.22.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
+    #   jupyterlab-server
     #   nbformat
 jsonschema-specifications==2023.12.1
     # via
@@ -220,19 +289,51 @@ jupyter-client==8.6.2
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
+    #   jupyter-server
     #   nbclient
 jupyter-core==5.7.2
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
+    #   jupyter-server
+    #   jupyterlab
     #   nbclient
     #   nbconvert
     #   nbformat
+jupyter-events==0.10.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+jupyter-lsp==2.2.5
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+jupyter-server==2.14.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-lsp
+    #   jupyterlab
+    #   jupyterlab-server
+    #   notebook
+    #   notebook-shim
+jupyter-server-terminals==0.5.3
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+jupyterlab==4.2.1
+    # via
+    #   -c envs/dev.env.txt
+    #   notebook
 jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
+jupyterlab-server==2.27.2
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+    #   notebook
 jupyterlab-widgets==3.0.11
     # via
     #   -c envs/dev.env.txt
@@ -283,10 +384,12 @@ nbconvert==7.16.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   jupyter-server
 nbformat==5.10.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   jupyter-server
     #   nbclient
     #   nbconvert
 nest-asyncio==1.6.0
@@ -300,6 +403,15 @@ networkx==3.3
     #   -r deps/runtime.txt
     #   cirq-core
     #   openfermion
+notebook==7.2.0
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
+notebook-shim==0.2.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+    #   notebook
 numba==0.59.1
     # via
     #   -c envs/dev.env.txt
@@ -332,11 +444,18 @@ opt-einsum==3.3.0
     # via
     #   -c envs/dev.env.txt
     #   jax
+overrides==7.7.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 packaging==24.0
     # via
     #   -c envs/dev.env.txt
     #   deprecation
     #   ipykernel
+    #   jupyter-server
+    #   jupyterlab
+    #   jupyterlab-server
     #   matplotlib
     #   nbconvert
     #   plotly
@@ -374,6 +493,10 @@ pluggy==1.5.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
+prometheus-client==0.20.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 prompt-toolkit==3.0.45
     # via
     #   -c envs/dev.env.txt
@@ -395,6 +518,7 @@ ptyprocess==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pexpect
+    #   terminado
 pubchempy==1.0.4
     # via
     #   -c envs/dev.env.txt
@@ -403,6 +527,10 @@ pure-eval==0.2.2
     # via
     #   -c envs/dev.env.txt
     #   stack-data
+pycparser==2.22
+    # via
+    #   -c envs/dev.env.txt
+    #   cffi
 pydot==2.0.0
     # via
     #   -c envs/dev.env.txt
@@ -443,18 +571,28 @@ pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
     # via
     #   -c envs/dev.env.txt
+    #   arrow
     #   jupyter-client
     #   matplotlib
     #   pandas
+python-json-logger==2.0.7
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
 pytz==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
+pyyaml==6.0.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
 pyzmq==26.0.3
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
+    #   jupyter-server
 qsharp==1.5.0
     # via
     #   -c envs/dev.env.txt
@@ -472,15 +610,27 @@ referencing==0.35.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
+    #   jupyter-events
 requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   dash
+    #   jupyterlab-server
     #   openfermion
 retrying==1.3.4
     # via
     #   -c envs/dev.env.txt
     #   dash
+rfc3339-validator==0.1.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+    #   jupyter-events
+rfc3986-validator==0.1.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+    #   jupyter-events
 rpds-py==0.18.1
     # via
     #   -c envs/dev.env.txt
@@ -496,6 +646,10 @@ scipy==1.13.1
     #   openfermion
     #   pyscf
     #   quimb
+send2trash==1.8.3
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 six==1.16.0
     # via
     #   -c envs/dev.env.txt
@@ -503,6 +657,12 @@ six==1.16.0
     #   bleach
     #   python-dateutil
     #   retrying
+    #   rfc3339-validator
+sniffio==1.3.1
+    # via
+    #   -c envs/dev.env.txt
+    #   anyio
+    #   httpx
 sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
@@ -525,6 +685,11 @@ tenacity==8.3.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
+terminado==0.18.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+    #   jupyter-server-terminals
 tinycss2==1.3.0
     # via
     #   -c envs/dev.env.txt
@@ -533,6 +698,7 @@ tomli==2.0.1
     # via
     #   -c envs/dev.env.txt
     #   coverage
+    #   jupyterlab
     #   pytest
 toolz==0.12.1
     # via
@@ -543,6 +709,10 @@ tornado==6.4
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
+    #   jupyter-server
+    #   jupyterlab
+    #   notebook
+    #   terminado
 tqdm==4.66.4
     # via
     #   -c envs/dev.env.txt
@@ -557,14 +727,23 @@ traitlets==5.14.3
     #   ipywidgets
     #   jupyter-client
     #   jupyter-core
+    #   jupyter-events
+    #   jupyter-server
+    #   jupyterlab
     #   matplotlib-inline
     #   nbclient
     #   nbconvert
     #   nbformat
+types-python-dateutil==2.9.0.20240316
+    # via
+    #   -c envs/dev.env.txt
+    #   arrow
 typing-extensions==4.12.0
     # via
     #   -c envs/dev.env.txt
+    #   anyio
     #   anywidget
+    #   async-lru
     #   cirq-core
     #   dash
     #   ipython
@@ -572,6 +751,10 @@ tzdata==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
+uri-template==1.3.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 urllib3==2.2.1
     # via
     #   -c envs/dev.env.txt
@@ -580,11 +763,19 @@ wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit
+webcolors==1.13
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 webencodings==0.5.1
     # via
     #   -c envs/dev.env.txt
     #   bleach
     #   tinycss2
+websocket-client==1.8.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 werkzeug==3.0.3
     # via
     #   -c envs/dev.env.txt
@@ -594,7 +785,7 @@ widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-zipp==3.19.0
+zipp==3.19.1
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -4,14 +4,35 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/runtime.env.txt deps/runtime.txt
 #
+anyio==4.4.0
+    # via
+    #   -c envs/dev.env.txt
+    #   httpx
+    #   jupyter-server
 anywidget==0.9.12
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
+argon2-cffi==23.1.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+argon2-cffi-bindings==21.2.0
+    # via
+    #   -c envs/dev.env.txt
+    #   argon2-cffi
+arrow==1.3.0
+    # via
+    #   -c envs/dev.env.txt
+    #   isoduration
 asttokens==2.4.1
     # via
     #   -c envs/dev.env.txt
     #   stack-data
+async-lru==2.0.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
 attrs==23.2.0
     # via
     #   -c envs/dev.env.txt
@@ -24,6 +45,10 @@ autoray==0.6.12
     #   -c envs/dev.env.txt
     #   cotengra
     #   quimb
+babel==2.15.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab-server
 beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
@@ -43,7 +68,13 @@ cachetools==5.3.3
 certifi==2024.2.2
     # via
     #   -c envs/dev.env.txt
+    #   httpcore
+    #   httpx
     #   requests
+cffi==1.16.0
+    # via
+    #   -c envs/dev.env.txt
+    #   argon2-cffi-bindings
 charset-normalizer==3.3.2
     # via
     #   -c envs/dev.env.txt
@@ -59,6 +90,7 @@ click==8.1.7
 comm==0.2.2
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   ipywidgets
 contourpy==1.2.1
     # via
@@ -92,6 +124,10 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
+debugpy==1.8.1
+    # via
+    #   -c envs/dev.env.txt
+    #   ipykernel
 decorator==5.1.1
     # via
     #   -c envs/dev.env.txt
@@ -107,6 +143,7 @@ duet==0.2.9
 exceptiongroup==1.2.1
     # via
     #   -c envs/dev.env.txt
+    #   anyio
     #   ipython
 executing==2.0.1
     # via
@@ -120,32 +157,60 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.52.4
+fonttools==4.53.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
+fqdn==1.5.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+h11==0.14.0
+    # via
+    #   -c envs/dev.env.txt
+    #   httpcore
+httpcore==1.0.5
+    # via
+    #   -c envs/dev.env.txt
+    #   httpx
+httpx==0.27.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
 idna==3.7
     # via
     #   -c envs/dev.env.txt
+    #   anyio
+    #   httpx
+    #   jsonschema
     #   requests
 importlib-metadata==7.1.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-ipython==8.24.0
+ipykernel==6.29.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+ipython==8.25.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   ipykernel
     #   ipywidgets
 ipywidgets==8.1.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   anywidget
+isoduration==20.11.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 itsdangerous==2.2.0
     # via
     #   -c envs/dev.env.txt
@@ -158,10 +223,23 @@ jinja2==3.1.4
     # via
     #   -c envs/dev.env.txt
     #   flask
+    #   jupyter-server
+    #   jupyterlab
+    #   jupyterlab-server
     #   nbconvert
-jsonschema==4.22.0
+json5==0.9.25
     # via
     #   -c envs/dev.env.txt
+    #   jupyterlab-server
+jsonpointer==2.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+jsonschema[format-nongpl]==4.22.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
+    #   jupyterlab-server
     #   nbformat
 jsonschema-specifications==2023.12.1
     # via
@@ -170,18 +248,52 @@ jsonschema-specifications==2023.12.1
 jupyter-client==8.6.2
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
+    #   jupyter-server
     #   nbclient
 jupyter-core==5.7.2
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   jupyter-client
+    #   jupyter-server
+    #   jupyterlab
     #   nbclient
     #   nbconvert
     #   nbformat
+jupyter-events==0.10.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+jupyter-lsp==2.2.5
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+jupyter-server==2.14.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-lsp
+    #   jupyterlab
+    #   jupyterlab-server
+    #   notebook
+    #   notebook-shim
+jupyter-server-terminals==0.5.3
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+jupyterlab==4.2.1
+    # via
+    #   -c envs/dev.env.txt
+    #   notebook
 jupyterlab-pygments==0.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
+jupyterlab-server==2.27.2
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+    #   notebook
 jupyterlab-widgets==3.0.11
     # via
     #   -c envs/dev.env.txt
@@ -208,6 +320,7 @@ matplotlib==3.9.0
 matplotlib-inline==0.1.7
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   ipython
 mistune==3.0.2
     # via
@@ -225,21 +338,33 @@ nbconvert==7.16.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   jupyter-server
 nbformat==5.10.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   jupyter-server
     #   nbclient
     #   nbconvert
 nest-asyncio==1.6.0
     # via
     #   -c envs/dev.env.txt
     #   dash
+    #   ipykernel
 networkx==3.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
+notebook==7.2.0
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
+notebook-shim==0.2.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
+    #   notebook
 numba==0.59.1
     # via
     #   -c envs/dev.env.txt
@@ -256,9 +381,17 @@ numpy==1.26.4
     #   pandas
     #   quimb
     #   scipy
+overrides==7.7.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 packaging==24.0
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
+    #   jupyter-server
+    #   jupyterlab
+    #   jupyterlab-server
     #   matplotlib
     #   nbconvert
     #   plotly
@@ -291,6 +424,10 @@ plotly==5.22.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   dash
+prometheus-client==0.20.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 prompt-toolkit==3.0.45
     # via
     #   -c envs/dev.env.txt
@@ -302,6 +439,7 @@ protobuf==5.27.0
 psutil==5.9.8
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   quimb
 psygnal==0.11.1
     # via
@@ -311,10 +449,15 @@ ptyprocess==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pexpect
+    #   terminado
 pure-eval==0.2.2
     # via
     #   -c envs/dev.env.txt
     #   stack-data
+pycparser==2.22
+    # via
+    #   -c envs/dev.env.txt
+    #   cffi
 pydot==2.0.0
     # via
     #   -c envs/dev.env.txt
@@ -332,17 +475,28 @@ pyparsing==3.1.2
 python-dateutil==2.9.0.post0
     # via
     #   -c envs/dev.env.txt
+    #   arrow
     #   jupyter-client
     #   matplotlib
     #   pandas
+python-json-logger==2.0.7
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
 pytz==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
+pyyaml==6.0.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-events
 pyzmq==26.0.3
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   jupyter-client
+    #   jupyter-server
 qsharp==1.5.0
     # via
     #   -c envs/dev.env.txt
@@ -360,14 +514,26 @@ referencing==0.35.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jsonschema-specifications
+    #   jupyter-events
 requests==2.32.3
     # via
     #   -c envs/dev.env.txt
     #   dash
+    #   jupyterlab-server
 retrying==1.3.4
     # via
     #   -c envs/dev.env.txt
     #   dash
+rfc3339-validator==0.1.4
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+    #   jupyter-events
+rfc3986-validator==0.1.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
+    #   jupyter-events
 rpds-py==0.18.1
     # via
     #   -c envs/dev.env.txt
@@ -378,6 +544,10 @@ scipy==1.13.1
     #   -c envs/dev.env.txt
     #   cirq-core
     #   quimb
+send2trash==1.8.3
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 six==1.16.0
     # via
     #   -c envs/dev.env.txt
@@ -385,6 +555,12 @@ six==1.16.0
     #   bleach
     #   python-dateutil
     #   retrying
+    #   rfc3339-validator
+sniffio==1.3.1
+    # via
+    #   -c envs/dev.env.txt
+    #   anyio
+    #   httpx
 sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
@@ -406,10 +582,19 @@ tenacity==8.3.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
+terminado==0.18.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
+    #   jupyter-server-terminals
 tinycss2==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
+tomli==2.0.1
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyterlab
 toolz==0.12.1
     # via
     #   -c envs/dev.env.txt
@@ -417,7 +602,12 @@ toolz==0.12.1
 tornado==6.4
     # via
     #   -c envs/dev.env.txt
+    #   ipykernel
     #   jupyter-client
+    #   jupyter-server
+    #   jupyterlab
+    #   notebook
+    #   terminado
 tqdm==4.66.4
     # via
     #   -c envs/dev.env.txt
@@ -427,18 +617,28 @@ traitlets==5.14.3
     # via
     #   -c envs/dev.env.txt
     #   comm
+    #   ipykernel
     #   ipython
     #   ipywidgets
     #   jupyter-client
     #   jupyter-core
+    #   jupyter-events
+    #   jupyter-server
+    #   jupyterlab
     #   matplotlib-inline
     #   nbclient
     #   nbconvert
     #   nbformat
+types-python-dateutil==2.9.0.20240316
+    # via
+    #   -c envs/dev.env.txt
+    #   arrow
 typing-extensions==4.12.0
     # via
     #   -c envs/dev.env.txt
+    #   anyio
     #   anywidget
+    #   async-lru
     #   cirq-core
     #   dash
     #   ipython
@@ -446,6 +646,10 @@ tzdata==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
+uri-template==1.3.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 urllib3==2.2.1
     # via
     #   -c envs/dev.env.txt
@@ -454,11 +658,19 @@ wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit
+webcolors==1.13
+    # via
+    #   -c envs/dev.env.txt
+    #   jsonschema
 webencodings==0.5.1
     # via
     #   -c envs/dev.env.txt
     #   bleach
     #   tinycss2
+websocket-client==1.8.0
+    # via
+    #   -c envs/dev.env.txt
+    #   jupyter-server
 werkzeug==3.0.3
     # via
     #   -c envs/dev.env.txt
@@ -468,7 +680,7 @@ widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-zipp==3.19.0
+zipp==3.19.1
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata


### PR DESCRIPTION
Jupyter notebook isn't a hard dependency for using the library, but your experience will be severely limited without it. This adds jupyter notebook (i.e. `notebook`) to the runtime requirements. This means it will get installed by default if you `pip install qualtran`, since that will read `deps/runtime.txt`. 

You can see that the `dev.env.txt` doesn't change much since it was already included there, but the notebook dependencies get added to all the other environments. 