### PR TITLE
Add script to check whether autogenerating notebooks is idempotent

### DIFF
--- a/check/autogenerate-notebooks
+++ b/check/autogenerate-notebooks
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Autogenerates the notebooks and reports whether there were any changes.
+#
+# Usage:
+#     check/autogenerate-notebooks
+#
+################################################################################
+
+python dev_tools/autogenerate-bloqs-notebooks-v2.py || exit $?
+
+if output=$(git status --porcelain) && [ -z "$output" ]; then
+  # Working directory clean
+  exit 0
+else
+  # Uncommitted changes
+  echo $output
+  exit 1
+fi


### PR DESCRIPTION
This script can be useful in a manual or CI test that a PR has appropriately updated the notebooks associated with a code change.

Running `check/autogenerate-notebooks` will either return 0 if `dev_tools/autogenerate-bloqs-notebooks-v2.py` leaves the Git working directory clean, or return 1 and print a message like the following:

```
...
[hamiltonian_simulation_by_gqsp] Replacing HamiltonianSimulationByGQSP.call_graph.py cell.
M qualtran/bloqs/block_encoding/block_encoding.ipynb
```
