### PR TITLE
More direct bloq_counts()

### DIFF
--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -360,8 +360,9 @@ class Bloq(metaclass=abc.ABCMeta):
         Returns:
             A dictionary mapping subbloq to the number of times they appear in the decomposition.
         """
-        _, sigma = self.call_graph(generalizer=generalizer, max_depth=1)
-        return sigma
+        from qualtran.resource_counting import get_bloq_callee_counts
+
+        return dict(get_bloq_callee_counts(self, generalizer=generalizer))
 
     def get_ctrl_system(
         self, ctrl_spec: Optional['CtrlSpec'] = None

--- a/qualtran/resource_counting/_call_graph_test.py
+++ b/qualtran/resource_counting/_call_graph_test.py
@@ -31,6 +31,7 @@ from qualtran.resource_counting import (
     get_bloq_callee_counts,
     SympySymbolAllocator,
 )
+from qualtran.resource_counting.generalizers import generalize_rotation_angle
 from qualtran.symbolics import SymbolicInt
 
 
@@ -227,3 +228,18 @@ def test_funnel_graph_generalize():
 
     assert edgeset == {('x', 'a', 2), ('a', 'b', 1), ('b', 'c', 1)}
     assert sigma == {'c': 2}
+
+
+def test_multiple_overlaping_call_graph_entries():
+    b = OnlyCallGraphBloqShim(name='multi', callees=[(TGate(), 1), (TGate(), 2)])
+    counts = get_bloq_callee_counts(b)
+    assert counts == [(TGate(), 3)]
+
+    b = OnlyCallGraphBloqShim(name='sep', callees=[(TGate(), 1), (TGate().adjoint(), 2)])
+    counts = get_bloq_callee_counts(b)
+    # TODO: set needed because of https://github.com/quantumlib/Qualtran/issues/845
+    assert set(counts) == {(TGate(), 1), (TGate().adjoint(), 2)}
+
+    b = OnlyCallGraphBloqShim(name='for_gen', callees=[(TGate(), 1), (TGate().adjoint(), 2)])
+    counts = get_bloq_callee_counts(b, generalizer=generalize_rotation_angle)
+    assert counts == [(TGate(), 3)]


### PR DESCRIPTION
Get bloq counts directly without going via the call graph. This can massively speed up `qlt_testing.assert_equivalent_bloq_counts`, which will necessarily call `CompositeBloq.bloq_counts` which will involve lots of hashing of the composite bloq xref #1073 .

This also has prompted me to finally deal with what happens if you have two of the same bloq in your list of BloqCountT, perhaps returned by `build_call_graph`. Indeed, bloq_counts returns a dictionary so we have to add those keys. This was also necessary to make sure that if two things get generalized to the same result, their counts get added into one entry. Dealing with this is a pre-requisite for #845 