### PR TITLE
Remove legacy register methods from `BlockEncoding` interface

### DIFF
--- a/qualtran/bloqs/block_encoding/block_encoding_base.py
+++ b/qualtran/bloqs/block_encoding/block_encoding_base.py
@@ -12,9 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import abc
-from typing import Tuple
 
-from qualtran import Bloq, BloqDocSpec, Register
+from qualtran import Bloq, BloqDocSpec
 from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
 from qualtran.symbolics import SymbolicFloat, SymbolicInt
 
@@ -92,21 +91,6 @@ class BlockEncoding(Bloq):
     def epsilon(self) -> SymbolicFloat:
         """The precision to which the block encoding is to be prepared."""
         raise NotImplementedError
-
-    @property
-    @abc.abstractmethod
-    def selection_registers(self) -> Tuple[Register, ...]:
-        """The ancilla registers `a` above."""
-
-    @property
-    @abc.abstractmethod
-    def junk_registers(self) -> Tuple[Register, ...]:
-        """Any additional junk registers not included in selection registers."""
-
-    @property
-    @abc.abstractmethod
-    def target_registers(self) -> Tuple[Register, ...]:
-        """The system registers of combined size `s`."""
 
     @property
     @abc.abstractmethod

--- a/qualtran/bloqs/block_encoding/chebyshev_polynomial.py
+++ b/qualtran/bloqs/block_encoding/chebyshev_polynomial.py
@@ -108,18 +108,6 @@ class ChebyshevPolynomial(BlockEncoding):
         return self.block_encoding.epsilon * self.order
 
     @property
-    def target_registers(self) -> Tuple[Register, ...]:
-        return tuple(self.signature.rights())
-
-    @property
-    def junk_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("resource"),) if self.resource_bitsize > 0 else ()
-
-    @property
-    def selection_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("ancilla"),) if self.ancilla_bitsize > 0 else ()
-
-    @property
     def signal_state(self) -> PrepareOracle:
         # This method will be implemented in the future after PrepareOracle
         # is updated for the BlockEncoding interface.

--- a/qualtran/bloqs/block_encoding/chebyshev_polynomial_test.py
+++ b/qualtran/bloqs/block_encoding/chebyshev_polynomial_test.py
@@ -20,7 +20,7 @@ import pytest
 from attr import field, frozen
 from numpy.typing import NDArray
 
-from qualtran import BloqBuilder, Register, Signature, Soquet, SoquetT
+from qualtran import BloqBuilder, Signature, Soquet, SoquetT
 from qualtran.bloqs.basic_gates import Hadamard, Identity, IntEffect, IntState, XGate
 from qualtran.bloqs.block_encoding import BlockEncoding, Unitary
 from qualtran.bloqs.block_encoding.chebyshev_polynomial import (
@@ -185,18 +185,6 @@ class TestBlockEncoding(BlockEncoding):
 
     @property
     def signal_state(self) -> PrepareOracle:
-        raise NotImplementedError
-
-    @property
-    def target_registers(self) -> Tuple[Register, ...]:
-        raise NotImplementedError
-
-    @property
-    def junk_registers(self) -> Tuple[Register, ...]:
-        raise NotImplementedError
-
-    @property
-    def selection_registers(self) -> Tuple[Register, ...]:
         raise NotImplementedError
 
     def build_composite_bloq(

--- a/qualtran/bloqs/block_encoding/linear_combination.py
+++ b/qualtran/bloqs/block_encoding/linear_combination.py
@@ -170,18 +170,6 @@ class LinearCombination(BlockEncoding):
         )
 
     @property
-    def target_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("system"),)
-
-    @property
-    def junk_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("resource"),)
-
-    @property
-    def selection_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("ancilla"),)
-
-    @property
     def signal_state(self) -> PrepareOracle:
         # This method will be implemented in the future after PrepareOracle
         # is updated for the BlockEncoding interface.

--- a/qualtran/bloqs/block_encoding/phase.py
+++ b/qualtran/bloqs/block_encoding/phase.py
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Set, Tuple
+from typing import Dict, Set
 
 from attrs import frozen
 
