### PR TITLE
`GraphvizCallGraph.from_bloq`

### DIFF
--- a/qualtran/bloqs/for_testing/atom.py
+++ b/qualtran/bloqs/for_testing/atom.py
@@ -28,6 +28,7 @@ from qualtran import (
     Signature,
 )
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
+from qualtran.resource_counting import CostKey, GateCounts, QECGatesCost
 
 if TYPE_CHECKING:
     import quimb.tensor as qtn
@@ -65,6 +66,11 @@ class TestAtom(Bloq):
                 tags=[str(self)],
             )
         ]
+
+    def my_static_costs(self, cost_key: 'CostKey'):
+        if cost_key == QECGatesCost():
+            return GateCounts(t=100)
+        return NotImplemented
 
     def _t_complexity_(self) -> 'TComplexity':
         return TComplexity(100)

--- a/qualtran/drawing/_show_funcs.py
+++ b/qualtran/drawing/_show_funcs.py
@@ -15,12 +15,14 @@
 """Convenience functions for showing rich displays in Jupyter notebook."""
 
 import os
-from typing import Dict, Optional, Sequence, TYPE_CHECKING, Union
+from typing import Dict, Optional, overload, Sequence, TYPE_CHECKING, Union
 
 import IPython.display
 import ipywidgets
 
-from .bloq_counts_graph import format_counts_sigma, GraphvizCounts
+from qualtran import Bloq
+
+from .bloq_counts_graph import format_counts_sigma, GraphvizCallGraph, GraphvizCounts
 from .flame_graph import get_flame_graph_svg_data
 from .graphviz import PrettyGraphDrawer, TypedGraphDrawer
 from .musical_score import draw_musical_score, get_musical_score_data
@@ -29,8 +31,6 @@ from .qpic_diagram import qpic_diagram_for_bloq
 if TYPE_CHECKING:
     import networkx as nx
     import sympy
-
-    from qualtran import Bloq
 
 
 def show_bloq(bloq: 'Bloq', type: str = 'graph'):  # pylint: disable=redefined-builtin
