### PR TITLE
Fix `AutoPartition` indexing bug with multiple `Unused`

### DIFF
--- a/qualtran/bloqs/bookkeeping/auto_partition.py
+++ b/qualtran/bloqs/bookkeeping/auto_partition.py
@@ -106,14 +106,14 @@ class AutoPartition(Bloq):
         parts: Dict[str, Partition] = dict()
         in_regs: Dict[str, SoquetT] = dict()
         unused_regs: Dict[str, SoquetT] = dict()
-        for out_reg, bloq_regs in self.partitions:
+        for parti, (out_reg, bloq_regs) in enumerate(self.partitions):
             part = Partition(
                 out_reg.bitsize,
                 regs=tuple(
                     (
                         self.bloq.signature.get_left(r)
                         if isinstance(r, str)
-                        else Register(f"_unused{i}", QAny(r.bitsize))
+                        else Register(f"_unused{parti}_{i}", QAny(r.bitsize))
                     )
                     for i, r in enumerate(bloq_regs)
                 ),

--- a/qualtran/bloqs/bookkeeping/auto_partition_test.py
+++ b/qualtran/bloqs/bookkeeping/auto_partition_test.py
@@ -16,6 +16,8 @@ import subprocess
 import pytest
 from attrs import evolve
 
+from qualtran import Controlled, CtrlSpec, QAny, Register
+from qualtran.bloqs.basic_gates import Swap
 from qualtran.bloqs.bookkeeping.auto_partition import (
     _auto_partition,
     _auto_partition_unused,
@@ -165,6 +167,39 @@ def test_auto_partition_unused():
 
     x, y, z = bloq.call_classically(x=0b010, y=0b0, z=0b01)
     assert x == 0b010
+    assert y == 0b0
+    assert z == 0b01
+
+    with pytest.raises(ValueError):
+        _ = evolve(bloq, left_only=True)
+
+
+def test_auto_partition_unused_index():
+    bloq = Controlled(Swap(1), CtrlSpec())
+    bloq = AutoPartition(
+        bloq,
+        [
+            (Register('x', QAny(3)), [Unused(1), 'ctrl', 'x']),
+            (Register('y', QAny(1)), ['y']),
+            (Register('z', QAny(2)), [Unused(2)]),
+        ],
+    )
+
+    assert tuple(bloq.signature.lefts()) == (
+        Register('x', dtype=QAny(3)),
+        Register('y', dtype=QAny(1)),
+        Register('z', dtype=QAny(2)),
+    )
+
+    assert tuple(bloq.signature.rights()) == tuple(bloq.signature.lefts())
+
+    x, y, z = bloq.call_classically(x=0b111, y=0b0, z=0b10)
+    assert x == 0b110
+    assert y == 0b1
+    assert z == 0b10
+
+    x, y, z = bloq.call_classically(x=0b001, y=0b0, z=0b01)
+    assert x == 0b001
     assert y == 0b0
     assert z == 0b01
 


### PR DESCRIPTION
Fix a bug in `AutoPartition` where having `Unused` assigned to the same position in two different exposed registers would map them to the same internal `_unused` register and break decomposition.
