### PR TITLE
Add `InvertRealNumber` bloq

### DIFF
--- a/dev_tools/autogenerate-bloqs-notebooks-v2.py
+++ b/dev_tools/autogenerate-bloqs-notebooks-v2.py
@@ -359,6 +359,7 @@ ARITHMETIC = [
             qualtran.bloqs.arithmetic.multiplication._SCALE_INT_BY_REAL_DOC,
             qualtran.bloqs.arithmetic.multiplication._MULTIPLY_TWO_REALS_DOC,
             qualtran.bloqs.arithmetic.multiplication._SQUARE_REAL_NUMBER_DOC,
+            qualtran.bloqs.arithmetic.multiplication._INVERT_REAL_NUMBER_DOC,
         ],
     ),
     NotebookSpecV2(

--- a/qualtran/bloqs/arithmetic/__init__.py
+++ b/qualtran/bloqs/arithmetic/__init__.py
@@ -26,6 +26,7 @@ from qualtran.bloqs.arithmetic.comparison import (
 from qualtran.bloqs.arithmetic.conversions import SignedIntegerToTwosComplement, ToContiguousIndex
 from qualtran.bloqs.arithmetic.hamming_weight import HammingWeightCompute
 from qualtran.bloqs.arithmetic.multiplication import (
+    InvertRealNumber,
     MultiplyTwoReals,
     PlusEqualProduct,
     Product,

--- a/qualtran/bloqs/arithmetic/multiplication.ipynb
+++ b/qualtran/bloqs/arithmetic/multiplication.ipynb
@@ -788,6 +788,117 @@
     "show_bloqs([plus_equal_product],\n",
     "           ['`plus_equal_product`'])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2be05cf8",
+   "metadata": {
+    "cq.autogen": "InvertRealNumber.bloq_doc.md"
+   },
+   "source": [
+    "## `InvertRealNumber`\n",
+    "Invert a fixed-point representation of a real number.\n",
+    "\n",
+    "Implements the unitary:\n",
+    "$$\n",
+    "    |a\\rangle|0\\rangle \\rightarrow |a\\rangle|1/a\\rangle\n",
+    "$$\n",
+    "where $a \\ge 1$.\n",
+    "\n",
+    "#### Parameters\n",
+    " - `bitsize`: Number of bits used to represent the number.\n",
+    " - `num_frac`: Number of fraction bits in the number. \n",
+    "\n",
+    "#### Registers\n",
+    " - `a`: `bitsize`-sized input register.\n",
+    " - `result`: `bitsize`-sized output register. \n",
+    " - `References`: \n",
+    " - `[Quantum Algorithms and Circuits for Scientific Computing](`: \n",
+    " - `https`: //arxiv.org/pdf/1511.08253). Section 2.1.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "587e4a5f",
+   "metadata": {
+    "cq.autogen": "InvertRealNumber.bloq_doc.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.arithmetic import InvertRealNumber"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "feabf392",
+   "metadata": {
+    "cq.autogen": "InvertRealNumber.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc402a6a",
+   "metadata": {
+    "cq.autogen": "InvertRealNumber.invert_real_number"
+   },
+   "outputs": [],
+   "source": [
+    "invert_real_number = InvertRealNumber(bitsize=10, num_frac=7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a600ad4",
+   "metadata": {
+    "cq.autogen": "InvertRealNumber.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "608833cb",
+   "metadata": {
+    "cq.autogen": "InvertRealNumber.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([invert_real_number],\n",
+    "           ['`invert_real_number`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20751180",
+   "metadata": {
+    "cq.autogen": "InvertRealNumber.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62cd4ee3",
+   "metadata": {
+    "cq.autogen": "InvertRealNumber.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.generalizers import ignore_split_join\n",
+    "invert_real_number_g, invert_real_number_sigma = invert_real_number.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
+    "show_call_graph(invert_real_number_g)\n",
+    "show_counts_sigma(invert_real_number_sigma)"
+   ]
   }
  ],
  "metadata": {

--- a/qualtran/bloqs/arithmetic/multiplication.py
+++ b/qualtran/bloqs/arithmetic/multiplication.py
@@ -30,6 +30,7 @@ from qualtran import (
     Side,
     Signature,
 )
+from qualtran.bloqs.arithmetic.subtraction import Subtract
 from qualtran.bloqs.basic_gates import CNOT, TGate, Toffoli, XGate
 from qualtran.bloqs.mcmt import MultiControlPauli
 from qualtran.symbolics import HasLength, smax, SymbolicInt
@@ -539,9 +540,6 @@ class InvertRealNumber(Bloq):
         return "1/a"
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        # import here to avoid circular dependency on qualtran.bloqs.arithmetic
-        from qualtran.bloqs.arithmetic.subtraction import Subtract
-
         # initial approximation: Figure 4
         num_int = self.bitsize - self.num_frac
         # Newton-Raphson: Eq. (1)

--- a/qualtran/bloqs/arithmetic/multiplication.py
+++ b/qualtran/bloqs/arithmetic/multiplication.py
@@ -30,9 +30,9 @@ from qualtran import (
     Side,
     Signature,
 )
-from qualtran.bloqs.basic_gates import TGate, Toffoli
-from qualtran.symbolics import smax
-from qualtran.symbolics.types import SymbolicInt
+from qualtran.bloqs.basic_gates import CNOT, TGate, Toffoli, XGate
+from qualtran.bloqs.mcmt import MultiControlPauli
+from qualtran.symbolics import HasLength, smax, SymbolicInt
 
 if TYPE_CHECKING:
     import quimb.tensor as qtn
@@ -495,3 +495,81 @@ def _square_real_number() -> SquareRealNumber:
 
 
 _SQUARE_REAL_NUMBER_DOC = BloqDocSpec(bloq_cls=SquareRealNumber, examples=[_square_real_number])
+
+
+@frozen
+class InvertRealNumber(Bloq):
+    r"""Invert a fixed-point representation of a real number.
+
+    Implements the unitary:
+    $$
+        |a\rangle|0\rangle \rightarrow |a\rangle|1/a\rangle
+    $$
+    where $a \ge 1$.
+
+    Args:
+        bitsize: Number of bits used to represent the number.
+        num_frac: Number of fraction bits in the number.
+
+    Registers:
+        a: `bitsize`-sized input register.
+        result: `bitsize`-sized output register.
+
+        References:
+        [Quantum Algorithms and Circuits for Scientific Computing](
+        https://arxiv.org/pdf/1511.08253). Section 2.1.
+    """
+
+    bitsize: int
+    num_frac: int
+
+    def __attrs_post_init__(self):
+        if (
+            isinstance(self.num_frac, int)
+            and isinstance(self.bitsize, int)
+            and self.num_frac >= self.bitsize
+        ):
+            raise ValueError("num_frac must be < bitsize since a >= 1.")
+
+    @property
+    def signature(self):
+        return Signature(
+            [
+                Register("a", QFxp(self.bitsize, self.num_frac)),
+                Register("result", QFxp(self.bitsize, self.num_frac)),
+            ]
+        )
+
+    def pretty_name(self) -> str:
+        return "1/a"
+
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+        # import here to avoid circular dependency on qualtran.bloqs.arithmetic
+        from qualtran.bloqs.arithmetic.subtraction import Subtract
+
+        # initial approximation: Figure 4
+        num_int = self.bitsize - self.num_frac
+        # Newton-Raphson: Eq. (1)
+        # x' = -a * x^2 + 2 * x
+        num_iters = int(np.ceil(np.log2(self.bitsize)))
+        # TODO: When decomposing we will potentially need to use larger registers.
+        # Related issue: https://github.com/quantumlib/Qualtran/issues/655
+        return {
+            (Toffoli(), num_int - 1),
+            (CNOT(), 2 + num_int - 1),
+            (MultiControlPauli(cvs=HasLength(num_int), target_gate=cirq.X), 1),
+            (XGate(), 1),
+            (SquareRealNumber(self.bitsize), num_iters),  # x^2
+            (MultiplyTwoReals(self.bitsize), num_iters),  # a * x^2
+            (ScaleIntByReal(self.bitsize, 2), num_iters),  # 2 * x
+            (Subtract(QUInt(self.bitsize)), num_iters),  # 2 * x - a * x^2
+        }
+
+
+@bloq_example
+def _invert_real_number() -> InvertRealNumber:
+    invert_real_number = InvertRealNumber(bitsize=10, num_frac=7)
+    return invert_real_number
+
+
+_INVERT_REAL_NUMBER_DOC = BloqDocSpec(bloq_cls=InvertRealNumber, examples=[_invert_real_number])

--- a/qualtran/bloqs/arithmetic/multiplication.py
+++ b/qualtran/bloqs/arithmetic/multiplication.py
@@ -516,19 +516,14 @@ class InvertRealNumber(Bloq):
         result: `bitsize`-sized output register.
 
         References:
-        [Quantum Algorithms and Circuits for Scientific Computing](
-        https://arxiv.org/pdf/1511.08253). Section 2.1.
+        [Quantum Algorithms and Circuits for Scientific Computing](https://arxiv.org/pdf/1511.08253). Section 2.1.
     """
 
     bitsize: int
     num_frac: int
 
     def __attrs_post_init__(self):
-        if (
-            isinstance(self.num_frac, int)
-            and isinstance(self.bitsize, int)
-            and self.num_frac >= self.bitsize
-        ):
+        if self.num_frac == self.bitsize:
             raise ValueError("num_frac must be < bitsize since a >= 1.")
 
     @property

--- a/qualtran/bloqs/arithmetic/multiplication_test.py
+++ b/qualtran/bloqs/arithmetic/multiplication_test.py
@@ -34,6 +34,7 @@ from qualtran.bloqs.arithmetic.multiplication import (
     SquareRealNumber,
     SumOfSquares,
 )
+from qualtran.bloqs.arithmetic.subtraction import Subtract
 from qualtran.bloqs.basic_gates import CNOT, IntState, Toffoli, XGate
 from qualtran.bloqs.mcmt.multi_control_multi_target_pauli import MultiControlPauli
 from qualtran.cirq_interop.t_complexity_protocol import t_complexity, TComplexity
@@ -176,8 +177,6 @@ def test_plus_equal_product():
 
 
 def test_invert_real_number():
-    from qualtran.bloqs.arithmetic.subtraction import Subtract
-
     bitsize = 10
     num_frac = 7
     num_int = bitsize - num_frac

--- a/qualtran/bloqs/arithmetic/multiplication_test.py
+++ b/qualtran/bloqs/arithmetic/multiplication_test.py
@@ -69,6 +69,10 @@ def test_plus_equals_product_auto(bloq_autotester):
     bloq_autotester(_plus_equal_product)
 
 
+def test_invert_real_number_auto(bloq_autotester):
+    bloq_autotester(_invert_real_number)
+
+
 def test_square():
     bb = BloqBuilder()
     bitsize = 4

--- a/qualtran/bloqs/arithmetic/subtraction.py
+++ b/qualtran/bloqs/arithmetic/subtraction.py
@@ -30,7 +30,8 @@ from qualtran import (
     Soquet,
     SoquetT,
 )
-from qualtran.bloqs.arithmetic import Add, Negate
+from qualtran.bloqs.arithmetic.addition import Add
+from qualtran.bloqs.arithmetic.negate import Negate
 from qualtran.drawing import Text
 
 if TYPE_CHECKING:

--- a/qualtran/serialization/resolver_dict.py
+++ b/qualtran/serialization/resolver_dict.py
@@ -150,6 +150,7 @@ RESOLVER_DICT = {
     "qualtran.bloqs.arithmetic.conversions.SignedIntegerToTwosComplement": qualtran.bloqs.arithmetic.conversions.SignedIntegerToTwosComplement,
     "qualtran.bloqs.arithmetic.conversions.ToContiguousIndex": qualtran.bloqs.arithmetic.conversions.ToContiguousIndex,
     "qualtran.bloqs.arithmetic.hamming_weight.HammingWeightCompute": qualtran.bloqs.arithmetic.hamming_weight.HammingWeightCompute,
+    "qualtran.bloqs.arithmetic.multiplication.InvertRealNumber": qualtran.bloqs.arithmetic.multiplication.InvertRealNumber,
     "qualtran.bloqs.arithmetic.multiplication.MultiplyTwoReals": qualtran.bloqs.arithmetic.multiplication.MultiplyTwoReals,
     "qualtran.bloqs.arithmetic.multiplication.PlusEqualProduct": qualtran.bloqs.arithmetic.multiplication.PlusEqualProduct,
     "qualtran.bloqs.arithmetic.multiplication.Product": qualtran.bloqs.arithmetic.multiplication.Product,

--- a/qualtran/serialization/resolver_dict.py
+++ b/qualtran/serialization/resolver_dict.py
@@ -165,6 +165,7 @@ RESOLVER_DICT = {
     "qualtran.bloqs.arithmetic.sorting.BitonicSort": qualtran.bloqs.arithmetic.sorting.BitonicSort,
     "qualtran.bloqs.arithmetic.sorting.Comparator": qualtran.bloqs.arithmetic.sorting.Comparator,
     "qualtran.bloqs.arithmetic.sorting.ParallelComparators": qualtran.bloqs.arithmetic.sorting.ParallelComparators,
+    "qualtran.bloqs.arithmetic.subtraction.Subtract": qualtran.bloqs.arithmetic.subtraction.Subtract,
     "qualtran.bloqs.basic_gates.cnot.CNOT": qualtran.bloqs.basic_gates.cnot.CNOT,
     "qualtran.bloqs.basic_gates.identity.Identity": qualtran.bloqs.basic_gates.identity.Identity,
     "qualtran.bloqs.basic_gates.global_phase.GlobalPhase": qualtran.bloqs.basic_gates.global_phase.GlobalPhase,


### PR DESCRIPTION
Cost out the arithmetic operation of inverting a real number >= 1. Uses Newton-Raphson iteration as specified by [this reference](https://arxiv.org/pdf/1511.08253).

This bloq can be combined with inverse square root to compute the square root of a number.
