### PR TITLE
Add random tests for `Product` block encoding

### DIFF
--- a/qualtran/bloqs/block_encoding/product_test.py
+++ b/qualtran/bloqs/block_encoding/product_test.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import random
 from typing import cast
 
 import cirq

--- a/qualtran/bloqs/block_encoding/product_test.py
+++ b/qualtran/bloqs/block_encoding/product_test.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import random
 from typing import cast
 
 import cirq
@@ -37,6 +38,7 @@ from qualtran.bloqs.block_encoding.product import (
     Product,
 )
 from qualtran.bloqs.block_encoding.unitary import Unitary
+from qualtran.bloqs.for_testing.matrix_gate import MatrixGate
 from qualtran.cirq_interop.testing import assert_circuit_inp_out_cirqsim
 
 
@@ -150,3 +152,28 @@ def test_product_cirq():
     initial_state = [0, 0, 0]
     final_state = [1, 0, 0]
     assert_circuit_inp_out_cirqsim(circuit, qubits, initial_state, final_state)
+
+
+random.seed(1234)
+
+
+def gen_test():
+    n = random.randint(3, 6)
+    bitsize = random.randint(1, 3)
+    gates = [MatrixGate.random(bitsize, random_state=1234) for _ in range(n)]
+    return gates
+
+
+@pytest.mark.parametrize('gates', [gen_test() for _ in range(10)])
+def test_product_random(gates):
+    bloq = Product(tuple(Unitary(gate) for gate in gates))
+    bb = BloqBuilder()
+    system = bb.add_register("system", cast(int, bloq.system_bitsize))
+    ancilla = cast(Soquet, bb.add(IntState(0, bloq.ancilla_bitsize)))
+    system, ancilla = bb.add_t(bloq, system=system, ancilla=ancilla)
+    bb.add(IntEffect(0, cast(int, bloq.ancilla_bitsize)), val=ancilla)
+    bloq = bb.finalize(system=system)
+
+    from_gate = np.linalg.multi_dot(tuple(gate.tensor_contract() for gate in gates))
+    from_tensors = bloq.tensor_contract()
+    np.testing.assert_allclose(from_gate, from_tensors)


### PR DESCRIPTION
These tests increase confidence in the correctness of the implementation. They are pretty fast to run.