@@ -75,9 +75,51 @@ def show_bloqs(bloqs: Sequence['Bloq'], labels: Optional[Sequence[Optional[str]]
     IPython.display.display(box)
 
 
-def show_call_graph(g: 'nx.DiGraph') -> None:
-    """Display a graph representation of the counts graph `g`."""
-    IPython.display.display(GraphvizCounts(g).get_svg())
+@overload
+def show_call_graph(
+    item: 'Bloq', /, *, max_depth: Optional[int] = None, agg_gate_counts: Optional[str] = None
+) -> None:
+    ...
+
+
+@overload
+def show_call_graph(
+    item: 'nx.Graph', /, *, max_depth: Optional[int] = None, agg_gate_counts: Optional[str] = None
+) -> None:
+    ...
+
+
+def show_call_graph(
+    item: Union['Bloq', 'nx.Graph'],
+    /,
+    *,
+    max_depth: Optional[int] = None,
+    agg_gate_counts: Optional[str] = None,
+) -> None:
+    """Display a graph representation of the call graph.
+
+    Args:
+        item: Either a networkx graph or a bloq. If a networkx graph, it should be a "call graph"
+            which is passed verbatim to the graph drawer and the additional arguments to this
+            function are ignored. If it is a bloq, the factory
+            method `GraphvizCallGraph.from_bloq()` is used to construct the call graph, compute
+            relevant costs, and display the call graph annotated with the costs.
+        max_depth: The maximum depth (from the root bloq) of the call graph to draw. Note
+            that the cost computations will walk the whole call graph, but only the nodes
+            within this depth will be drawn.
+        agg_gate_counts: One of 'factored', 'total_t', 't_and_ccz', or 'beverland' to
+            (optionally) aggregate the gate counts. If not specified, the 'factored'
+            approach is used where each type of gate is counted individually.
+
+    """
+    if isinstance(item, Bloq):
+        IPython.display.display(
+            GraphvizCallGraph.from_bloq(
+                item, max_depth=max_depth, agg_gate_counts=agg_gate_counts
+            ).get_svg()
+        )
+    else:
+        IPython.display.display(GraphvizCounts(item).get_svg())
 
 
 def show_counts_sigma(sigma: Dict['Bloq', Union[int, 'sympy.Expr']]):

--- a/qualtran/drawing/bloq_counts_graph.py
+++ b/qualtran/drawing/bloq_counts_graph.py
@@ -15,7 +15,8 @@
 """Classes for drawing bloq counts graphs with Graphviz."""
 import abc
 import html
-from typing import Any, Dict, Iterable, Optional, Tuple, Union
+import warnings
+from typing import Any, cast, Dict, Iterable, Mapping, Optional, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import IPython.display
@@ -24,6 +25,10 @@ import pydot
 import sympy
 
 from qualtran import Bloq, CompositeBloq
+from qualtran.symbolics import SymbolicInt
+
+if TYPE_CHECKING:
+    from qualtran.resource_counting import CostKey, CostValT, GateCounts
 
 
 class _CallGraphDrawerBase(metaclass=abc.ABCMeta):
@@ -176,7 +181,15 @@ class GraphvizCallGraph(_CallGraphDrawerBase):
     Each edge is labeled with the number of times the "caller" (predecessor) bloq calls the
     "callee" (successor) bloq.
 
-    This class follows the behavior described in https://github.com/quantumlib/Qualtran/issues/791
+    The constructor of this class assumes you have already generated the call graph as a networkx
+    graph and constructed any associated data. See the factory method
+    `GraphvizCallGraph.from_bloq()` to set up a call graph diagram from a bloq with sensible
+    defaults.
+
+    This class uses a bloq's `__str__` string to title the bloq. Arbitrary additional tabular
+    data can be provided with `bloq_data`.
+
+    This graph drawer is the successor to the `GraphvizCounts` existing drawer,
     and will replace `GraphvizCounts` when all bloqs have been migrated to use `__str__()`.
 
     Args:
@@ -192,6 +205,133 @@ class GraphvizCallGraph(_CallGraphDrawerBase):
             bloq_data = {}
 
         self.bloq_data = bloq_data
+
+    @classmethod
+    def format_qubit_count(cls, val: SymbolicInt) -> Dict[str, str]:
+        """Format `QubitCount` cost values as a string.
+
+        Args:
+            val: The qubit count value, which should be an integer
+
+        Returns:
+            A dictionary mapping a string cost name to a string cost value.
+        """
+        return {'Qubits': f'{val}'}
+
+    @classmethod
+    def format_qec_gates_cost(cls, val: 'GateCounts', agg: Optional[str] = None) -> Dict[str, str]:
+        """Format `QECGatesCost` cost values as a string.
+
+        Args:
+            val: The qec gate costs value, which should be a `GateCounts` dataclass.
+            agg: One of 'factored', 'total_t', 't_and_ccz', or 'beverland' to
+                (optionally) aggregate the gate counts. If not specified, the 'factored'
+                approach is used where each type of gate is counted individually. See the
+                methods on `GateCounts` for more information.
+
+        Returns:
+            A dictionary mapping string cost names to string cost values.
+        """
+        labels = {
+            't': 'Ts',
+            'n_t': 'Ts',
+            'toffoli': 'Toffolis',
+            'n_ccz': 'CCZs',
+            'cswap': 'CSwaps',
+            'and_bloq': 'Ands',
+            'clifford': 'Cliffords',
+            'rotation': 'Rotations',
+            'measurement': 'Measurements',
+        }
+        counts_dict: Mapping[str, SymbolicInt]
+        if agg is None or agg == 'factored':
+            counts_dict = val.asdict()
+        elif agg == 'total_t':
+            counts_dict = {'t': val.total_t_count()}
+        elif agg == 't_and_ccz':
+            counts_dict = val.total_t_and_ccz_count()
+        elif agg == 'beverland':
+            counts_dict = val.total_beverland_count()
+        else:
+            raise ValueError(f"Unknown aggregation mode {agg}.")
+
+        return {labels.get(gate_k, gate_k): f'{gate_v}' for gate_k, gate_v in counts_dict.items()}
+
+    @classmethod
+    def format_cost_data(
+        cls,
+        cost_data: Dict['Bloq', Dict['CostKey', 'CostValT']],
+        agg_gate_counts: Optional[str] = None,
+    ) -> Dict['Bloq', Dict[str, str]]:
+        """Format `cost_data` as human-readable strings.
+
+        Args:
+            cost_data: The cost data, likely returned from a call to `query_costs()`. This
+                class method will delegate to `format_qubit_count` and `format_qec_gates_cost`
+                for `QubitCount` and `QECGatesCost` cost keys, respectively.
+            agg_gate_counts: One of 'factored', 'total_t', 't_and_ccz', or 'beverland' to
+                (optionally) aggregate the gate counts. If not specified, the 'factored'
+                approach is used where each type of gate is counted individually. See the
+                methods on `GateCounts` for more information.
+
+        Returns:
+            For each bloq key, a table of label/value pairs consisting of
+            human-readable labels and formatted values.
+        """
+        from qualtran.resource_counting import GateCounts, QECGatesCost, QubitCount
+
+        disp_data: Dict['Bloq', Dict[str, str]] = {}
+        for bloq in cost_data.keys():
+            bloq_disp: Dict[str, str] = {}
+            for cost_key, cost_val in cost_data[bloq].items():
+                if isinstance(cost_key, QubitCount):
+                    bloq_disp |= cls.format_qubit_count(cast(SymbolicInt, cost_val))
+                elif isinstance(cost_key, QECGatesCost):
+                    assert isinstance(cost_val, GateCounts)
+                    bloq_disp |= cls.format_qec_gates_cost(cost_val, agg=agg_gate_counts)
+                else:
+                    warnings.warn(f"Unknown cost key {cost_key}")
+                    bloq_disp[str(cost_key)] = str(cost_val)
+
+            disp_data[bloq] = bloq_disp
+        return disp_data
+
+    @classmethod
+    def from_bloq(
+        cls, bloq: Bloq, *, max_depth: Optional[int] = None, agg_gate_counts: Optional[str] = None
+    ) -> 'GraphvizCallGraph':
+        """Draw a bloq call graph.
+
+        This factory method will generate a call graph from the bloq, query the `QECGatesCost`
+        and `QubitCount` costs, format the cost data, and merge it with the call graph
+        to create a call graph diagram with annotated costs.
+
+        For additional customization, users can construct the call graph and bloq data themselves
+        and use the normal constructor, or provide minor display customizations by
+        overriding the `format_xxx` class methods.
+
+        Args:
+            bloq: The bloq from which we construct the call graph and query the costs.
+            max_depth: The maximum depth (from the root bloq) of the call graph to draw. Note
+                that the cost computations will walk the whole call graph, but only the nodes
+                within this depth will be drawn.
+            agg_gate_counts: One of 'factored', 'total_t', 't_and_ccz', or 'beverland' to
+                (optionally) aggregate the gate counts. If not specified, the 'factored'
+                approach is used where each type of gate is counted individually. See the
+                methods on `GateCounts` for more information.
+
+        Returns:
+            A `GraphvizCallGraph` diagram-drawer, whose methods can be used to generate
+            graphviz inputs or SVG diagrams.
+        """
+        from qualtran.resource_counting import QECGatesCost, QubitCount, query_costs
+
+        call_graph, _ = bloq.call_graph(max_depth=max_depth)
+        cost_data: Dict['Bloq', Dict[CostKey, Any]] = query_costs(
+            bloq, [QubitCount(), QECGatesCost()]
+        )
+        formatted_cost_data = cls.format_cost_data(cost_data, agg_gate_counts=agg_gate_counts)
+        return cls(g=call_graph, bloq_data=formatted_cost_data)
 
     def get_node_title(self, b: Bloq):
         return str(b)

--- a/qualtran/resource_counting/_bloq_counts.py
+++ b/qualtran/resource_counting/_bloq_counts.py
@@ -17,7 +17,10 @@ from typing import Callable, Dict, Sequence, Tuple, TYPE_CHECKING
 
 import attrs
 import networkx as nx
+import sympy
 from attrs import field, frozen
+
+from qualtran.symbolics import SymbolicInt
 
 from ._call_graph import get_bloq_callee_counts
 from ._costing import CostKey
@@ -120,13 +123,13 @@ class GateCounts:
     `TwoBitCSwap`, `And`, clifford bloqs, single qubit rotations, and measurements.
     """
 
-    t: int = 0
-    toffoli: int = 0
-    cswap: int = 0
-    and_bloq: int = 0
-    clifford: int = 0
-    rotation: int = 0
-    measurement: int = 0
+    t: SymbolicInt = 0
+    toffoli: SymbolicInt = 0
+    cswap: SymbolicInt = 0
+    and_bloq: SymbolicInt = 0
+    clifford: SymbolicInt = 0
+    rotation: SymbolicInt = 0
+    measurement: SymbolicInt = 0
 
     def __add__(self, other):
         if not isinstance(other, GateCounts):
@@ -157,17 +160,21 @@ class GateCounts:
         return self.__mul__(other)
 
     def __str__(self):
-        strs = []
-        for k, v in self.asdict().items():
-            strs.append(f'{k}: {v}')
-
+        strs = [f'{k}: {v}' for k, v in self.asdict().items()]
         if strs:
             return ', '.join(strs)
         return '-'
 
-    def asdict(self):
+    def asdict(self) -> Dict[str, int]:
         d = attrs.asdict(self)
-        return {k: v for k, v in d.items() if v > 0}
+
+        def _is_nonzero(v):
+            maybe_nonzero = sympy.sympify(v)
+            if maybe_nonzero is None:
+                return True
+            return maybe_nonzero
+
+        return {k: v for k, v in d.items() if _is_nonzero(v)}
 
     def total_t_count(
         self,
@@ -192,12 +199,12 @@ class GateCounts:
             + ts_per_rotation * self.rotation
         )
 
-    def total_t_and_ccz_count(self, ts_per_rotation: int = 11) -> Dict[str, int]:
+    def total_t_and_ccz_count(self, ts_per_rotation: int = 11) -> Dict[str, SymbolicInt]:
         n_ccz = self.toffoli + self.cswap + self.and_bloq
         n_t = self.t + ts_per_rotation * self.rotation
         return {'n_t': n_t, 'n_ccz': n_ccz}
 
-    def total_beverland_count(self) -> Dict[str, int]:
+    def total_beverland_count(self) -> Dict[str, SymbolicInt]:
         r"""Counts used by Beverland. et. al. using notation from the reference.
 
          - $M_\mathrm{meas}$ is the number of measurements.

--- a/qualtran/resource_counting/_bloq_counts_test.py
+++ b/qualtran/resource_counting/_bloq_counts_test.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 import cirq
 import pytest
+import sympy
 
 from qualtran.bloqs import basic_gates, mcmt, rotations
 from qualtran.bloqs.basic_gates import Hadamard, TGate, Toffoli
@@ -54,6 +55,9 @@ def test_gate_counts():
     assert 2 * GateCounts(t=10) == GateCounts(t=20)
 
     assert GateCounts(toffoli=1, cswap=1, and_bloq=1).total_t_count() == 4 + 7 + 4
+
+    gc2 = GateCounts(t=sympy.Symbol('n'), toffoli=sympy.sympify('0'), cswap=2)
+    assert str(gc2) == 't: n, cswap: 2'
 
 
 def test_qec_gates_cost():

--- a/qualtran/resource_counting/call_graph.ipynb
+++ b/qualtran/resource_counting/call_graph.ipynb
@@ -20,8 +20,8 @@
     "from qualtran.drawing import show_call_graph, show_counts_sigma\n",
     "from qualtran.bloqs.mcmt import MultiAnd, And\n",
     "\n",
-    "graph, _ = MultiAnd(cvs=(1,)*6).call_graph()\n",
-    "show_call_graph(graph)"
+    "bloq = MultiAnd(cvs=(1,)*6)\n",
+    "show_call_graph(bloq)"
    ]
   },
   {
@@ -31,8 +31,25 @@
    "source": [
     "## Interface\n",
     "\n",
-    "The primary method for accessing the call graph of a bloq is `Bloq.call_graph()`. It returns a networkx graph as well as an accounting of total bloq counts for \"leaf\" bloqs. \n",
-    "\n",
+    "The primary method for accessing the call graph of a bloq is `Bloq.call_graph()`. It returns a networkx graph as well as an accounting of total bloq counts for \"leaf\" bloqs. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d95b9366-cdd2-4c79-be40-10944720b586",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph, sigma = bloq.call_graph()\n",
+    "print(graph)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b44715e-2cbe-4076-b91b-22f6f36c8d48",
+   "metadata": {},
+   "source": [
     "Another method is `Bloq.bloq_counts`, which will return a dictionary of immediate children."
    ]
   },
@@ -286,7 +303,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/qualtran/surface_code/beverland_et_al_model.py
+++ b/qualtran/surface_code/beverland_et_al_model.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 import attrs
 
 from qualtran.resource_counting import GateCounts
+from qualtran.symbolics import SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran.surface_code import AlgorithmSummary, QECScheme, RotationCostModel
@@ -116,7 +117,7 @@ def n_discrete_logical_gates(
         rotation_model: Cost model used to compute the number of T gates
             needed to approximate rotations.
     """
-    n_rotations: int = alg.n_logical_gates.rotation
+    n_rotations: SymbolicInt = alg.n_logical_gates.rotation
     ret = attrs.evolve(alg.n_logical_gates, rotation=0)
     if n_rotations > 0:
         ret = (


### PR DESCRIPTION
This adds a new factory method `GraphvizCallGraph.from_bloq` that will set up a nice call graph for you

 - It takes a bloq, and will generate the networkx call graph
 - It will query `QECGatesCost` and `QubitCount`
 - It will take those two things and draw them in a nice way. I added class methods to format the cost values, which could theoretically be overridden by an intrepid customizer.

Some drive-by improvements to handling symbolics in `GateCounts`. 

I've also modified the `show_call_graph` convenience function to dispatch based on the input type: If it's a graph (like before) it will use the previous code path (which will eventually be deprecated when I go through and make sure all the bloqs have good-enough `__str__` values). If a bloq is provided, it will use the new functionality. Watching some new users: It seems like people expected to be able to pass a bloq to `show_call_graph` and have it show the call graph. 