### PR TITLE
Make methods `abstractmethod` in `BlockEncoding`

### DIFF
--- a/qualtran/bloqs/block_encoding/block_encoding_base.py
+++ b/qualtran/bloqs/block_encoding/block_encoding_base.py
@@ -69,29 +69,29 @@ class BlockEncoding(Bloq):
         return 'B[H]'
 
     @property
+    @abc.abstractmethod
     def alpha(self) -> SymbolicFloat:
         """The normalization constant."""
-        raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def system_bitsize(self) -> SymbolicInt:
         """The number of qubits that represent the system being block encoded."""
-        raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def ancilla_bitsize(self) -> SymbolicInt:
         """The number of ancilla qubits."""
-        raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def resource_bitsize(self) -> SymbolicInt:
         """The number of resource qubits not counted in ancillas."""
-        raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def epsilon(self) -> SymbolicFloat:
         """The precision to which the block encoding is to be prepared."""
-        raise NotImplementedError
 
     @property
     @abc.abstractmethod

--- a/qualtran/bloqs/block_encoding/lcu_block_encoding.py
+++ b/qualtran/bloqs/block_encoding/lcu_block_encoding.py
@@ -247,6 +247,18 @@ class LCUBlockEncoding(BlockEncoding):
     prepare: Union[BlackBoxPrepare, PrepareOracle]
 
     @cached_property
+    def ancilla_bitsize(self) -> int:
+        return _total_bits(self.prepare.selection_registers)
+
+    @cached_property
+    def resource_bitsize(self) -> int:
+        return _total_bits(self.prepare.junk_registers)
+
+    @cached_property
+    def system_bitsize(self) -> int:
+        return _total_bits(self.select.target_registers)
+
+    @cached_property
     def selection_registers(self) -> Tuple[Register, ...]:
         return self.prepare.selection_registers
 
@@ -329,6 +341,18 @@ class LCUBlockEncodingZeroState(BlockEncoding):
     epsilon: SymbolicFloat
     select: Union[BlackBoxSelect, SelectOracle]
     prepare: Union[BlackBoxPrepare, PrepareOracle]
+
+    @cached_property
+    def ancilla_bitsize(self) -> int:
+        return _total_bits(self.prepare.selection_registers)
+
+    @cached_property
+    def resource_bitsize(self) -> int:
+        return _total_bits(self.prepare.junk_registers)
+
+    @cached_property
+    def system_bitsize(self) -> int:
+        return _total_bits(self.select.target_registers)
 
     @cached_property
     def selection_registers(self) -> Tuple[Register, ...]:

--- a/qualtran/bloqs/chemistry/df/double_factorization.py
+++ b/qualtran/bloqs/chemistry/df/double_factorization.py
@@ -122,13 +122,13 @@ class DoubleFactorizationOneBody(BlockEncoding):
 
     @property
     def alpha(self) -> float:
-        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
-        return 1.0
+        # TODO: implement, see https://github.com/quantumlib/Qualtran/issues/1247
+        raise NotImplementedError
 
     @property
     def epsilon(self) -> float:
-        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
-        return 0.0
+        # TODO: implement, see https://github.com/quantumlib/Qualtran/issues/1247
+        raise NotImplementedError
 
     @cached_property
     def ancilla_bitsize(self) -> int:
@@ -369,13 +369,13 @@ class DoubleFactorizationBlockEncoding(BlockEncoding):
 
     @property
     def alpha(self) -> float:
-        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
-        return 1.0
+        # TODO: implement, see https://github.com/quantumlib/Qualtran/issues/1247
+        raise NotImplementedError
 
     @property
     def epsilon(self) -> float:
-        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
-        return 0.0
+        # TODO: implement, see https://github.com/quantumlib/Qualtran/issues/1247
+        raise NotImplementedError
 
     @cached_property
     def ancilla_bitsize(self) -> int:

--- a/qualtran/bloqs/chemistry/df/double_factorization.py
+++ b/qualtran/bloqs/chemistry/df/double_factorization.py
@@ -121,6 +121,28 @@ class DoubleFactorizationOneBody(BlockEncoding):
         )
 
     @property
