### PR TITLE
Fix symbolic expression in `bit_length`

### DIFF
--- a/qualtran/bloqs/arithmetic/permutation.ipynb
+++ b/qualtran/bloqs/arithmetic/permutation.ipynb
@@ -106,7 +106,7 @@
     "\n",
     "from qualtran.symbolics import Shaped\n",
     "\n",
-    "N, k = sympy.symbols(\"N k\")\n",
+    "N, k = sympy.symbols(\"N k\", positive=True, integer=True)\n",
     "permutation_symb = Permutation(N, Shaped((k,)))"
    ]
   },
@@ -123,7 +123,7 @@
     "\n",
     "from qualtran.symbolics import Shaped\n",
     "\n",
-    "N = sympy.symbols(\"N\")\n",
+    "N = sympy.symbols(\"N\", positive=True, integer=True)\n",
     "n_cycles = 4\n",
     "d = sympy.IndexedBase('d', shape=(n_cycles,))\n",
     "permutation_symb_with_cycles = Permutation(N, tuple(Shaped((d[i],)) for i in range(n_cycles)))"
@@ -274,7 +274,7 @@
     "\n",
     "from qualtran.symbolics import Shaped\n",
     "\n",
-    "N, L = sympy.symbols(\"N L\")\n",
+    "N, L = sympy.symbols(\"N L\", positive=True, integer=True)\n",
     "cycle = Shaped((L,))\n",
     "permutation_cycle_symb = PermutationCycle(N, cycle)"
    ]

--- a/qualtran/bloqs/arithmetic/permutation.py
+++ b/qualtran/bloqs/arithmetic/permutation.py
@@ -149,7 +149,7 @@ def _permutation_cycle_symb() -> PermutationCycle:
 
     from qualtran.symbolics import Shaped
 
-    N, L = sympy.symbols("N L")
+    N, L = sympy.symbols("N L", positive=True, integer=True)
     cycle = Shaped((L,))
     permutation_cycle_symb = PermutationCycle(N, cycle)
     return permutation_cycle_symb
@@ -281,7 +281,7 @@ def _permutation_symb() -> Permutation:
 
     from qualtran.symbolics import Shaped
 
-    N, k = sympy.symbols("N k")
+    N, k = sympy.symbols("N k", positive=True, integer=True)
     permutation_symb = Permutation(N, Shaped((k,)))
     return permutation_symb
 
@@ -292,7 +292,7 @@ def _permutation_symb_with_cycles() -> Permutation:
 
     from qualtran.symbolics import Shaped
 
-    N = sympy.symbols("N")
+    N = sympy.symbols("N", positive=True, integer=True)
     n_cycles = 4
     d = sympy.IndexedBase('d', shape=(n_cycles,))
     permutation_symb_with_cycles = Permutation(N, tuple(Shaped((d[i],)) for i in range(n_cycles)))

