### PR TITLE
Add symbolic call graph for `SparseMatrix`

### DIFF
--- a/qualtran/bloqs/block_encoding/block_encoding.ipynb
+++ b/qualtran/bloqs/block_encoding/block_encoding.ipynb
@@ -1432,8 +1432,29 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecd95252",
+   "metadata": {
+    "cq.autogen": "SparseMatrix.sparse_matrix_symb_block_encoding"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.block_encoding.sparse_matrix import (\n",
+    "    TopLeftRowColumnOracle,\n",
+    "    UniformEntryOracle,\n",
+    ")\n",
+    "\n",
+    "n = sympy.Symbol('n')\n",
+    "row_oracle = TopLeftRowColumnOracle(system_bitsize=n)\n",
+    "col_oracle = TopLeftRowColumnOracle(system_bitsize=n)\n",
+    "entry_oracle = UniformEntryOracle(system_bitsize=n, entry=0.3)\n",
+    "sparse_matrix_symb_block_encoding = SparseMatrix(row_oracle, col_oracle, entry_oracle, eps=0)"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "d3b284ec",
+   "id": "0f6289c0",
    "metadata": {
     "cq.autogen": "SparseMatrix.graphical_signature.md"
    },
@@ -1444,20 +1465,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aeb878e9",
+   "id": "d84b6eea",
    "metadata": {
     "cq.autogen": "SparseMatrix.graphical_signature.py"
    },
    "outputs": [],
    "source": [
     "from qualtran.drawing import show_bloqs\n",
-    "show_bloqs([sparse_matrix_block_encoding, explicit_matrix_block_encoding, symmetric_banded_matrix_block_encoding],\n",
-    "           ['`sparse_matrix_block_encoding`', '`explicit_matrix_block_encoding`', '`symmetric_banded_matrix_block_encoding`'])"
+    "show_bloqs([sparse_matrix_block_encoding, sparse_matrix_symb_block_encoding, explicit_matrix_block_encoding, symmetric_banded_matrix_block_encoding],\n",
+    "           ['`sparse_matrix_block_encoding`', '`sparse_matrix_symb_block_encoding`', '`explicit_matrix_block_encoding`', '`symmetric_banded_matrix_block_encoding`'])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "84a1bbe1",
+   "id": "49c15da6",
    "metadata": {
     "cq.autogen": "SparseMatrix.call_graph.md"
    },
@@ -1468,7 +1489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ca44b35",
+   "id": "8fd1601b",
    "metadata": {
     "cq.autogen": "SparseMatrix.call_graph.py"
    },

--- a/qualtran/bloqs/block_encoding/sparse_matrix.py
+++ b/qualtran/bloqs/block_encoding/sparse_matrix.py
@@ -502,7 +502,6 @@ _SPARSE_MATRIX_DOC = BloqDocSpec(
     bloq_cls=SparseMatrix,
     import_line="from qualtran.bloqs.block_encoding import SparseMatrix",
     examples=[
-
         _sparse_matrix_block_encoding,
         _sparse_matrix_symb_block_encoding,
         _explicit_matrix_block_encoding,

--- a/qualtran/bloqs/block_encoding/sparse_matrix.py
+++ b/qualtran/bloqs/block_encoding/sparse_matrix.py
@@ -17,6 +17,7 @@ from functools import cached_property
 from typing import Dict, Iterable, Set, Tuple
 
 import numpy as np
+import sympy
 from attrs import field, frozen
 from numpy.typing import NDArray
 
@@ -455,6 +456,21 @@ def _sparse_matrix_block_encoding() -> SparseMatrix:
 
 
 @bloq_example
+def _sparse_matrix_symb_block_encoding() -> SparseMatrix:
+    from qualtran.bloqs.block_encoding.sparse_matrix import (
+        TopLeftRowColumnOracle,
+        UniformEntryOracle,
+    )
+
+    n = sympy.Symbol('n')
+    row_oracle = TopLeftRowColumnOracle(system_bitsize=n)
+    col_oracle = TopLeftRowColumnOracle(system_bitsize=n)
+    entry_oracle = UniformEntryOracle(system_bitsize=n, entry=0.3)
+    sparse_matrix_symb_block_encoding = SparseMatrix(row_oracle, col_oracle, entry_oracle, eps=0)
+    return sparse_matrix_symb_block_encoding
+
+
+@bloq_example
 def _explicit_matrix_block_encoding() -> SparseMatrix:
     from qualtran.bloqs.block_encoding.sparse_matrix import (
         ExplicitEntryOracle,
@@ -486,7 +502,9 @@ _SPARSE_MATRIX_DOC = BloqDocSpec(
     bloq_cls=SparseMatrix,
     import_line="from qualtran.bloqs.block_encoding import SparseMatrix",
     examples=[
+
         _sparse_matrix_block_encoding,
+        _sparse_matrix_symb_block_encoding,
         _explicit_matrix_block_encoding,
         _symmetric_banded_matrix_block_encoding,
     ],

--- a/qualtran/bloqs/block_encoding/sparse_matrix_test.py
+++ b/qualtran/bloqs/block_encoding/sparse_matrix_test.py
@@ -236,6 +236,15 @@ def test_symmetric_banded_row_column_matrix():
     np.testing.assert_allclose(test_matrix, from_tensors, atol=0.003)
 
 
+def test_counts():
+    qlt_testing.assert_equivalent_bloq_counts(
+        _sparse_matrix_block_encoding(), generalizer=ignore_split_join
+    )
+    qlt_testing.assert_equivalent_bloq_counts(
+        _explicit_matrix_block_encoding(), generalizer=ignore_split_join
+    )
+
+
 @pytest.mark.slow
 def test_matrix_stress():
     rs = np.random.RandomState(1234)

--- a/qualtran/conftest.py
+++ b/qualtran/conftest.py
@@ -104,6 +104,7 @@ def assert_bloq_example_serializes_for_pytest(bloq_ex: BloqExample):
         'linear_combination_block_encoding',
         'phase_block_encoding',
         'sparse_matrix_block_encoding',
+        'sparse_matrix_symb_block_encoding',
         'sparse_state_prep_alias_symb',  # cannot serialize Shaped
         'sparse_permutation',
         'permutation_cycle_symb',


### PR DESCRIPTION
Enables symbolic resource counting for `SparseMatrix` block encoding.
