### PR TITLE
Add `ToFxp` to convert a `QUInt` to a `QFxp`

### DIFF
--- a/dev_tools/autogenerate-bloqs-notebooks-v2.py
+++ b/dev_tools/autogenerate-bloqs-notebooks-v2.py
@@ -417,6 +417,7 @@ ARITHMETIC = [
         bloq_specs=[
             qualtran.bloqs.arithmetic.conversions._SIGNED_TO_TWOS,
             qualtran.bloqs.arithmetic.conversions._TO_CONTG_INDX,
+            qualtran.bloqs.arithmetic.conversions._TO_FXP,
         ],
     ),
     NotebookSpecV2(

--- a/qualtran/bloqs/arithmetic/__init__.py
+++ b/qualtran/bloqs/arithmetic/__init__.py
@@ -23,7 +23,11 @@ from qualtran.bloqs.arithmetic.comparison import (
     LessThanEqual,
     SingleQubitCompare,
 )
-from qualtran.bloqs.arithmetic.conversions import SignedIntegerToTwosComplement, ToContiguousIndex
+from qualtran.bloqs.arithmetic.conversions import (
+    SignedIntegerToTwosComplement,
+    ToContiguousIndex,
+    ToFxp,
+)
 from qualtran.bloqs.arithmetic.hamming_weight import HammingWeightCompute
 from qualtran.bloqs.arithmetic.multiplication import (
     InvertRealNumber,

--- a/qualtran/bloqs/arithmetic/conversions.ipynb
+++ b/qualtran/bloqs/arithmetic/conversions.ipynb
@@ -244,6 +244,111 @@
     "show_call_graph(to_contg_index_g)\n",
     "show_counts_sigma(to_contg_index_sigma)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc8b699b",
+   "metadata": {
+    "cq.autogen": "ToFxp.bloq_doc.md"
+   },
+   "source": [
+    "## `ToFxp`\n",
+    "Convert a register storing a `QUInt` to a `QFxp`, optionally dividing by a power of two.\n",
+    "\n",
+    "#### Parameters\n",
+    " - `a_dtype`: Quantum datatype used to represent the input.\n",
+    " - `b_dtype`: Quantum datatype used to represent the output.\n",
+    " - `divide_by`: Power of two to divide by when converting (default: 0). \n",
+    "\n",
+    "#### Registers\n",
+    " - `a`: A a_dtype.bitsize-sized input register (register a above).\n",
+    " - `b`: A b_dtype.bitsize-sized output register (register b above).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a27378ba",
+   "metadata": {
+    "cq.autogen": "ToFxp.bloq_doc.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.arithmetic import ToFxp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c6486fa",
+   "metadata": {
+    "cq.autogen": "ToFxp.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c8ecc32",
+   "metadata": {
+    "cq.autogen": "ToFxp.to_fxp"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran import QFxp, QUInt\n",
+    "\n",
+    "to_fxp = ToFxp(QUInt(4), QFxp(4, 2, False), 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3333f12",
+   "metadata": {
+    "cq.autogen": "ToFxp.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4a8791a",
+   "metadata": {
+    "cq.autogen": "ToFxp.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([to_fxp],\n",
+    "           ['`to_fxp`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "137cb66b",
+   "metadata": {
+    "cq.autogen": "ToFxp.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30033a51",
+   "metadata": {
+    "cq.autogen": "ToFxp.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.generalizers import ignore_split_join\n",
+    "to_fxp_g, to_fxp_sigma = to_fxp.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
+    "show_call_graph(to_fxp_g)\n",
+    "show_counts_sigma(to_fxp_sigma)"
+   ]
   }
  ],
  "metadata": {

--- a/qualtran/bloqs/arithmetic/conversions.ipynb
+++ b/qualtran/bloqs/arithmetic/conversions.ipynb
@@ -302,8 +302,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f7a42d1",
+   "metadata": {
+    "cq.autogen": "ToFxp.to_fxp_resize"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran import QFxp, QUInt\n",
+    "\n",
+    "to_fxp_resize = ToFxp(QUInt(4), QFxp(6, 3, False), 2)"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "f3333f12",
+   "id": "5f939e07",
    "metadata": {
     "cq.autogen": "ToFxp.graphical_signature.md"
    },
@@ -314,20 +328,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a4a8791a",
+   "id": "0c5fa3a9",
    "metadata": {
     "cq.autogen": "ToFxp.graphical_signature.py"
    },
    "outputs": [],
    "source": [
     "from qualtran.drawing import show_bloqs\n",
-    "show_bloqs([to_fxp],\n",
-    "           ['`to_fxp`'])"
+    "show_bloqs([to_fxp, to_fxp_resize],\n",
+    "           ['`to_fxp`', '`to_fxp_resize`'])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "137cb66b",
+   "id": "2615396f",
    "metadata": {
     "cq.autogen": "ToFxp.call_graph.md"
    },
@@ -338,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30033a51",
+   "id": "8e42cea3",
    "metadata": {
     "cq.autogen": "ToFxp.call_graph.py"
    },

--- a/qualtran/bloqs/arithmetic/conversions.py
+++ b/qualtran/bloqs/arithmetic/conversions.py
@@ -221,4 +221,12 @@ def _to_fxp() -> ToFxp:
     return to_fxp
 
 
-_TO_FXP = BloqDocSpec(bloq_cls=ToFxp, examples=[_to_fxp])
+@bloq_example
+def _to_fxp_resize() -> ToFxp:
+    from qualtran import QFxp, QUInt
+
+    to_fxp_resize = ToFxp(QUInt(4), QFxp(6, 3, False), 2)
+    return to_fxp_resize
+
+
+_TO_FXP = BloqDocSpec(bloq_cls=ToFxp, examples=[_to_fxp, _to_fxp_resize])

--- a/qualtran/bloqs/arithmetic/conversions_test.py
+++ b/qualtran/bloqs/arithmetic/conversions_test.py
@@ -21,6 +21,7 @@ from qualtran.bloqs.arithmetic.conversions import (
     _signed_to_twos,
     _to_contg_index,
     _to_fxp,
+    _to_fxp_resize,
     SignedIntegerToTwosComplement,
     ToContiguousIndex,
     ToFxp,
@@ -61,6 +62,10 @@ def test_to_fxp(bloq_autotester):
     bloq_autotester(_to_fxp)
 
 
+def test_to_fxp_resize(bloq_autotester):
+    bloq_autotester(_to_fxp_resize)
+
+
 def test_to_fxp_checks():
     with pytest.raises(ValueError):
         _ = ToFxp(QUInt(6), QFxp(5, 3))
@@ -78,6 +83,17 @@ def test_to_fxp_correct():
         c = a
         want[(a << 4) | (c ^ b)][a_b] = 1
     got = _to_fxp().tensor_contract()
+    np.testing.assert_allclose(got, want)
+
+
+def test_to_fxp_resize_correct():
+    tot = 1 << 10
+    want = np.zeros((tot, tot))
+    for a_b in range(tot):
+        a, b = a_b >> 6, a_b & ((1 << 6) - 1)
+        c = a << 1
+        want[(a << 6) | (c ^ b)][a_b] = 1
+    got = _to_fxp_resize().tensor_contract()
     np.testing.assert_allclose(got, want)
 
 

--- a/qualtran/serialization/resolver_dict.py
+++ b/qualtran/serialization/resolver_dict.py
@@ -164,6 +164,7 @@ RESOLVER_DICT = {
     "qualtran.bloqs.arithmetic.controlled_add_or_subtract.ControlledAddOrSubtract": qualtran.bloqs.arithmetic.controlled_add_or_subtract.ControlledAddOrSubtract,
     "qualtran.bloqs.arithmetic.conversions.SignedIntegerToTwosComplement": qualtran.bloqs.arithmetic.conversions.SignedIntegerToTwosComplement,
     "qualtran.bloqs.arithmetic.conversions.ToContiguousIndex": qualtran.bloqs.arithmetic.conversions.ToContiguousIndex,
+    "qualtran.bloqs.arithmetic.conversions.ToFxp": qualtran.bloqs.arithmetic.conversions.ToFxp,
     "qualtran.bloqs.arithmetic.hamming_weight.HammingWeightCompute": qualtran.bloqs.arithmetic.hamming_weight.HammingWeightCompute,
     "qualtran.bloqs.arithmetic.multiplication.InvertRealNumber": qualtran.bloqs.arithmetic.multiplication.InvertRealNumber,
     "qualtran.bloqs.arithmetic.multiplication.MultiplyTwoReals": qualtran.bloqs.arithmetic.multiplication.MultiplyTwoReals,


### PR DESCRIPTION
This bloq enables us to safely convert between `QUInt` and `QFxp` of compatible size and to divide integers by powers of two in the process.

If the bitsize of the output is equal to the input, then `Cast` could be used as an unsafe alternative. This bloq is a little safer and supports using a larger register to store the divided the value.