+    def alpha(self) -> float:
+        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
+        return 1.0
+
+    @property
+    def epsilon(self) -> float:
+        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
+        return 0.0
+
+    @cached_property
+    def ancilla_bitsize(self) -> int:
+        return sum(r.total_bits() for r in self.selection_registers)
+
+    @cached_property
+    def resource_bitsize(self) -> int:
+        return sum(r.total_bits() for r in self.junk_registers)
+
+    @cached_property
+    def system_bitsize(self) -> int:
+        return sum(r.total_bits() for r in self.target_registers)
+
+    @property
     def selection_registers(self) -> Iterable[Register]:
         return (
             Register("p", QAny(bitsize=(self.num_spin_orb // 2 - 1).bit_length())),
@@ -344,6 +366,28 @@ class DoubleFactorizationBlockEncoding(BlockEncoding):
     @property
     def control_registers(self) -> Iterable[Register]:
         return (Register('ctrl', QBit(), shape=(4,)),)
+
+    @property
+    def alpha(self) -> float:
+        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
+        return 1.0
+
+    @property
+    def epsilon(self) -> float:
+        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
+        return 0.0
+
+    @cached_property
+    def ancilla_bitsize(self) -> int:
+        return sum(r.total_bits() for r in self.selection_registers)
+
+    @cached_property
+    def resource_bitsize(self) -> int:
+        return sum(r.total_bits() for r in self.junk_registers)
+
+    @cached_property
+    def system_bitsize(self) -> int:
+        return sum(r.total_bits() for r in self.target_registers)
 
     @property
     def selection_registers(self) -> Iterable[Register]:

--- a/qualtran/bloqs/chemistry/sf/single_factorization.py
+++ b/qualtran/bloqs/chemistry/sf/single_factorization.py
@@ -121,13 +121,13 @@ class SingleFactorizationOneBody(BlockEncoding):
 
     @property
     def alpha(self) -> float:
-        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
-        return 1.0
+        # TODO: implement, see https://github.com/quantumlib/Qualtran/issues/1247
+        raise NotImplementedError
 
     @property
     def epsilon(self) -> float:
-        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
-        return 0.0
+        # TODO: implement, see https://github.com/quantumlib/Qualtran/issues/1247
+        raise NotImplementedError
 
     @cached_property
     def ancilla_bitsize(self) -> int:
@@ -331,13 +331,13 @@ class SingleFactorizationBlockEncoding(BlockEncoding):
 
     @property
     def alpha(self) -> float:
-        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
-        return 1.0
+        # TODO: implement, see https://github.com/quantumlib/Qualtran/issues/1247
+        raise NotImplementedError
 
     @property
     def epsilon(self) -> float:
-        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
-        return 0.0
+        # TODO: implement, see https://github.com/quantumlib/Qualtran/issues/1247
+        raise NotImplementedError
 
     @cached_property
     def ancilla_bitsize(self) -> int:

--- a/qualtran/bloqs/chemistry/sf/single_factorization.py
+++ b/qualtran/bloqs/chemistry/sf/single_factorization.py
@@ -120,6 +120,28 @@ class SingleFactorizationOneBody(BlockEncoding):
         return evolve(self, is_adjoint=not self.is_adjoint)
 
     @property
+    def alpha(self) -> float:
+        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
+        return 1.0
+
+    @property
+    def epsilon(self) -> float:
+        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
+        return 0.0
+
+    @cached_property
+    def ancilla_bitsize(self) -> int:
+        return sum(r.total_bits() for r in self.selection_registers)
+
+    @cached_property
+    def resource_bitsize(self) -> int:
+        return sum(r.total_bits() for r in self.junk_registers)
+
+    @cached_property
+    def system_bitsize(self) -> int:
+        return sum(r.total_bits() for r in self.target_registers)
+
+    @property
     def selection_registers(self) -> Iterable[Register]:
         return (
             Register(
@@ -306,6 +328,28 @@ class SingleFactorizationBlockEncoding(BlockEncoding):
     @property
     def control_registers(self) -> Iterable[Register]:
         return (Register('ctrl', QBit(), shape=(3,)),)
+
+    @property
+    def alpha(self) -> float:
+        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
+        return 1.0
+
+    @property
+    def epsilon(self) -> float:
+        # TODO: correct if necessary, see https://github.com/quantumlib/Qualtran/issues/1247
+        return 0.0
+
+    @cached_property
+    def ancilla_bitsize(self) -> int:
+        return sum(r.total_bits() for r in self.selection_registers)
+
+    @cached_property
+    def resource_bitsize(self) -> int:
+        return sum(r.total_bits() for r in self.junk_registers)
+
+    @cached_property
+    def system_bitsize(self) -> int:
+        return sum(r.total_bits() for r in self.target_registers)
 
     @property
     def selection_registers(self) -> Iterable[Register]:


### PR DESCRIPTION
See #1247.

These methods were not previously marked as abstract due to not being implemented in chemistry block encodings.
