### PR TITLE
Remove redundant import_line from BloqDocSpec

### DIFF
--- a/qualtran/bloqs/basic_gates/identity.py
+++ b/qualtran/bloqs/basic_gates/identity.py
@@ -100,8 +100,4 @@ def _identity() -> Identity:
     return identity
 
 
-_IDENTITY_DOC = BloqDocSpec(
-    bloq_cls=Identity,
-    import_line='from qualtran.bloqs.basic_gates import Identity',
-    examples=[_identity],
-)
+_IDENTITY_DOC = BloqDocSpec(bloq_cls=Identity, examples=[_identity])

--- a/qualtran/bloqs/basic_gates/su2_rotation.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation.py
@@ -197,7 +197,5 @@ def _t_gate() -> SU2RotationGate:
 
 
 _SU2_ROTATION_GATE_DOC = BloqDocSpec(
-    bloq_cls=SU2RotationGate,
-    import_line='from qualtran.bloqs.basic_gates import SU2RotationGate',
-    examples=[_su2_rotation_gate, _hadamard, _t_gate],
+    bloq_cls=SU2RotationGate, examples=[_su2_rotation_gate, _hadamard, _t_gate]
 )

--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -350,8 +350,4 @@ def _cswap_large() -> CSwap:
     return cswap_large
 
 
-_CSWAP_DOC = BloqDocSpec(
-    bloq_cls=CSwap,
-    import_line='from qualtran.bloqs.basic_gates import CSwap',
-    examples=(_cswap_symb, _cswap_small, _cswap_large),
-)
+_CSWAP_DOC = BloqDocSpec(bloq_cls=CSwap, examples=(_cswap_symb, _cswap_small, _cswap_large))

--- a/qualtran/bloqs/basic_gates/t_gate.py
+++ b/qualtran/bloqs/basic_gates/t_gate.py
@@ -117,6 +117,4 @@ def _t_gate() -> TGate:
     return t_gate
 
 
-_T_GATE_DOC = BloqDocSpec(
-    bloq_cls=TGate, import_line='from qualtran.bloqs.basic_gates import TGate', examples=[_t_gate]
-)
+_T_GATE_DOC = BloqDocSpec(bloq_cls=TGate, examples=[_t_gate])

--- a/qualtran/bloqs/basic_gates/toffoli.py
+++ b/qualtran/bloqs/basic_gates/toffoli.py
@@ -131,8 +131,4 @@ def _toffoli() -> Toffoli:
     return toffoli
 
 
-_TOFFOLI_DOC = BloqDocSpec(
-    bloq_cls=Toffoli,
-    import_line='from qualtran.bloqs.basic_gates import Toffoli',
-    examples=[_toffoli],
-)
+_TOFFOLI_DOC = BloqDocSpec(bloq_cls=Toffoli, examples=[_toffoli])

--- a/qualtran/bloqs/block_encoding/block_encoding_base.py
+++ b/qualtran/bloqs/block_encoding/block_encoding_base.py
@@ -115,7 +115,5 @@ class BlockEncoding(Bloq):
 
 
 _BLOCK_ENCODING_DOC = BloqDocSpec(
-    bloq_cls=BlockEncoding,  # type: ignore[type-abstract]
-    import_line="from qualtran.bloqs.block_encoding import BlockEncoding",
-    examples=[],
+    bloq_cls=BlockEncoding, examples=[]  # type: ignore[type-abstract]
 )

--- a/qualtran/bloqs/block_encoding/lcu_block_encoding.py
+++ b/qualtran/bloqs/block_encoding/lcu_block_encoding.py
@@ -450,20 +450,11 @@ def _black_box_lcu_zero_state_block() -> LCUBlockEncodingZeroState:
     return black_box_lcu_zero_state_block
 
 
