### PR TITLE
BugFix in `SelectSwapQROM` when multiple datasets are specified

### DIFF
--- a/qualtran/_version.py
+++ b/qualtran/_version.py
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/qualtran/bloqs/data_loading/qrom.py
+++ b/qualtran/bloqs/data_loading/qrom.py
@@ -51,7 +51,6 @@ def _to_tuple(x: Iterable[NDArray]) -> Sequence[NDArray]:
     return tuple(x)
 
 
-@cirq.value_equality()
 @attrs.frozen
 class QROM(QROMBase, UnaryIterationGate):  # type: ignore[misc]
     r"""Bloq to load `data[l]` in the target register when the selection stores an index `l`.

--- a/qualtran/bloqs/data_loading/qrom_base.py
+++ b/qualtran/bloqs/data_loading/qrom_base.py
@@ -162,6 +162,15 @@ class QROMBase(metaclass=abc.ABCMeta):
     )
     num_controls: SymbolicInt = 0
 
+    def is_symbolic(self) -> bool:
+        return is_symbolic(
+            self.num_controls,
+            *self.data_or_shape,
+            *self.selection_bitsizes,
+            *self.target_bitsizes,
+            *[sh for target_shape in self.target_shapes for sh in target_shape],
+        )
+
     @target_shapes.default
     def _default_target_shapes(self):
         return ((),) * len(self.data_or_shape)

--- a/qualtran/bloqs/data_loading/select_swap_qrom.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom.py
@@ -285,8 +285,9 @@ class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
         # 3. Construct CNOTs from 0th borrowed register to clean target registers.
         cnot_ops = []
         for qrom_batched_target, target_reg in zip(qrom_targets.values(), self.target_registers):
+            idx = (0,) * len(qrom.target_registers[0].shape)
             cnot_ops += [
-                [cirq.CNOT(a, b) for a, b in zip(qrom_batched_target[0], quregs[target_reg.name])]
+                [cirq.CNOT(a, b) for a, b in zip(qrom_batched_target[idx], quregs[target_reg.name])]
             ]
 
         # Yield the operations in correct order.
@@ -331,7 +332,7 @@ class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
         raise ValueError(f'Unknown register name {name}')
 
     def _value_equality_values_(self):
-        return self.log_block_sizes, *super()._value_equality_values_()
+        return self.use_dirty_ancilla, self.log_block_sizes, *super()._value_equality_values_()
 
 
 @bloq_example

--- a/qualtran/bloqs/data_loading/select_swap_qrom.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom.py
@@ -125,6 +125,9 @@ class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
         )
         return tuple(find_optimal_log_block_size(ilen, target_bitsize) for ilen in self.data_shape)
 
+    def is_symbolic(self) -> bool:
+        return super().is_symbolic() or is_symbolic(*self.log_block_sizes)
+
     @classmethod
     def build_from_data(
         cls: Type['SelectSwapQROM'],
@@ -212,13 +215,14 @@ class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
 
     @cached_property
     def qrom_bloq(self) -> QROM:
-        return QROM.build_from_bitsize(
+        qrom = QROM.build_from_bitsize(
             self.batched_qrom_shape,
             self.target_bitsizes,
             target_shapes=(self.block_sizes,) * len(self.target_bitsizes),
             selection_bitsizes=self.batched_qrom_selection_bitsizes,
             num_controls=self.num_controls,
         )
+        return qrom if is_symbolic(self) else qrom.with_data(*self.batched_data)
 
     @cached_property
     def swap_with_zero_bloqs(self) -> List[SwapWithZero]:
@@ -260,7 +264,7 @@ class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
         **quregs: NDArray[cirq.Qid],  # type:ignore[type-var]
     ) -> cirq.OP_TREE:
         # 1. Construct QROM to load the batched data.
-        qrom = self.qrom_bloq.with_data(*self.batched_data)
+        qrom = self.qrom_bloq
         qrom_ctrls = {reg.name: quregs[reg.name] for reg in qrom.control_registers}
         qrom_selection = {
             qrom_reg.name: quregs[sel_reg.name][: qrom_reg.bitsize]
@@ -284,8 +288,9 @@ class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
             swz_ops.append(swz.on_registers(**swz_selection, targets=targets))
         # 3. Construct CNOTs from 0th borrowed register to clean target registers.
         cnot_ops = []
-        for qrom_batched_target, target_reg in zip(qrom_targets.values(), self.target_registers):
-            idx = (0,) * len(qrom.target_registers[0].shape)
+        for qrom_reg, target_reg in zip(qrom.target_registers, self.target_registers):
+            qrom_batched_target = qrom_targets[qrom_reg.name]
+            idx = (0,) * len(qrom_reg.shape)
             cnot_ops += [
                 [cirq.CNOT(a, b) for a, b in zip(qrom_batched_target[idx], quregs[target_reg.name])]
             ]

--- a/qualtran/bloqs/data_loading/select_swap_qrom.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom.py
@@ -60,7 +60,6 @@ def find_optimal_log_block_size(
     return int(k_int[np.argmin(value(k_int))])  # obtain optimal k
 
 
-@cirq.value_equality(distinct_child_types=True)
 @attrs.frozen
 class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
     """Gate to load data[l] in the target register when the selection register stores integer l.
