### PR TITLE
Add an optimizer for `LinearCombination`s

### DIFF
--- a/qualtran/bloqs/block_encoding/rewrites.py
+++ b/qualtran/bloqs/block_encoding/rewrites.py
@@ -1,0 +1,73 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+r"""Rewrite rules to optimize the construction of block encodings."""
+
+from collections import defaultdict
+from typing import Dict
+
+from qualtran.bloqs.block_encoding import (
+    BlockEncoding,
+    LinearCombination,
+    Phase,
+    Product,
+    SparseMatrix,
+    TensorProduct,
+    Unitary,
+)
+from qualtran.symbolics import smax
+
+
+def collect_like_terms(x: BlockEncoding) -> BlockEncoding:
+    '''Optimize a `BlockEncoding` by collecting like terms in nested `LinearCombination`s.
+
+    The effect is to replace instances of
+    ```
+    LinearCombination(
+        (LinearCombination((a, b), (l_a, l_b)), LinearCombination((c, d), (l_c, l_d)),
+        (l_ab, l_cd)
+    )
+    ```
+    with
+    ```
+    LinearCombination(
+        (a, b, c, d), (l_ab * l_a, l_ab * l_b, l_cd * l_c, l_cd * l_d)
+    )
+    ```
+    which requires fewer resources.
+    '''
+
+    if isinstance(x, (Unitary, SparseMatrix)):
+        return x
+    if isinstance(x, Phase):
+        return Phase(collect_like_terms(x.block_encoding), x.phi, x.eps)
+    if isinstance(x, TensorProduct):
+        return TensorProduct(tuple(collect_like_terms(y) for y in x.block_encodings))
+    if isinstance(x, Product):
+        return Product(tuple(collect_like_terms(y) for y in x.block_encodings))
+    if isinstance(x, LinearCombination):
+        block_encodings: Dict[BlockEncoding, float] = defaultdict(float)
+        terms = tuple(collect_like_terms(y) for y in x._block_encodings)
+        lambd_bits = x.lambd_bits
+        for y, l in zip(terms, x._lambd):
+            if isinstance(y, LinearCombination):
+                lambd_bits = smax(lambd_bits, x.lambd_bits + y.lambd_bits)
+                for z, m in zip(y._block_encodings, y._lambd):
+                    block_encodings[z] += l * m
+            else:
+                block_encodings[y] += l
+        return LinearCombination(
+            tuple(block_encodings.keys()), tuple(block_encodings.values()), lambd_bits
+        )
+    return x

--- a/qualtran/bloqs/block_encoding/rewrites.py
+++ b/qualtran/bloqs/block_encoding/rewrites.py
@@ -30,7 +30,7 @@ from qualtran.symbolics import smax
 
 
 def collect_like_terms(x: BlockEncoding) -> BlockEncoding:
-    '''Optimize a `BlockEncoding` by collecting like terms in nested `LinearCombination`s.
+    """Optimize a `BlockEncoding` by collecting like terms in nested `LinearCombination`s.
 
     The effect is to replace instances of
     ```
@@ -46,7 +46,7 @@ def collect_like_terms(x: BlockEncoding) -> BlockEncoding:
     )
     ```
     which requires fewer resources.
-    '''
+    """
 
     if isinstance(x, (Unitary, SparseMatrix)):
         return x

--- a/qualtran/bloqs/block_encoding/rewrites_test.py
+++ b/qualtran/bloqs/block_encoding/rewrites_test.py
@@ -1,0 +1,57 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from qualtran.bloqs.basic_gates import Hadamard, XGate
+from qualtran.bloqs.block_encoding import LinearCombination, Phase, Product, TensorProduct, Unitary
+from qualtran.bloqs.block_encoding.rewrites import collect_like_terms
+
+
+def test_collect_like_terms_atomic():
+    assert collect_like_terms(Unitary(XGate())) == Unitary(XGate())
+    assert collect_like_terms(
+        Product((Phase(Unitary(XGate()), phi=1, eps=1), Unitary(XGate())))
+    ) == Product((Phase(Unitary(XGate()), phi=1, eps=1), Unitary(XGate())))
+
+
+def test_collect_like_terms_nested():
+    assert collect_like_terms(
+        TensorProduct(
+            (
+                LinearCombination(
+                    (
+                        LinearCombination(
+                            (Unitary(XGate()), Unitary(Hadamard())), (2.0, 2.0), lambd_bits=1
+                        ),
+                        LinearCombination(
+                            (Unitary(XGate()), Phase(Unitary(Hadamard()), phi=1, eps=1)),
+                            (1.0, -1.0),
+                            lambd_bits=1,
+                        ),
+                    ),
+                    (1.0, -1.0),
+                    lambd_bits=1,
+                ),
+                Unitary(XGate()),
+            )
+        )
+    ) == TensorProduct(
+        (
+            LinearCombination(
+                (Unitary(XGate()), Unitary(Hadamard()), Phase(Unitary(Hadamard()), phi=1, eps=1)),
+                (1.0, 2.0, 1.0),
+                lambd_bits=2,
+            ),
+            Unitary(XGate()),
+        )
+    )


### PR DESCRIPTION
This rewrite rule reduces the resource cost of nested `LinearCombinations` by flattening them.