-_BLOCK_ENCODING_DOC = BloqDocSpec(
-    bloq_cls=BlockEncoding,  # type: ignore[type-abstract]
-    import_line="from qualtran.bloqs.block_encoding import BlockEncoding",
-    examples=[],
-)
-
 _LCU_BLOCK_ENCODING_DOC = BloqDocSpec(
-    bloq_cls=LCUBlockEncoding,
-    import_line='from qualtran.bloqs.block_encoding import LCUBlockEncoding',
-    examples=(_lcu_block, _black_box_lcu_block),
+    bloq_cls=LCUBlockEncoding, examples=(_lcu_block, _black_box_lcu_block)
 )
 
 _LCU_ZERO_STATE_BLOCK_ENCODING_DOC = BloqDocSpec(
     bloq_cls=LCUBlockEncodingZeroState,
-    import_line='from qualtran.bloqs.block_encoding import LCUBlockEncodingZeroState',
     examples=(_lcu_zero_state_block, _black_box_lcu_zero_state_block),
 )

--- a/qualtran/bloqs/block_encoding/linear_combination.py
+++ b/qualtran/bloqs/block_encoding/linear_combination.py
@@ -348,7 +348,5 @@ def _linear_combination_block_encoding() -> LinearCombination:
 
 
 _LINEAR_COMBINATION_DOC = BloqDocSpec(
-    bloq_cls=LinearCombination,
-    import_line="from qualtran.bloqs.block_encoding import LinearCombination",
-    examples=[_linear_combination_block_encoding],
+    bloq_cls=LinearCombination, examples=[_linear_combination_block_encoding]
 )

--- a/qualtran/bloqs/block_encoding/phase.py
+++ b/qualtran/bloqs/block_encoding/phase.py
@@ -115,8 +115,4 @@ def _phase_block_encoding() -> Phase:
     return phase_block_encoding
 
 
-_PHASE_DOC = BloqDocSpec(
-    bloq_cls=Phase,
-    import_line="from qualtran.bloqs.block_encoding import Phase",
-    examples=[_phase_block_encoding],
-)
+_PHASE_DOC = BloqDocSpec(bloq_cls=Phase, examples=[_phase_block_encoding])

