### PR TITLE
Switch `SubtractFrom` to use `BitwiseNot`

### DIFF
--- a/qualtran/bloqs/arithmetic/multiplication.ipynb
+++ b/qualtran/bloqs/arithmetic/multiplication.ipynb
@@ -813,8 +813,7 @@
     " - `a`: `bitsize`-sized input register.\n",
     " - `result`: `bitsize`-sized output register. \n",
     " - `References`: \n",
-    " - `[Quantum Algorithms and Circuits for Scientific Computing](`: \n",
-    " - `https`: //arxiv.org/pdf/1511.08253). Section 2.1.\n"
+    " - `[Quantum Algorithms and Circuits for Scientific Computing](https`: //arxiv.org/pdf/1511.08253). Section 2.1.\n"
    ]
   },
   {

--- a/qualtran/bloqs/arithmetic/subtraction.py
+++ b/qualtran/bloqs/arithmetic/subtraction.py
@@ -31,6 +31,7 @@ from qualtran import (
     SoquetT,
 )
 from qualtran.bloqs.arithmetic.addition import Add
+from qualtran.bloqs.arithmetic.bitwise import BitwiseNot
 from qualtran.bloqs.arithmetic.negate import Negate
 from qualtran.drawing import Text
 
@@ -219,11 +220,12 @@ class SubtractFrom(Bloq):
             raise ValueError()
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(Negate(self.dtype), 1), (Subtract(self.dtype, self.dtype), 1)}
+        return {(BitwiseNot(self.dtype), 2), (Add(self.dtype, self.dtype), 1)}
 
     def build_composite_bloq(self, bb: 'BloqBuilder', a: Soquet, b: Soquet) -> Dict[str, 'SoquetT']:
-        a, b = bb.add_t(Subtract(self.dtype, self.dtype), a=a, b=b)  # a, a - b
-        b = bb.add(Negate(self.dtype), x=b)  # a, b - a
+        b = bb.add(BitwiseNot(self.dtype), x=b)  # a, -1 - b
+        a, b = bb.add_t(Add(self.dtype, self.dtype), a=a, b=b)  # a, a - 1 - b
+        b = bb.add(BitwiseNot(self.dtype), x=b)  # a, -1 - (a - 1 - b) = a, -a + b
         return {'a': a, 'b': b}
 
 


### PR DESCRIPTION
Switch the implementation of `SubtractFrom` to use `BitwiseNot` rather than `Negate` to save some Toffolis as per [suggestion](https://github.com/quantumlib/Qualtran/pull/1158#discussion_r1683629710).
