### PR TITLE
Make static type checking work better with symbolics

### DIFF
--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -962,11 +962,9 @@ class EqualsAConstant(Bloq):
 
     @property
     def bits_k(self) -> Union[tuple[int, ...], HasLength]:
-        if self.is_symbolic():
+        if is_symbolic(self.bitsize) or is_symbolic(self.val):
             return HasLength(self.bitsize)
 
-        assert not isinstance(self.bitsize, sympy.Expr)
-        assert not isinstance(self.val, sympy.Expr)
         return tuple(QUInt(self.bitsize).to_bits(self.val))
 
     def build_composite_bloq(

--- a/qualtran/bloqs/arithmetic/permutation.py
+++ b/qualtran/bloqs/arithmetic/permutation.py
@@ -108,9 +108,8 @@ class PermutationCycle(Bloq):
         return is_symbolic(self.N, self.cycle)
 
     def build_composite_bloq(self, bb: 'BloqBuilder', x: 'SoquetT') -> dict[str, 'SoquetT']:
-        if self.is_symbolic():
+        if is_symbolic(self.cycle):
             raise DecomposeTypeError(f"cannot decompose symbolic {self}")
-        assert not isinstance(self.cycle, Shaped)
 
         a: 'SoquetT' = bb.allocate(dtype=QBit())
 
@@ -253,10 +252,9 @@ class Permutation(Bloq):
         return cls(N, cycles)
 
     def build_composite_bloq(self, bb: 'BloqBuilder', x: 'Soquet') -> dict[str, 'SoquetT']:
-        if self.is_symbolic():
+        if is_symbolic(self.cycles):
             raise DecomposeTypeError(f"cannot decompose symbolic {self}")
 
-        assert not isinstance(self.cycles, Shaped)
         for cycle in self.cycles:
             x = bb.add(PermutationCycle(self.N, cycle), x=x)
 

--- a/qualtran/bloqs/arithmetic/sorting.py
+++ b/qualtran/bloqs/arithmetic/sorting.py
@@ -147,7 +147,7 @@ class ParallelComparators(Bloq):
     @cached_property
     def num_comparisons(self) -> SymbolicInt:
         """Number of `Comparator` gates used in the decomposition"""
-        if is_symbolic(self.k, self.offset):
+        if is_symbolic(self.k) or is_symbolic(self.offset):
             return self.k // 2  # upper bound
 
         full = (self.k // (2 * self.offset)) * self.offset
@@ -155,12 +155,11 @@ class ParallelComparators(Bloq):
         return full + max(rest - self.offset, 0)
 
     def build_composite_bloq(self, bb: 'BloqBuilder', xs: 'SoquetT') -> Dict[str, 'SoquetT']:
-        if is_symbolic(self.k, self.offset):
+        if is_symbolic(self.k) or is_symbolic(self.offset):
             raise DecomposeTypeError(f"Cannot decompose symbolic {self=}")
 
-        # make mypy happy
-        k = int(self.k)
-        offset = int(self.offset)
+        k = self.k
+        offset = self.offset
         assert isinstance(xs, np.ndarray)
 
         comp = Comparator(self.bitsize)
@@ -225,7 +224,6 @@ class BitonicMerge(Bloq):
     def __attrs_post_init__(self):
         k = self.half_length
         if not is_symbolic(k):
-            assert not isinstance(k, sympy.Expr)
             assert k >= 1, "length of input lists must be positive"
             # TODO(#1090) support non-power-of-two input lengths
             assert (k & (k - 1)) == 0, "length of input lists must be a power of 2"
@@ -260,7 +258,7 @@ class BitonicMerge(Bloq):
         assert isinstance(xs, np.ndarray)
         assert isinstance(ys, np.ndarray)
 
-        k = int(self.half_length)
+        k = self.half_length
 
         first_round_junk = []
         for i in range(k):
@@ -340,7 +338,6 @@ class BitonicSort(Bloq):
     def __attrs_post_init__(self):
         k = self.k
         if not is_symbolic(k):
-            assert not isinstance(k, sympy.Expr)
             assert k >= 1, f"length of input list must be positive, got {k=}"
             # TODO(#1090) support non-power-of-two input lengths
             assert (k & (k - 1)) == 0, f"length of input list must be a power of 2, got {k=}"

--- a/qualtran/bloqs/block_encoding/product.py
+++ b/qualtran/bloqs/block_encoding/product.py
@@ -146,11 +146,6 @@ class Product(BlockEncoding):
             or is_symbolic(self.resource_bitsize)
         ):
             raise DecomposeTypeError(f"Cannot decompose symbolic {self=}")
-        assert (
-            isinstance(self.system_bitsize, int)
-            and isinstance(self.ancilla_bitsize, int)
-            and isinstance(self.resource_bitsize, int)
-        )
         n = len(self.block_encodings)
 
         if self.ancilla_bitsize > 0:
@@ -176,8 +171,8 @@ class Product(BlockEncoding):
 
         # connect constituent bloqs
         for i, u in enumerate(reversed(self.block_encodings)):
-            assert isinstance(u.ancilla_bitsize, int)
-            assert isinstance(u.resource_bitsize, int)
+            assert not is_symbolic(u.ancilla_bitsize)
+            assert not is_symbolic(u.resource_bitsize)
             u_soqs = {"system": system}
             partition: List[Tuple[Register, List[Union[str, Unused]]]] = [
                 (Register("system", dtype=QAny(u.system_bitsize)), ["system"])

--- a/qualtran/bloqs/block_encoding/tensor_product.py
+++ b/qualtran/bloqs/block_encoding/tensor_product.py
@@ -14,7 +14,7 @@
 
 from collections import Counter
 from functools import cached_property
-from typing import cast, Dict, Set, Tuple
+from typing import Dict, Set, Tuple
 
 from attrs import evolve, field, frozen, validators
 
@@ -142,13 +142,13 @@ class TensorProduct(BlockEncoding):
             if "resource" in u.signature._lefts
         )
 
-        sys_part = Partition(cast(int, self.system_bitsize), regs=sys_regs)
+        sys_part = Partition(self.system_bitsize, regs=sys_regs)
         sys_out_regs = list(bb.add_t(sys_part, x=system))
         if len(anc_regs) > 0:
-            anc_part = Partition(cast(int, self.ancilla_bitsize), regs=anc_regs)
+            anc_part = Partition(self.ancilla_bitsize, regs=anc_regs)
             anc_out_regs = list(bb.add_t(anc_part, x=soqs["ancilla"]))
         if len(res_regs) > 0:
-            res_part = Partition(cast(int, self.resource_bitsize), regs=res_regs)
+            res_part = Partition(self.resource_bitsize, regs=res_regs)
             res_out_regs = list(bb.add_t(res_part, x=soqs["resource"]))
         sys_i = 0
         anc_i = 0

--- a/qualtran/bloqs/data_loading/select_swap_qrom.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom.py
@@ -29,7 +29,7 @@ from qualtran.bloqs.data_loading.qrom import QROM
 from qualtran.bloqs.data_loading.qrom_base import QROMBase
 from qualtran.bloqs.swap_network import SwapWithZero
 from qualtran.drawing import Circle, Text, TextBox, WireSymbol
-from qualtran.symbolics import ceil, is_symbolic, log2, prod, SymbolicInt
+from qualtran.symbolics import ceil, is_symbolic, log2, prod, SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran import Bloq
@@ -46,7 +46,7 @@ def find_optimal_log_block_size(
         * iteration_length/2^k + target_bitsize*(2^k - 1) is minimized.
     The corresponding block size for SelectSwapQROM would be 2^k.
     """
-    k = 0.5 * log2(iteration_length / target_bitsize)
+    k: SymbolicFloat = 0.5 * log2(iteration_length / target_bitsize)
     if is_symbolic(k):
         return ceil(k)
 

--- a/qualtran/bloqs/qft/qft_text_book.py
+++ b/qualtran/bloqs/qft/qft_text_book.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import cast, Iterator, Set
+from typing import Iterator, Set
 
 import attrs
 import cirq
@@ -94,7 +94,7 @@ class QFTTextBook(GateWithRegisters):
                 )
             }
         else:
-            for i in range(1, cast(int, self.bitsize)):
+            for i in range(1, self.bitsize):
                 ret |= {(PhaseGradientUnitary(i, exponent=0.5, is_controlled=True), 1)}
         if self.with_reverse:
             ret |= {(TwoBitSwap(), self.bitsize // 2)}

--- a/qualtran/bloqs/rotations/phase_gradient.py
+++ b/qualtran/bloqs/rotations/phase_gradient.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import cast, Dict, Iterator, List, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import Dict, Iterator, List, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import cirq
@@ -138,7 +138,7 @@ class PhaseGradientUnitary(GateWithRegisters):
             }
 
         ret: Set['BloqCountT'] = set()
-        for i in range(cast(int, self.bitsize)):
+        for i in range(self.bitsize):
             ret.add((gate(exponent=self.exponent / 2**i, eps=self.eps / self.bitsize), 1))
         return ret
 

--- a/qualtran/bloqs/state_preparation/prepare_uniform_superposition.py
+++ b/qualtran/bloqs/state_preparation/prepare_uniform_superposition.py
@@ -96,7 +96,6 @@ class PrepareUniformSuperposition(GateWithRegisters):
         k, n, logL = 0, self.n, bit_length(self.n - 1)
         if is_symbolic(n):
             return 0, self.n, bit_length(self.n - 1)
-        n = int(n)
         while n > 1 and n % 2 == 0:
             k += 1
             logL -= 1

--- a/qualtran/bloqs/state_preparation/state_preparation_via_rotation.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_via_rotation.py
@@ -145,7 +145,6 @@ class StatePreparationViaRotations(GateWithRegisters):
     def __attrs_post_init__(self):
         if is_symbolic(self.state_coefficients):
             return
-        assert isinstance(self.state_coefficients, tuple)
         # a valid quantum state has a number of coefficients that is a power of two
         assert slen(self.state_coefficients) == 2**self.state_bitsize
         # negative number of control bits is not allowed

--- a/qualtran/symbolics/types.py
+++ b/qualtran/symbolics/types.py
@@ -11,11 +11,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Union
+from typing import overload, TypeVar, Union
 
 import sympy
 from attrs import field, frozen, validators
 from cirq._doc import document
+from typing_extensions import TypeIs
 
 SymbolicFloat = Union[float, sympy.Expr]
 document(SymbolicFloat, """A floating point value or a sympy expression.""")
@@ -63,7 +64,22 @@ class HasLength:
         return True
 
 
+T = TypeVar('T')
+
+
+@overload
+def is_symbolic(
+    arg: Union[T, sympy.Expr, Shaped, HasLength], /
+) -> TypeIs[Union[sympy.Expr, Shaped, HasLength]]:
+    ...
+
+
+@overload
 def is_symbolic(*args) -> bool:
+    ...
+
+
+def is_symbolic(*args) -> Union[TypeIs[Union[sympy.Expr, Shaped, HasLength]], bool]:
     """Returns whether the inputs contain any symbolic object.
 
     Returns:


### PR DESCRIPTION
This change adds `TypeIs` to the signature of `is_symbolic`, thereby making spurious static type checker errors less likely and enabling us to remove uses of `cast` and `assert`.

# Motivation

A common pattern in the codebase is as follows:

```
x: SymbolicInt = ...
if is_symbolic(x):
    raise DecomposeTypeError(...)

# do something that assumes that x: int, such as:
c = "abcde"[x]
```

Unfortunately, this pattern doesn't play well with static type checkers such as mypy, which we use.
As an example we actually encountered, consider this snippet from #1089 (just prior to commit 23577b27fb54f8bc5d88da05521fa092c6843a04):

```
if is_symbolic(self.k, self.offset):
    raise DecomposeTypeError(f"Cannot decompose symbolic {self=}")

for start in range(0, self.k, 2 * self.offset):
    for step in range(self.offset):
        # do something
```

Given the above code, mypy fails with the error:
```
qualtran/bloqs/arithmetic/sorting.py:168: error: Argument 2 to "range" has incompatible type "int | Expr"; expected "SupportsIndex"  [arg-type]
qualtran/bloqs/arithmetic/sorting.py:169: error: Argument 1 to "range" has incompatible type "int | Expr"; expected "SupportsIndex"  [arg-type]
```

This overly conservative type checking error occurs because in general, a static type checker cannot infer that the type of the argument of `is_symbolic` should be _narrowed_ to `int` from `Union[int, Expr]` when `is_symbolic` returns False. Such inference is normally reserved for specific language patterns, such as `isinstance`:

```
if not isinstance(x, sympy.Expr):
    raise DecomposeTypeError(...)

# here, mypy does actually infer that x: int
c = "abcde"[x]  # no type error
```

We do sometimes use `isinstance` in the codebase for this purpose, but it is less general and we would prefer not to replace `is_symbolic` with it.

# Solution

Fortunately, we can do better and get the benefit of type narrowing using the recently introduced [`TypeIs`](https://peps.python.org/pep-0742/) type annotation. In brief, by annotating the return type of `is_symbolic` as `TypeIs[sympy.Expr]` rather than `bool`, the static type checker will infer that when `is_symbolic(arg: Union[int, Expr])` returns True, then `arg: Expr`, and otherwise `arg: int`.

This PR makes the above change. Consequently, it safely removes numerous instances of `cast(int, ...)`, `assert [not] isinstance(...)`, `int(...)`, and similar patterns from the code.

There are some caveats due to limitations of the Python type system:
- The benefit does not extend to variadic arguments to `is_symbolic`. To get the benefit, it is necessary to rewrite `is_symbolic(x, y)` as `is_symbolic(x) or is_symbolic(y)`.
- The benefit does not extend to other situations such using an `is_symbolic(self)` method defined on a class rather than `symbolics.types.is_symbolic`.
- The benefit extends to `HasLength` and `Shaped`. However, in one scenario, it was necessary to explicitly annotate `k: SymbolicFloat` so that the type checker would infer `k: Expr` rather than `k: Union[HasLength, Shaped, Expr]` when `is_symbolic(k)` returns True.
- The benefit does not yet extend to more deeply nested types, such as narrowing `Tuple[SymbolicInt, ...]` to `Tuple[int, ...]`.