--- a/qualtran/bloqs/block_encoding/product.py
+++ b/qualtran/bloqs/block_encoding/product.py
@@ -264,7 +264,6 @@ def _product_block_encoding_symb() -> Product:
 
 _PRODUCT_DOC = BloqDocSpec(
     bloq_cls=Product,
-    import_line="from qualtran.bloqs.block_encoding import Product",
     examples=[
         _product_block_encoding,
         _product_block_encoding_properties,

--- a/qualtran/bloqs/block_encoding/sparse_matrix.py
+++ b/qualtran/bloqs/block_encoding/sparse_matrix.py
@@ -500,7 +500,6 @@ def _symmetric_banded_matrix_block_encoding() -> SparseMatrix:
 
 _SPARSE_MATRIX_DOC = BloqDocSpec(
     bloq_cls=SparseMatrix,
-    import_line="from qualtran.bloqs.block_encoding import SparseMatrix",
     examples=[
         _sparse_matrix_block_encoding,
         _sparse_matrix_symb_block_encoding,

--- a/qualtran/bloqs/block_encoding/tensor_product.py
+++ b/qualtran/bloqs/block_encoding/tensor_product.py
@@ -230,7 +230,6 @@ def _tensor_product_block_encoding_symb() -> TensorProduct:
 
 _TENSOR_PRODUCT_DOC = BloqDocSpec(
     bloq_cls=TensorProduct,
-    import_line="from qualtran.bloqs.block_encoding import TensorProduct",
     examples=[
         _tensor_product_block_encoding,
         _tensor_product_block_encoding_properties,

--- a/qualtran/bloqs/block_encoding/unitary.py
+++ b/qualtran/bloqs/block_encoding/unitary.py
@@ -135,7 +135,5 @@ def _unitary_block_encoding_properties() -> Unitary:
 
 
 _UNITARY_DOC = BloqDocSpec(
-    bloq_cls=Unitary,
-    import_line="from qualtran.bloqs.block_encoding import Unitary",
-    examples=[_unitary_block_encoding, _unitary_block_encoding_properties],
+    bloq_cls=Unitary, examples=[_unitary_block_encoding, _unitary_block_encoding_properties]
 )

--- a/qualtran/bloqs/bookkeeping/auto_partition.py
+++ b/qualtran/bloqs/bookkeeping/auto_partition.py
@@ -173,7 +173,5 @@ def _auto_partition_unused() -> AutoPartition:
 
 
 _AUTO_PARTITION_DOC = BloqDocSpec(
-    bloq_cls=AutoPartition,
-    import_line="from qualtran.bloqs.bookkeeping import AutoPartition",
-    examples=[_auto_partition, _auto_partition_unused],
+    bloq_cls=AutoPartition, examples=[_auto_partition, _auto_partition_unused]
 )

--- a/qualtran/bloqs/chemistry/hubbard_model/qubitization/prepare_hubbard.py
+++ b/qualtran/bloqs/chemistry/hubbard_model/qubitization/prepare_hubbard.py
@@ -152,8 +152,4 @@ def _prep_hubb() -> PrepareHubbard:
     return prep_hubb
 
 
-_PREPARE_HUBBARD = BloqDocSpec(
-    bloq_cls=PrepareHubbard,
-    import_line='from qualtran.bloqs.chemistry.hubbard_model.qubitization import PrepareHubbard',
-    examples=(_prep_hubb,),
-)
+_PREPARE_HUBBARD = BloqDocSpec(bloq_cls=PrepareHubbard, examples=(_prep_hubb,))

--- a/qualtran/bloqs/chemistry/hubbard_model/qubitization/select_hubbard.py
+++ b/qualtran/bloqs/chemistry/hubbard_model/qubitization/select_hubbard.py
@@ -197,8 +197,4 @@ def _sel_hubb() -> SelectHubbard:
     return sel_hubb
 
 
-_SELECT_HUBBARD: BloqDocSpec = BloqDocSpec(
-    bloq_cls=SelectHubbard,
-    import_line='from qualtran.bloqs.chemistry.hubbard_model.qubitization import SelectHubbard',
-    examples=(_sel_hubb,),
-)
+_SELECT_HUBBARD: BloqDocSpec = BloqDocSpec(bloq_cls=SelectHubbard, examples=(_sel_hubb,))

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_and_prepare.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_and_prepare.py
@@ -604,13 +604,9 @@ def _sel_first_quant() -> SelectFirstQuantizationWithProj:
 
 
 _FIRST_QUANTIZED_WITH_PROJ_PREPARE_DOC = BloqDocSpec(
-    bloq_cls=PrepareFirstQuantizationWithProj,
-    import_line='from qualtran.bloqs.chemistry.pbc.first_quantization.projectile import PrepareFirstQuantizationWithProj',
-    examples=(_prep_first_quant,),
+    bloq_cls=PrepareFirstQuantizationWithProj, examples=(_prep_first_quant,)
 )
 
 _FIRST_QUANTIZED_WITH_PROJ_SELECT_DOC = BloqDocSpec(
-    bloq_cls=SelectFirstQuantizationWithProj,
-    import_line='from qualtran.bloqs.chemistry.pbc.first_quantization.projectile import SelectFirstQuantizationWithProj',
-    examples=(_sel_first_quant,),
+    bloq_cls=SelectFirstQuantizationWithProj, examples=(_sel_first_quant,)
 )

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/select_and_prepare.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/select_and_prepare.py
@@ -544,13 +544,9 @@ def _sel_first_quant() -> SelectFirstQuantization:
 
 
 _FIRST_QUANTIZED_PREPARE_DOC = BloqDocSpec(
-    bloq_cls=PrepareFirstQuantization,
-    import_line='from qualtran.bloqs.chemistry.pbc.first_quantization import PrepareFirstQuantization',
-    examples=(_prep_first_quant,),
+    bloq_cls=PrepareFirstQuantization, examples=(_prep_first_quant,)
 )
 
 _FIRST_QUANTIZED_SELECT_DOC = BloqDocSpec(
-    bloq_cls=SelectFirstQuantization,
-    import_line='from qualtran.bloqs.chemistry.pbc.first_quantization import SelectFirstQuantization',
-    examples=(_sel_first_quant,),
+    bloq_cls=SelectFirstQuantization, examples=(_sel_first_quant,)
 )

--- a/qualtran/bloqs/mcmt/and_bloq.py
+++ b/qualtran/bloqs/mcmt/and_bloq.py
@@ -223,9 +223,7 @@ def _and_bloq() -> And:
     return and_bloq
 
 
-_AND_DOC = BloqDocSpec(
-    bloq_cls=And, import_line='from qualtran.bloqs.mcmt import And', examples=(_and_bloq,)
-)
+_AND_DOC = BloqDocSpec(bloq_cls=And, examples=(_and_bloq,))
 
 
 def _to_tuple_or_has_length(
@@ -372,8 +370,4 @@ def _multi_and_symb() -> MultiAnd:
     return multi_and_symb
 
 
-_MULTI_AND_DOC = BloqDocSpec(
-    bloq_cls=MultiAnd,
-    import_line='from qualtran.bloqs.mcmt import MultiAnd',
-    examples=(_multi_and,),
-)
+_MULTI_AND_DOC = BloqDocSpec(bloq_cls=MultiAnd, examples=(_multi_and,))

--- a/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
+++ b/qualtran/bloqs/mcmt/multi_control_multi_target_pauli.py
@@ -99,11 +99,7 @@ def _c_multi_not() -> MultiTargetCNOT:
     return c_multi_not
 
 
-_C_MULTI_NOT_DOC = BloqDocSpec(
-    bloq_cls=MultiTargetCNOT,
-    import_line='from qualtran.bloqs.mcmt import MultiTargetCNOT',
-    examples=(_c_multi_not_symb, _c_multi_not),
-)
+_C_MULTI_NOT_DOC = BloqDocSpec(bloq_cls=MultiTargetCNOT, examples=(_c_multi_not_symb, _c_multi_not))
 
 
 @frozen
@@ -243,11 +239,7 @@ def _ccpauli_symb() -> MultiControlPauli:
     return ccpauli_symb
 
 
-_CC_PAULI_DOC = BloqDocSpec(
-    bloq_cls=MultiControlPauli,
-    import_line='from qualtran.bloqs.mcmt import MultiControlPauli',
-    examples=(_ccpauli,),
-)
+_CC_PAULI_DOC = BloqDocSpec(bloq_cls=MultiControlPauli, examples=(_ccpauli,))
 
 
 @frozen

--- a/qualtran/bloqs/phase_estimation/text_book_qpe.py
+++ b/qualtran/bloqs/phase_estimation/text_book_qpe.py
@@ -290,7 +290,6 @@ def _textbook_qpe_from_standard_deviation_eps() -> TextbookQPE:
 
 _CC_TEXTBOOK_PHASE_ESTIMATION_DOC = BloqDocSpec(
     bloq_cls=TextbookQPE,
-    import_line='from qualtran.bloqs.phase_estimation import TextbookQPE',
     examples=(
         _textbook_qpe_small,
         _textbook_qpe_using_m_bits,

--- a/qualtran/bloqs/qubitization/qubitization_walk_operator.py
+++ b/qualtran/bloqs/qubitization/qubitization_walk_operator.py
@@ -204,7 +204,5 @@ def _walk_op_chem_sparse() -> QubitizationWalkOperator:
 
 
 _QUBITIZATION_WALK_DOC = BloqDocSpec(
-    bloq_cls=QubitizationWalkOperator,
-    import_line='from qualtran.bloqs.qubitization import QubitizationWalkOperator',
-    examples=(_walk_op, _thc_walk_op, _walk_op_chem_sparse),
+    bloq_cls=QubitizationWalkOperator, examples=(_walk_op, _thc_walk_op, _walk_op_chem_sparse)
 )

--- a/qualtran/bloqs/state_preparation/prepare_uniform_superposition.py
+++ b/qualtran/bloqs/state_preparation/prepare_uniform_superposition.py
@@ -186,7 +186,5 @@ def _c_prep_uniform() -> PrepareUniformSuperposition:
 
 
 _PREP_UNIFORM_DOC = BloqDocSpec(
-    bloq_cls=PrepareUniformSuperposition,
-    import_line='from qualtran.bloqs.state_preparation import PrepareUniformSuperposition',
-    examples=(_prep_uniform, _c_prep_uniform),
+    bloq_cls=PrepareUniformSuperposition, examples=(_prep_uniform, _c_prep_uniform)
 )

--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
@@ -283,9 +283,7 @@ def _state_prep_alias_symb() -> StatePreparationAliasSampling:
 
 
 _STATE_PREP_ALIAS_DOC = BloqDocSpec(
-    bloq_cls=StatePreparationAliasSampling,
-    import_line='from qualtran.bloqs.state_preparation import StatePreparationAliasSampling',
-    examples=(_state_prep_alias, _state_prep_alias_symb),
+    bloq_cls=StatePreparationAliasSampling, examples=(_state_prep_alias, _state_prep_alias_symb)
 )
 
 

--- a/qualtran/bloqs/swap_network/cswap_approx.py
+++ b/qualtran/bloqs/swap_network/cswap_approx.py
@@ -145,7 +145,5 @@ def _approx_cswap_large() -> CSwapApprox:
 
 
 _APPROX_CSWAP_DOC = BloqDocSpec(
-    bloq_cls=CSwapApprox,
-    import_line='from qualtran.bloqs.swap_network import CSwapApprox',
-    examples=(_approx_cswap_symb, _approx_cswap_small, _approx_cswap_large),
+    bloq_cls=CSwapApprox, examples=(_approx_cswap_symb, _approx_cswap_small, _approx_cswap_large)
 )

--- a/qualtran/bloqs/swap_network/multiplexed_cswap.py
+++ b/qualtran/bloqs/swap_network/multiplexed_cswap.py
@@ -121,8 +121,4 @@ def _multiplexed_cswap() -> MultiplexedCSwap:
     return multiplexed_cswap
 
 
-_MULTIPLEXED_CSWAP_DOC = BloqDocSpec(
-    bloq_cls=MultiplexedCSwap,
-    import_line='from qualtran.bloqs.swap_network import MultiplexedCSwap',
-    examples=(_multiplexed_cswap,),
-)
+_MULTIPLEXED_CSWAP_DOC = BloqDocSpec(bloq_cls=MultiplexedCSwap, examples=(_multiplexed_cswap,))

--- a/qualtran/bloqs/swap_network/swap_with_zero.py
+++ b/qualtran/bloqs/swap_network/swap_with_zero.py
@@ -193,8 +193,4 @@ def _swz_multi_dimensional() -> SwapWithZero:
     return swz_multi_dimensional
 
 
-_SWZ_DOC = BloqDocSpec(
-    bloq_cls=SwapWithZero,
-    import_line='from qualtran.bloqs.swap_network import SwapWithZero',
-    examples=(_swz, _swz_small, _swz_multi_dimensional),
-)
+_SWZ_DOC = BloqDocSpec(bloq_cls=SwapWithZero, examples=(_swz, _swz_small, _swz_multi_dimensional))


### PR DESCRIPTION
These `import_line`s are all equivalent to the default generated by `BloqDocSpec`.

There may be more that are technically redundant but are different from their current state in the notebook (i.e. import from a child rather than parent module). They can be addressed in a follow-up PR.
