### PR TITLE
Generalize `symbolics.prod` to allow `SymbolicFloat` or `SymbolicInt`

### DIFF
--- a/qualtran/bloqs/data_loading/qrom.py
+++ b/qualtran/bloqs/data_loading/qrom.py
@@ -219,8 +219,8 @@ class QROM(QROMBase, UnaryIterationGate):  # type: ignore[misc]
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         if self.has_data():
             return super().build_call_graph(ssa=ssa)
-        n_and = prod(*self.data_shape) - 2 + self.num_controls
-        n_cnot = prod(*self.target_bitsizes, *self.data_shape)
+        n_and = prod(self.data_shape) - 2 + self.num_controls
+        n_cnot = prod(self.target_bitsizes) * prod(self.data_shape)
         return {(And(), n_and), (And().adjoint(), n_and), (CNOT(), n_cnot)}
 
 

--- a/qualtran/bloqs/data_loading/select_swap_qrom.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom.py
@@ -120,7 +120,7 @@ class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
     @log_block_sizes.default
     def _default_block_sizes(self) -> Tuple[SymbolicInt, ...]:
         target_bitsize = sum(self.target_bitsizes) * sum(
-            prod(*shape) for shape in self.target_shapes
+            prod(shape) for shape in self.target_shapes
         )
         return tuple(find_optimal_log_block_size(ilen, target_bitsize) for ilen in self.data_shape)
 

--- a/qualtran/bloqs/swap_network/swap_with_zero.py
+++ b/qualtran/bloqs/swap_network/swap_with_zero.py
@@ -152,7 +152,7 @@ class SwapWithZero(GateWithRegisters):
         return sel | {'targets': targets}
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        num_swaps = prod(*[x for x in self.n_target_registers]) - 1
+        num_swaps = prod(x for x in self.n_target_registers) - 1
         return {(CSwapApprox(self.target_bitsize), num_swaps)}
 
     def _circuit_diagram_info_(self, args) -> cirq.CircuitDiagramInfo:

--- a/qualtran/symbolics/math_funcs.py
+++ b/qualtran/symbolics/math_funcs.py
@@ -85,13 +85,13 @@ def smin(*args):
 # This is only used in the type signature of functions that should be generic over different
 # symbolic types, in situations where Union and @overload are not sufficient.
 # The user should not need to invoke it directly. Rather, the user can use a function that
-# takes AnySymbolic by calling it with e.g. a SymbolicInt. Correspondingly, if the type signature
-# of the function returns AnySymbolic, then this call will then return a SymbolicInt.
-AnySymbolic = TypeVar('AnySymbolic', SymbolicInt, SymbolicFloat, SymbolicComplex)
+# takes SymbolicT by calling it with e.g. a SymbolicInt. Correspondingly, if the type signature
+# of the function returns SymbolicT, then this call will then return a SymbolicInt.
+SymbolicT = TypeVar('SymbolicT', SymbolicInt, SymbolicFloat, SymbolicComplex)
 
 
-def prod(args: Iterable[AnySymbolic]) -> AnySymbolic:
-    ret: AnySymbolic = 1
+def prod(args: Iterable[SymbolicT]) -> SymbolicT:
+    ret: SymbolicT = 1
     for arg in args:
         ret = ret * arg
     return ret

--- a/qualtran/symbolics/math_funcs.py
+++ b/qualtran/symbolics/math_funcs.py
@@ -11,13 +11,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import cast, Iterable, overload, Sized, Tuple, Union
+from typing import cast, Iterable, overload, Sized, Tuple, TypeVar, Union
 
 import numpy as np
 import sympy
 
 from qualtran.symbolics.types import (
-    AnySymbolic,
     HasLength,
     is_symbolic,
     Shaped,
@@ -81,6 +80,14 @@ def smin(*args):
     if is_symbolic(*args):
         return sympy.Min(*args)
     return min(*args)
+
+
+# This is only used in the type signature of functions that should be generic over different
+# symbolic types, in situations where Union and @overload are not sufficient.
+# The user should not need to invoke it directly. Rather, the user can use a function that
+# takes AnySymbolic by calling it with e.g. a SymbolicInt. Correspondingly, if the type signature
+# of the function returns AnySymbolic, then this call will then return a SymbolicInt.
+AnySymbolic = TypeVar('AnySymbolic', SymbolicInt, SymbolicFloat, SymbolicComplex)
 
 
 def prod(args: Iterable[AnySymbolic]) -> AnySymbolic:

--- a/qualtran/symbolics/math_funcs.py
+++ b/qualtran/symbolics/math_funcs.py
@@ -11,12 +11,13 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import cast, overload, Sized, Tuple, Union
+from typing import cast, Iterable, overload, Sized, Tuple, Union
 
 import numpy as np
 import sympy
 
 from qualtran.symbolics.types import (
+    AnySymbolic,
     HasLength,
     is_symbolic,
     Shaped,
@@ -82,8 +83,8 @@ def smin(*args):
     return min(*args)
 
 
-def prod(*args: SymbolicInt) -> SymbolicInt:
-    ret: SymbolicInt = 1
+def prod(args: Iterable[AnySymbolic]) -> AnySymbolic:
+    ret: AnySymbolic = 1
     for arg in args:
         ret = ret * arg
     return ret

--- a/qualtran/symbolics/types.py
+++ b/qualtran/symbolics/types.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Union
+from typing import TypeVar, Union
 
 import sympy
 from attrs import field, frozen, validators
@@ -25,6 +25,9 @@ document(SymbolicFloat, """A floating point value or a sympy expression.""")
 
 SymbolicComplex = Union[complex, sympy.Expr]
 document(SymbolicComplex, """A complex value or a sympy expression.""")
+
+AnySymbolic = TypeVar('AnySymbolic', SymbolicInt, SymbolicFloat)
+document(AnySymbolic, """A type variable that can be either SymbolicInt or SymbolicFloat.""")
 
 
 @frozen

--- a/qualtran/symbolics/types.py
+++ b/qualtran/symbolics/types.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import TypeVar, Union
+from typing import Union
 
 import sympy
 from attrs import field, frozen, validators
@@ -25,9 +25,6 @@ document(SymbolicFloat, """A floating point value or a sympy expression.""")
 
 SymbolicComplex = Union[complex, sympy.Expr]
 document(SymbolicComplex, """A complex value or a sympy expression.""")
-
-AnySymbolic = TypeVar('AnySymbolic', SymbolicInt, SymbolicFloat)
-document(AnySymbolic, """A type variable that can be either SymbolicInt or SymbolicFloat.""")
 
 
 @frozen


### PR DESCRIPTION
Prior to this change, `symbolics.prod` only accepted `SymbolicInt` arguments and returned `SymbolicInt`. Now, it also accepts `SymbolicFloat` to return `SymbolicFloat`.

The function also now accepts an iterator rather than being variadic, matching the interface of built-in `sum`.

This goal is achieved via a new type variable `SymbolicT`. There does not seem to be a correct approach using `@overload` instead due to limitations of mypy, which does not consider `float | Expr` and `int | Expr` to be two valid overloads for a function since `int` is automatically promoted to `float`.