--- a/qualtran/bloqs/arithmetic/permutation_test.py
+++ b/qualtran/bloqs/arithmetic/permutation_test.py
@@ -40,7 +40,7 @@ from qualtran.bloqs.arithmetic.permutation import (
 from qualtran.bloqs.basic_gates import CNOT, TGate, XGate
 from qualtran.bloqs.bookkeeping import Allocate, ArbitraryClifford, Free
 from qualtran.resource_counting.generalizers import ignore_split_join
-from qualtran.symbolics import bit_length, slen
+from qualtran.symbolics import ceil, log2, slen
 
 
 def test_examples(bloq_autotester):
@@ -74,7 +74,7 @@ def test_permutation_cycle_unitary_and_call_graph():
 
 def test_permutation_cycle_symbolic_call_graph():
     bloq = _permutation_cycle_symb()
-    logN, L = bit_length(bloq.N - 1), slen(bloq.cycle)
+    logN, L = ceil(log2(bloq.N)), slen(bloq.cycle)
 
     _, sigma = bloq.call_graph()
     assert sigma == {
@@ -126,8 +126,8 @@ def test_sparse_permutation_classical_sim():
 
 
 def test_permutation_symbolic_call_graph():
-    N = sympy.Symbol("N")
-    logN = bit_length(N - 1)
+    N = sympy.Symbol("N", positive=True, integer=True)
+    logN = ceil(log2(N))
     bloq = _permutation_symb()
 
     _, sigma = bloq.call_graph()

--- a/qualtran/bloqs/block_encoding/block_encoding.ipynb
+++ b/qualtran/bloqs/block_encoding/block_encoding.ipynb
@@ -1445,7 +1445,7 @@
     "    UniformEntryOracle,\n",
     ")\n",
     "\n",
-    "n = sympy.Symbol('n')\n",
+    "n = sympy.Symbol('n', positive=True, integer=True)\n",
     "row_oracle = TopLeftRowColumnOracle(system_bitsize=n)\n",
     "col_oracle = TopLeftRowColumnOracle(system_bitsize=n)\n",
     "entry_oracle = UniformEntryOracle(system_bitsize=n, entry=0.3)\n",

--- a/qualtran/bloqs/block_encoding/sparse_matrix.py
+++ b/qualtran/bloqs/block_encoding/sparse_matrix.py
@@ -462,7 +462,7 @@ def _sparse_matrix_symb_block_encoding() -> SparseMatrix:
         UniformEntryOracle,
     )
 
-    n = sympy.Symbol('n')
+    n = sympy.Symbol('n', positive=True, integer=True)
     row_oracle = TopLeftRowColumnOracle(system_bitsize=n)
     col_oracle = TopLeftRowColumnOracle(system_bitsize=n)
     entry_oracle = UniformEntryOracle(system_bitsize=n, entry=0.3)

--- a/qualtran/bloqs/block_encoding/sparse_matrix_test.py
+++ b/qualtran/bloqs/block_encoding/sparse_matrix_test.py
@@ -33,7 +33,6 @@ from qualtran.bloqs.block_encoding.sparse_matrix import (
     UniformEntryOracle,
 )
 from qualtran.resource_counting.generalizers import ignore_split_join
-from qualtran.symbolics import ceil, log2
 
 
 def test_sparse_matrix(bloq_autotester):
@@ -83,8 +82,8 @@ def test_call_graph():
 
     bloq = _sparse_matrix_symb_block_encoding()
     _, sigma = bloq.call_graph(generalizer=ignore_split_join)
-    n = sympy.Symbol('n')
-    assert sigma[Hadamard()] == 6 * ceil(log2(2**n - 1))
+    n = sympy.Symbol('n', integer=True, positive=True)
+    assert sigma[Hadamard()] == 6 * n
 
 
 def test_sparse_matrix_tensors():

--- a/qualtran/bloqs/block_encoding/sparse_matrix_test.py
+++ b/qualtran/bloqs/block_encoding/sparse_matrix_test.py
@@ -67,7 +67,7 @@ def test_sparse_matrix_params():
     assert bloq.resource_bitsize == 0
 
     bloq = _sparse_matrix_symb_block_encoding()
-    n = sympy.Symbol('n')
+    n = sympy.Symbol('n', positive=True, integer=True)
     assert bloq.system_bitsize == n
     assert bloq.alpha == 2**n
     assert bloq.epsilon == 0

--- a/qualtran/bloqs/state_preparation/prepare_uniform_superposition.py
+++ b/qualtran/bloqs/state_preparation/prepare_uniform_superposition.py
@@ -174,7 +174,8 @@ def _prep_uniform() -> PrepareUniformSuperposition:
 def _prep_uniform_symb() -> PrepareUniformSuperposition:
     import sympy
 
-    prep_uniform_symb = PrepareUniformSuperposition(n=sympy.Symbol("n"))
+    n = sympy.Symbol("n", positive=True, integer=True)
+    prep_uniform_symb = PrepareUniformSuperposition(n=n)
     return prep_uniform_symb
 
 

--- a/qualtran/bloqs/state_preparation/prepare_uniform_superposition_test.py
+++ b/qualtran/bloqs/state_preparation/prepare_uniform_superposition_test.py
@@ -40,7 +40,7 @@ def test_prep_uniform_symb():
     bloq = _prep_uniform_symb.make()
     # TODO: This should be 8logL instead because LessThanConst + LessThanConst.adjoint() should combined
     # be n AND / AND^{dagger} gates. We are doing the work twice right now.
-    assert bloq.t_complexity().t == 12 * ceil(log2(bloq.n - 1)) - 4
+    assert bloq.t_complexity().t == 12 * ceil(log2(bloq.n)) - 4
 
 
 @pytest.mark.notebook

--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling_test.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling_test.py
@@ -199,9 +199,10 @@ def test_sparse_state_preparation_via_coherent_alias():
 def test_symbolic_sparse_state_prep_t_complexity():
     from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 
-    N, d, qlambda, eps = sympy.symbols(r"N d \lambda \epsilon")
-    logN = ceil(log2(N - 1))
-    logd = ceil(log2(d - 1))
+    N, d = sympy.symbols("N d", positive=True, integer=True)
+    qlambda, eps = sympy.symbols(r"\lambda \epsilon")
+    logN = ceil(log2(N))
+    logd = ceil(log2(d))
     mu = ceil(log2(1 / (N * eps)))
     bloq = SparseStatePreparationAliasSampling.from_n_coeff(N, d, qlambda, precision=eps)
     assert bloq.t_complexity() == TComplexity(

--- a/qualtran/symbolics/math_funcs.py
+++ b/qualtran/symbolics/math_funcs.py
@@ -157,10 +157,7 @@ def bit_length(x: SymbolicFloat) -> SymbolicInt:
     """Returns the number of bits required to represent the integer part of positive float `x`."""
     if not is_symbolic(x) and 0 <= x < 1:
         return 0
-    ret = ceil(log2(x))
-    if is_symbolic(ret):
-        return ret
-    return ret + 1 if ret == floor(log2(x)) else ret
+    return ceil(log2(floor(x) + 1))
 
 
 def smax(*args):

--- a/qualtran/symbolics/math_funcs_test.py
+++ b/qualtran/symbolics/math_funcs_test.py
@@ -113,6 +113,13 @@ def test_bit_length():
         assert x.bit_length() == bit_length(x + 0.0001)
 
 
+@pytest.mark.parametrize('val', [3, 4])
+def test_bit_length_symbolic(val: int):
+    n: sympy.Expr = sympy.Symbol("n")
+    b: sympy.Expr = bit_length(n)
+    assert b.subs({n: val}) == val.bit_length()
+
+
 @pytest.mark.parametrize(
     "shape",
     [(4,), (1, 2), (1, 2, 3), (sympy.Symbol('n'),), (sympy.Symbol('n'), sympy.Symbol('m'), 100)],

--- a/qualtran/symbolics/math_funcs_test.py
+++ b/qualtran/symbolics/math_funcs_test.py
@@ -120,6 +120,15 @@ def test_bit_length_symbolic(val: int):
     assert b.subs({n: val}) == val.bit_length()
 
 
+def test_bit_length_symbolic_simplify():
+    """Most common use case of bit_length: bits to represent [0, N - 1]"""
+    n: sympy.Expr = sympy.Symbol("n", positive=True, integer=True)
+    N: sympy.Expr = sympy.Symbol("N", positive=True, integer=True)
+    b: sympy.Expr = bit_length(N - 1)
+    assert b == ceil(log2(N))
+    assert b.subs({N: 2**n}) == n
+
+
 @pytest.mark.parametrize(
     "shape",
     [(4,), (1, 2), (1, 2, 3), (sympy.Symbol('n'),), (sympy.Symbol('n'), sympy.Symbol('m'), 100)],


### PR DESCRIPTION
The previous symbolic expression was `ceil(log2(x))` which is incorrect (e.g. `n=4`). This refactor uses a single correct expression for both symbolic and non-symbolic cases.

- Added a test to verify the new expression matches.
- This also simplifies some awkward looking symbolic terms, e.g. `ceil(log2(2**n - 1))` to `n` (when `n` is a sympy symbol declared with `positive=True, integer=True`)