@@ -335,9 +334,6 @@ class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
         elif name == 'control':
             return Circle()
         raise ValueError(f'Unknown register name {name}')
-
-    def _value_equality_values_(self):
-        return self.use_dirty_ancilla, self.log_block_sizes, *super()._value_equality_values_()
 
 
 @bloq_example

--- a/qualtran/bloqs/data_loading/select_swap_qrom_test.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom_test.py
@@ -135,12 +135,12 @@ def test_qroam_hashable():
     assert t_complexity(qrom) == TComplexity(32, 160, 0)
 
 
-def test_qrom_t_complexity():
-    qrom = SelectSwapQROM.build_from_data(
+def test_qroam_t_complexity():
+    qroam = SelectSwapQROM.build_from_data(
         [1, 2, 3, 4, 5, 6, 7, 8], target_bitsizes=(4,), log_block_sizes=(2,)
     )
-    _, sigma = qrom.call_graph()
-    assert t_counts_from_sigma(sigma) == qrom.t_complexity().t == 192
+    _, sigma = qroam.call_graph()
+    assert t_counts_from_sigma(sigma) == qroam.t_complexity().t == 192
 
 
 def test_qroam_many_registers():
@@ -166,15 +166,20 @@ def test_qroam_many_registers():
     qrom.call_graph()
 
 
-@pytest.mark.parametrize('bloq_example', [_qroam_multi_data, _qroam_multi_dim])
-def test_valid_decomposition(bloq_example):
-    assert_valid_bloq_decomposition(bloq_example.make())
+def test_qroam_multi_data_autotest(bloq_autotester):
+    bloq_autotester(_qroam_multi_data)
+
+
+def test_qroam_multi_dim_autotest(bloq_autotester):
+    bloq_autotester(_qroam_multi_dim)
 
 
 @pytest.mark.parametrize('use_dirty_ancilla', [True, False])
 def test_tensor_contraction(use_dirty_ancilla: bool):
-    data1 = np.array([[1, 2, 0, 1]] * 4)
-    data2 = np.array([[1, 1, 0, 2]] * 4)
-    qroam = SelectSwapQROM.build_from_data(data1, data2, use_dirty_ancilla=use_dirty_ancilla)
-    qrom = QROM.build_from_data(data1, data2)
+    data = np.array([[0, 1, 0, 1]] * 8)
+    log_block_sizes = (2, 1)
+    qroam = SelectSwapQROM.build_from_data(
+        data, use_dirty_ancilla=use_dirty_ancilla, log_block_sizes=log_block_sizes
+    )
+    qrom = QROM.build_from_data(data)
     np.testing.assert_allclose(qrom.tensor_contract(), qroam.tensor_contract(), atol=1e-8)


### PR DESCRIPTION
Two bugfixes:

1. Use `self.use_dirty_ancilla` in `_value_equality_values_` -- This is important to make sure `bloq.t_complexity()` returns different values when `bloq` is initialized with `use_dirty_ancilla=True` vs `use_dirty_ancilla=False`. Right now, they can return the same value because the t-complexity is cached
2. `qrom_batched_target[0]` can return a numpy array because the target shapes can be multi-dimensional. This is especially true when input data is multi-dimensional (i.e. `data[N][M] --> bached_qrom_data[N / k1][M / k2]`). We need the `target_0_0_..._0`'th register and not the `target_0`th register; which can be multidimensional. 


The added tests fail on main but pass with this PR. 