-from qualtran import bloq_example, BloqBuilder, BloqDocSpec, QAny, Register, Signature, SoquetT
+from qualtran import bloq_example, BloqBuilder, BloqDocSpec, QAny, Signature, SoquetT
 from qualtran.bloqs.basic_gates import GlobalPhase
 from qualtran.bloqs.block_encoding import BlockEncoding
 from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
@@ -77,18 +77,6 @@ class Phase(BlockEncoding):
 
     def pretty_name(self) -> str:
         return f"B[exp({self.phi}i){self.block_encoding.pretty_name()[2:-1]}]"
-
-    @property
-    def target_registers(self) -> Tuple[Register, ...]:
-        return tuple(self.signature.rights())
-
-    @property
-    def junk_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("resource"),) if self.resource_bitsize > 0 else ()
-
-    @property
-    def selection_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("ancilla"),) if self.ancilla_bitsize > 0 else ()
 
     @property
     def signal_state(self) -> PrepareOracle:

--- a/qualtran/bloqs/block_encoding/product.py
+++ b/qualtran/bloqs/block_encoding/product.py
@@ -125,18 +125,6 @@ class Product(BlockEncoding):
         return ssum(u.alpha * u.epsilon for u in self.block_encodings)
 
     @property
-    def target_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("system"),)
-
-    @property
-    def junk_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("resource"),)
-
-    @property
-    def selection_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("ancilla"),)
-
-    @property
     def signal_state(self) -> PrepareOracle:
         # This method will be implemented in the future after PrepareOracle
         # is updated for the BlockEncoding interface.

--- a/qualtran/bloqs/block_encoding/sparse_matrix.py
+++ b/qualtran/bloqs/block_encoding/sparse_matrix.py
@@ -209,18 +209,6 @@ class SparseMatrix(BlockEncoding):
         return self.eps
 
     @property
-    def target_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("system"),)
-
-    @property
-    def junk_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("resource"),)
-
-    @property
-    def selection_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("ancilla"),)
-
-    @property
     def signal_state(self) -> PrepareOracle:
         # This method will be implemented in the future after PrepareOracle
         # is updated for the BlockEncoding interface.

--- a/qualtran/bloqs/block_encoding/tensor_product.py
+++ b/qualtran/bloqs/block_encoding/tensor_product.py
@@ -25,7 +25,6 @@ from qualtran import (
     BloqDocSpec,
     DecomposeTypeError,
     QAny,
-    Register,
     Signature,
     SoquetT,
 )
@@ -100,18 +99,6 @@ class TensorProduct(BlockEncoding):
     @cached_property
     def epsilon(self) -> SymbolicFloat:
         return ssum(u.alpha * u.epsilon for u in self.block_encodings)
-
-    @property
-    def target_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("system"),)
-
-    @property
-    def junk_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("resource"),) if self.resource_bitsize > 0 else ()
-
-    @property
-    def selection_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("ancilla"),) if self.ancilla_bitsize > 0 else ()
 
     @property
     def signal_state(self) -> PrepareOracle:

--- a/qualtran/bloqs/block_encoding/unitary.py
+++ b/qualtran/bloqs/block_encoding/unitary.py
@@ -13,21 +13,11 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Set, Tuple
+from typing import Dict, Set
 
 from attrs import frozen
 
-from qualtran import (
-    Bloq,
-    bloq_example,
-    BloqBuilder,
-    BloqDocSpec,
-    QAny,
-    Register,
-    Side,
-    Signature,
-    SoquetT,
-)
+from qualtran import Bloq, bloq_example, BloqBuilder, BloqDocSpec, QAny, Side, Signature, SoquetT
 from qualtran.bloqs.block_encoding import BlockEncoding
 from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
 from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
@@ -81,18 +71,6 @@ class Unitary(BlockEncoding):
 
     def pretty_name(self) -> str:
         return f"B[{self.U.pretty_name()}]"
-
-    @property
-    def target_registers(self) -> Tuple[Register, ...]:
-        return tuple(self.signature.rights())
-
-    @property
-    def junk_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("resource"),) if self.resource_bitsize > 0 else ()
-
-    @property
-    def selection_registers(self) -> Tuple[Register, ...]:
-        return (self.signature.get_right("ancilla"),) if self.ancilla_bitsize > 0 else ()
 
     @property
     def signal_state(self) -> PrepareOracle:


### PR DESCRIPTION
These methods have been superceded by corresponding `bitsize` methods.
