### PR TITLE
Add `SubtractFrom` to subtract from a register in place

### DIFF
--- a/dev_tools/autogenerate-bloqs-notebooks-v2.py
+++ b/dev_tools/autogenerate-bloqs-notebooks-v2.py
@@ -346,7 +346,10 @@ ARITHMETIC = [
     NotebookSpecV2(
         title='Subtraction',
         module=qualtran.bloqs.arithmetic.subtraction,
-        bloq_specs=[qualtran.bloqs.arithmetic.subtraction._SUB_DOC],
+        bloq_specs=[
+            qualtran.bloqs.arithmetic.subtraction._SUB_DOC,
+            qualtran.bloqs.arithmetic.subtraction._SUB_FROM_DOC,
+        ],
     ),
     NotebookSpecV2(
         title='Multiplication',

--- a/qualtran/bloqs/arithmetic/__init__.py
+++ b/qualtran/bloqs/arithmetic/__init__.py
@@ -36,6 +36,6 @@ from qualtran.bloqs.arithmetic.multiplication import (
 )
 from qualtran.bloqs.arithmetic.negate import Negate
 from qualtran.bloqs.arithmetic.sorting import BitonicSort, Comparator
-from qualtran.bloqs.arithmetic.subtraction import Subtract
+from qualtran.bloqs.arithmetic.subtraction import Subtract, SubtractFrom
 
 from ._shims import CHalf, Lt, MultiCToffoli

--- a/qualtran/bloqs/arithmetic/subtraction.ipynb
+++ b/qualtran/bloqs/arithmetic/subtraction.ipynb
@@ -179,21 +179,22 @@
    },
    "source": [
     "## `SubtractFrom`\n",
-    "A version of `Subtract` that stores the output in the register being subtracted from.\n",
+    "A version of `Subtract` that leaves behind the value being subtracted.\n",
     "\n",
     "Implements $U|a\n",
     "angle|b\n",
     "angle\n",
-    "ightarrow |a - b\n",
-    "angle|b\n",
-    "angle$.\n",
+    "ightarrow |a\n",
+    "angle|b - a\n",
+    "angle$, essentially equivalent to\n",
+    "the statement `b -= a`.\n",
     "\n",
     "#### Parameters\n",
     " - `dtype`: Quantum datatype used to represent the integers a, b, and a - b. \n",
     "\n",
     "#### Registers\n",
-    " - `a`: A dtype.bitsize-sized input/output register (register a above).\n",
-    " - `b`: A dtype.bitsize-sized input register (register b above).\n"
+    " - `a`: A dtype.bitsize-sized input register (register a above).\n",
+    " - `b`: A dtype.bitsize-sized input/output register (register b above).\n"
    ]
   },
   {

--- a/qualtran/bloqs/arithmetic/subtraction.ipynb
+++ b/qualtran/bloqs/arithmetic/subtraction.ipynb
@@ -179,7 +179,7 @@
    },
    "source": [
     "## `SubtractFrom`\n",
-    "A version of `Subtract` that leaves behind the value being subtracted.\n",
+    "A version of `Subtract` that subtracts the first register from the second in place.\n",
     "\n",
     "Implements $U|a\n",
     "angle|b\n",
@@ -190,7 +190,7 @@
     "the statement `b -= a`.\n",
     "\n",
     "#### Parameters\n",
-    " - `dtype`: Quantum datatype used to represent the integers a, b, and a - b. \n",
+    " - `dtype`: Quantum datatype used to represent the integers a, b, and b - a. \n",
     "\n",
     "#### Registers\n",
     " - `a`: A dtype.bitsize-sized input register (register a above).\n",

--- a/qualtran/bloqs/arithmetic/subtraction.ipynb
+++ b/qualtran/bloqs/arithmetic/subtraction.ipynb
@@ -170,6 +170,139 @@
     "show_call_graph(sub_symb_g)\n",
     "show_counts_sigma(sub_symb_sigma)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12650fb1",
+   "metadata": {
+    "cq.autogen": "SubtractFrom.bloq_doc.md"
+   },
+   "source": [
+    "## `SubtractFrom`\n",
+    "A version of `Subtract` that stores the input in the register being subtracted from.\n",
+    "\n",
+    "Implements $U|a\n",
+    "angle|b\n",
+    "angle\n",
+    "ightarrow |a - b\n",
+    "angle|b\n",
+    "angle$.\n",
+    "\n",
+    "#### Parameters\n",
+    " - `dtype`: Quantum datatype used to represent the integers a, b, and a - b. \n",
+    "\n",
+    "#### Registers\n",
+    " - `a`: A dtype.bitsize-sized input register (register a above).\n",
+    " - `b`: A dtype.bitsize-sized input/output register (register b above).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "746c25eb",
+   "metadata": {
+    "cq.autogen": "SubtractFrom.bloq_doc.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.arithmetic import SubtractFrom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75ea545f",
+   "metadata": {
+    "cq.autogen": "SubtractFrom.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7ee57a8",
+   "metadata": {
+    "cq.autogen": "SubtractFrom.sub_from_symb"
+   },
+   "outputs": [],
+   "source": [
+    "n = sympy.Symbol('n')\n",
+    "sub_from_symb = SubtractFrom(QInt(bitsize=n))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8123a738",
+   "metadata": {
+    "cq.autogen": "SubtractFrom.sub_from_small"
+   },
+   "outputs": [],
+   "source": [
+    "sub_from_small = SubtractFrom(QInt(bitsize=4))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e469b17a",
+   "metadata": {
+    "cq.autogen": "SubtractFrom.sub_from_large"
+   },
+   "outputs": [],
+   "source": [
+    "sub_from_large = SubtractFrom(QInt(bitsize=64))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a32af1e3",
+   "metadata": {
+    "cq.autogen": "SubtractFrom.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fd2dbd7",
+   "metadata": {
+    "cq.autogen": "SubtractFrom.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([sub_from_symb, sub_from_small, sub_from_large],\n",
+    "           ['`sub_from_symb`', '`sub_from_small`', '`sub_from_large`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47e50576",
+   "metadata": {
+    "cq.autogen": "SubtractFrom.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4564d561",
+   "metadata": {
+    "cq.autogen": "SubtractFrom.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.generalizers import ignore_split_join\n",
+    "sub_from_symb_g, sub_from_symb_sigma = sub_from_symb.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
+    "show_call_graph(sub_from_symb_g)\n",
+    "show_counts_sigma(sub_from_symb_sigma)"
+   ]
   }
  ],
  "metadata": {

--- a/qualtran/bloqs/arithmetic/subtraction.ipynb
+++ b/qualtran/bloqs/arithmetic/subtraction.ipynb
@@ -179,7 +179,7 @@
    },
    "source": [
     "## `SubtractFrom`\n",
-    "A version of `Subtract` that stores the input in the register being subtracted from.\n",
+    "A version of `Subtract` that stores the output in the register being subtracted from.\n",
     "\n",
     "Implements $U|a\n",
     "angle|b\n",
@@ -192,8 +192,8 @@
     " - `dtype`: Quantum datatype used to represent the integers a, b, and a - b. \n",
     "\n",
     "#### Registers\n",
-    " - `a`: A dtype.bitsize-sized input register (register a above).\n",
-    " - `b`: A dtype.bitsize-sized input/output register (register b above).\n"
+    " - `a`: A dtype.bitsize-sized input/output register (register a above).\n",
+    " - `b`: A dtype.bitsize-sized input register (register b above).\n"
    ]
   },
   {

--- a/qualtran/bloqs/arithmetic/subtraction.py
+++ b/qualtran/bloqs/arithmetic/subtraction.py
@@ -171,7 +171,7 @@ _SUB_DOC = BloqDocSpec(
 
 @frozen
 class SubtractFrom(Bloq):
-    """A version of `Subtract` that stores the input in the register being subtracted from.
+    """A version of `Subtract` that stores the output in the register being subtracted from.
 
     Implements $U|a\rangle|b\rangle \rightarrow |a - b\rangle|b\rangle$.
 
@@ -179,8 +179,8 @@ class SubtractFrom(Bloq):
         dtype: Quantum datatype used to represent the integers a, b, and a - b.
 
     Registers:
-        a: A dtype.bitsize-sized input register (register a above).
-        b: A dtype.bitsize-sized input/output register (register b above).
+        a: A dtype.bitsize-sized input/output register (register a above).
+        b: A dtype.bitsize-sized input register (register b above).
     """
 
     dtype: Union[QInt, QUInt, QMontgomeryUInt] = field()

--- a/qualtran/bloqs/arithmetic/subtraction.py
+++ b/qualtran/bloqs/arithmetic/subtraction.py
@@ -177,7 +177,7 @@ class SubtractFrom(Bloq):
     the statement `b -= a`.
 
     Args:
-        dtype: Quantum datatype used to represent the integers a, b, and a - b.
+        dtype: Quantum datatype used to represent the integers a, b, and b - a.
 
     Registers:
         a: A dtype.bitsize-sized input register (register a above).

--- a/qualtran/bloqs/arithmetic/subtraction.py
+++ b/qualtran/bloqs/arithmetic/subtraction.py
@@ -171,7 +171,7 @@ _SUB_DOC = BloqDocSpec(
 
 @frozen
 class SubtractFrom(Bloq):
-    """A version of `Subtract` that leaves behind the value being subtracted.
+    """A version of `Subtract` that subtracts the first register from the second in place.
 
     Implements $U|a\rangle|b\rangle \rightarrow |a\rangle|b - a\rangle$, essentially equivalent to
     the statement `b -= a`.

--- a/qualtran/bloqs/arithmetic/subtraction_test.py
+++ b/qualtran/bloqs/arithmetic/subtraction_test.py
@@ -86,14 +86,14 @@ def test_sub_from_large(bloq_autotester):
 
 
 def test_subtract_from_bloq_decomposition():
-    gate = SubtractFrom(QInt(3))
+    gate = SubtractFrom(QInt(4))
     qlt_testing.assert_valid_bloq_decomposition(gate)
 
-    want = np.zeros((64, 64))
-    for a_b in range(64):
-        a, b = a_b >> 3, a_b & 7
-        c = (a - b) % 8
-        want[(c << 3) | b][a_b] = 1
+    want = np.zeros((256, 256))
+    for a_b in range(256):
+        a, b = a_b >> 4, a_b & 15
+        c = (b - a) % 16
+        want[(a << 4) | c][a_b] = 1
     got = gate.tensor_contract()
     np.testing.assert_allclose(got, want)
 

--- a/qualtran/bloqs/arithmetic/subtraction_test.py
+++ b/qualtran/bloqs/arithmetic/subtraction_test.py
@@ -17,8 +17,34 @@ import pytest
 
 import qualtran.testing as qlt_testing
 from qualtran import QInt, QUInt
-from qualtran.bloqs.arithmetic import Subtract
+from qualtran.bloqs.arithmetic.subtraction import (
+    _sub_diff_size_regs,
+    _sub_from_large,
+    _sub_from_small,
+    _sub_from_symb,
+    _sub_large,
+    _sub_small,
+    _sub_symb,
+    Subtract,
+    SubtractFrom,
+)
 from qualtran.resource_counting.generalizers import ignore_split_join
+
+
+def test_sub_symb(bloq_autotester):
+    bloq_autotester(_sub_symb)
+
+
+def test_sub_small(bloq_autotester):
+    bloq_autotester(_sub_small)
+
+
+def test_sub_large(bloq_autotester):
+    bloq_autotester(_sub_large)
+
+
+def test_sub_diff_size_regs(bloq_autotester):
+    bloq_autotester(_sub_diff_size_regs)
 
 
 def test_subtract_bloq_decomposition():
@@ -41,7 +67,36 @@ def test_subtract_bloq_validation():
     assert Subtract(QUInt(3)).dtype == QUInt(3)
 
 
-def test_subtract_bloq_consitant_counts():
+def test_subtract_bloq_consistent_counts():
     qlt_testing.assert_equivalent_bloq_counts(
         Subtract(QInt(3), QInt(4)), generalizer=ignore_split_join
     )
+
+
+def test_sub_from_symb(bloq_autotester):
+    bloq_autotester(_sub_from_symb)
+
+
+def test_sub_from_small(bloq_autotester):
+    bloq_autotester(_sub_from_small)
+
+
+def test_sub_from_large(bloq_autotester):
+    bloq_autotester(_sub_from_large)
+
+
+def test_subtract_from_bloq_decomposition():
+    gate = SubtractFrom(QInt(3))
+    qlt_testing.assert_valid_bloq_decomposition(gate)
+
+    want = np.zeros((64, 64))
+    for a_b in range(64):
+        a, b = a_b >> 3, a_b & 7
+        c = (a - b) % 8
+        want[(c << 3) | b][a_b] = 1
+    got = gate.tensor_contract()
+    np.testing.assert_allclose(got, want)
+
+
+def test_subtract_from_bloq_consistent_counts():
+    qlt_testing.assert_equivalent_bloq_counts(SubtractFrom(QInt(3)), generalizer=ignore_split_join)

--- a/qualtran/serialization/resolver_dict.py
+++ b/qualtran/serialization/resolver_dict.py
@@ -23,6 +23,7 @@ import qualtran.bloqs.arithmetic.multiplication
 import qualtran.bloqs.arithmetic.negate
 import qualtran.bloqs.arithmetic.permutation
 import qualtran.bloqs.arithmetic.sorting
+import qualtran.bloqs.arithmetic.subtraction
 import qualtran.bloqs.basic_gates.cnot
 import qualtran.bloqs.basic_gates.hadamard
 import qualtran.bloqs.basic_gates.identity
@@ -174,6 +175,8 @@ RESOLVER_DICT = {
     "qualtran.bloqs.arithmetic.sorting.BitonicSort": qualtran.bloqs.arithmetic.sorting.BitonicSort,
     "qualtran.bloqs.arithmetic.sorting.Comparator": qualtran.bloqs.arithmetic.sorting.Comparator,
     "qualtran.bloqs.arithmetic.sorting.ParallelComparators": qualtran.bloqs.arithmetic.sorting.ParallelComparators,
+    "qualtran.bloqs.arithmetic.subtraction.Subtract": qualtran.bloqs.arithmetic.subtraction.Subtract,
+    "qualtran.bloqs.arithmetic.subtraction.SubtractFrom": qualtran.bloqs.arithmetic.subtraction.SubtractFrom,
     "qualtran.bloqs.basic_gates.cnot.CNOT": qualtran.bloqs.basic_gates.cnot.CNOT,
     "qualtran.bloqs.basic_gates.identity.Identity": qualtran.bloqs.basic_gates.identity.Identity,
     "qualtran.bloqs.basic_gates.global_phase.GlobalPhase": qualtran.bloqs.basic_gates.global_phase.GlobalPhase,


### PR DESCRIPTION
Add a new version of `Subtract` that instead of taking $|a\rangle|b\rangle \mapsto |a\rangle|a-b\rangle$, takes it to $|a\rangle|b-a\rangle$. This is essentially equivalent to the statement `b -= a`.

The implementation uses an additional `Negate`, which could likely be improved, but this is a first approach. For now, it only supports `a` and `b` register of equal dtype.

The reason we need this for `Subtract` but not for `Add` is because addition is commutative and we could always swap the operands, but we can't for subtraction.
