### PR TITLE
Switch `BlockEncoding.signal_state` to `BlackBoxPrepare`

### DIFF
--- a/qualtran/bloqs/block_encoding/block_encoding_base.py
+++ b/qualtran/bloqs/block_encoding/block_encoding_base.py
@@ -14,7 +14,7 @@
 import abc
 
 from qualtran import Bloq, BloqDocSpec
-from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
+from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 from qualtran.symbolics import SymbolicFloat, SymbolicInt
 
 
@@ -94,7 +94,7 @@ class BlockEncoding(Bloq):
 
     @property
     @abc.abstractmethod
-    def signal_state(self) -> PrepareOracle:
+    def signal_state(self) -> BlackBoxPrepare:
         r"""Returns the signal / ancilla flag state $|G\rangle."""
 
 

--- a/qualtran/bloqs/block_encoding/chebyshev_polynomial.py
+++ b/qualtran/bloqs/block_encoding/chebyshev_polynomial.py
@@ -31,7 +31,7 @@ from qualtran import (
 from qualtran.bloqs.block_encoding import BlockEncoding
 from qualtran.bloqs.block_encoding.linear_combination import LinearCombination
 from qualtran.bloqs.reflections.reflection_using_prepare import ReflectionUsingPrepare
-from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
+from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 from qualtran.symbolics import is_symbolic, SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
@@ -108,7 +108,7 @@ class ChebyshevPolynomial(BlockEncoding):
         return self.block_encoding.epsilon * self.order
 
     @property
-    def signal_state(self) -> PrepareOracle:
+    def signal_state(self) -> BlackBoxPrepare:
         # This method will be implemented in the future after PrepareOracle
         # is updated for the BlockEncoding interface.
         # Github issue: https://github.com/quantumlib/Qualtran/issues/1104
@@ -242,7 +242,7 @@ class ScaledChebyshevPolynomial(BlockEncoding):
         return (self.signature.get_right("ancilla"),) if self.ancilla_bitsize > 0 else ()
 
     @property
-    def signal_state(self) -> PrepareOracle:
+    def signal_state(self) -> BlackBoxPrepare:
         # This method will be implemented in the future after PrepareOracle
         # is updated for the BlockEncoding interface.
         # Github issue: https://github.com/quantumlib/Qualtran/issues/1104

--- a/qualtran/bloqs/block_encoding/chebyshev_polynomial_test.py
+++ b/qualtran/bloqs/block_encoding/chebyshev_polynomial_test.py
@@ -31,7 +31,7 @@ from qualtran.bloqs.block_encoding.chebyshev_polynomial import (
     ChebyshevPolynomial,
 )
 from qualtran.bloqs.for_testing.matrix_gate import MatrixGate
-from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
+from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 from qualtran.linalg.matrix import random_hermitian_matrix
 from qualtran.symbolics import is_symbolic, SymbolicFloat, SymbolicInt
 from qualtran.testing import assert_equivalent_bloq_example_counts, execute_notebook
@@ -189,7 +189,7 @@ class TestBlockEncoding(BlockEncoding):
         return Signature.build(system=1, ancilla=1, resource=1)
 
     @property
-    def signal_state(self) -> PrepareOracle:
+    def signal_state(self) -> BlackBoxPrepare:
         raise NotImplementedError
 
     def build_composite_bloq(

--- a/qualtran/bloqs/block_encoding/linear_combination.py
+++ b/qualtran/bloqs/block_encoding/linear_combination.py
@@ -36,7 +36,7 @@ from qualtran.bloqs.block_encoding.lcu_block_encoding import BlackBoxPrepare, Bl
 from qualtran.bloqs.block_encoding.phase import Phase
 from qualtran.bloqs.bookkeeping.auto_partition import AutoPartition, Unused
 from qualtran.bloqs.bookkeeping.partition import Partition
-from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
+from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 from qualtran.linalg.lcu_util import preprocess_probabilities_for_reversible_sampling
 from qualtran.symbolics import smax, ssum, SymbolicFloat, SymbolicInt
 from qualtran.symbolics.types import is_symbolic
@@ -170,7 +170,7 @@ class LinearCombination(BlockEncoding):
         )
 
     @property
-    def signal_state(self) -> PrepareOracle:
+    def signal_state(self) -> BlackBoxPrepare:
         # This method will be implemented in the future after PrepareOracle
         # is updated for the BlockEncoding interface.
         # GitHub issue: https://github.com/quantumlib/Qualtran/issues/1104

--- a/qualtran/bloqs/block_encoding/phase.py
+++ b/qualtran/bloqs/block_encoding/phase.py
@@ -20,7 +20,7 @@ from attrs import frozen
 from qualtran import bloq_example, BloqBuilder, BloqDocSpec, QAny, Signature, SoquetT
 from qualtran.bloqs.basic_gates import GlobalPhase
 from qualtran.bloqs.block_encoding import BlockEncoding
-from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
+from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 from qualtran.symbolics import SymbolicFloat, SymbolicInt
 
@@ -79,7 +79,7 @@ class Phase(BlockEncoding):
         return f"B[exp({self.phi}i){self.block_encoding.pretty_name()[2:-1]}]"
 
     @property
-    def signal_state(self) -> PrepareOracle:
+    def signal_state(self) -> BlackBoxPrepare:
         # This method will be implemented in the future after PrepareOracle
         # is updated for the BlockEncoding interface.
         # GitHub issue: https://github.com/quantumlib/Qualtran/issues/1104

--- a/qualtran/bloqs/block_encoding/product.py
+++ b/qualtran/bloqs/block_encoding/product.py
@@ -37,7 +37,7 @@ from qualtran.bloqs.block_encoding import BlockEncoding
 from qualtran.bloqs.bookkeeping.auto_partition import AutoPartition, Unused
 from qualtran.bloqs.bookkeeping.partition import Partition
 from qualtran.bloqs.mcmt.multi_control_multi_target_pauli import MultiControlPauli
-from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
+from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 from qualtran.symbolics import is_symbolic, prod, smax, ssum, SymbolicFloat, SymbolicInt
 
 
@@ -125,7 +125,7 @@ class Product(BlockEncoding):
         return ssum(u.alpha * u.epsilon for u in self.block_encodings)
 
     @property
-    def signal_state(self) -> PrepareOracle:
+    def signal_state(self) -> BlackBoxPrepare:
         # This method will be implemented in the future after PrepareOracle
         # is updated for the BlockEncoding interface.
         # Github issue: https://github.com/quantumlib/Qualtran/issues/1104

--- a/qualtran/bloqs/block_encoding/sparse_matrix.py
+++ b/qualtran/bloqs/block_encoding/sparse_matrix.py
@@ -41,7 +41,7 @@ from qualtran.bloqs.basic_gates import Ry, Swap
 from qualtran.bloqs.block_encoding import BlockEncoding
 from qualtran.bloqs.bookkeeping.auto_partition import AutoPartition, Unused
 from qualtran.bloqs.data_loading import QROM
-from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
+from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 from qualtran.bloqs.state_preparation.prepare_uniform_superposition import (
     PrepareUniformSuperposition,
 )
@@ -209,7 +209,7 @@ class SparseMatrix(BlockEncoding):
         return self.eps
 
     @property
-    def signal_state(self) -> PrepareOracle:
+    def signal_state(self) -> BlackBoxPrepare:
         # This method will be implemented in the future after PrepareOracle
         # is updated for the BlockEncoding interface.
         # Github issue: https://github.com/quantumlib/Qualtran/issues/1104

--- a/qualtran/bloqs/block_encoding/tensor_product.py
+++ b/qualtran/bloqs/block_encoding/tensor_product.py
@@ -30,7 +30,7 @@ from qualtran import (
 )
 from qualtran.bloqs.block_encoding import BlockEncoding
 from qualtran.bloqs.bookkeeping import Partition
-from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
+from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 from qualtran.symbolics import is_symbolic, prod, ssum, SymbolicFloat, SymbolicInt
 
@@ -101,7 +101,7 @@ class TensorProduct(BlockEncoding):
         return ssum(u.alpha * u.epsilon for u in self.block_encodings)
 
     @property
-    def signal_state(self) -> PrepareOracle:
+    def signal_state(self) -> BlackBoxPrepare:
         # This method will be implemented in the future after PrepareOracle
         # is updated for the BlockEncoding interface.
         # Github issue: https://github.com/quantumlib/Qualtran/issues/1104

--- a/qualtran/bloqs/block_encoding/unitary.py
+++ b/qualtran/bloqs/block_encoding/unitary.py
@@ -19,7 +19,7 @@ from attrs import frozen
 
 from qualtran import Bloq, bloq_example, BloqBuilder, BloqDocSpec, QAny, Side, Signature, SoquetT
 from qualtran.bloqs.block_encoding import BlockEncoding
-from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
+from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 from qualtran.symbolics import SymbolicFloat, SymbolicInt
 
@@ -73,7 +73,7 @@ class Unitary(BlockEncoding):
         return f"B[{self.U.pretty_name()}]"
 
     @property
-    def signal_state(self) -> PrepareOracle:
+    def signal_state(self) -> BlackBoxPrepare:
         # This method will be implemented in the future after PrepareOracle
         # is updated for the BlockEncoding interface.
         # Github issue: https://github.com/quantumlib/Qualtran/issues/1104

--- a/qualtran/bloqs/chemistry/df/double_factorization.py
+++ b/qualtran/bloqs/chemistry/df/double_factorization.py
@@ -60,7 +60,7 @@ from qualtran.bloqs.chemistry.df.prepare import (
 from qualtran.bloqs.chemistry.df.select_bloq import ProgRotGateArray
 from qualtran.bloqs.reflections.prepare_identity import PrepareIdentity
 from qualtran.bloqs.reflections.reflection_using_prepare import ReflectionUsingPrepare
-from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
+from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
@@ -166,8 +166,8 @@ class DoubleFactorizationOneBody(BlockEncoding):
         return (Register("sys", QAny(bitsize=self.num_spin_orb // 2), shape=(2,)),)
 
     @property
-    def signal_state(self) -> PrepareOracle:
-        return PrepareIdentity(self.selection_registers)
+    def signal_state(self) -> BlackBoxPrepare:
+        return BlackBoxPrepare(PrepareIdentity(self.selection_registers))
 
     @cached_property
     def signature(self) -> Signature:
@@ -414,8 +414,8 @@ class DoubleFactorizationBlockEncoding(BlockEncoding):
         return (Register("sys", QAny(bitsize=self.num_spin_orb // 2), shape=(2,)),)
 
     @property
-    def signal_state(self) -> PrepareOracle:
-        return PrepareIdentity(self.selection_registers)
+    def signal_state(self) -> BlackBoxPrepare:
+        return BlackBoxPrepare(PrepareIdentity(self.selection_registers))
 
     @cached_property
     def signature(self) -> Signature:

--- a/qualtran/bloqs/chemistry/sf/single_factorization.py
+++ b/qualtran/bloqs/chemistry/sf/single_factorization.py
@@ -52,7 +52,7 @@ from qualtran.bloqs.chemistry.sf.prepare import (
 from qualtran.bloqs.chemistry.sf.select_bloq import SelectSingleFactorization
 from qualtran.bloqs.reflections.prepare_identity import PrepareIdentity
 from qualtran.bloqs.reflections.reflection_using_prepare import ReflectionUsingPrepare
-from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
+from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
@@ -176,8 +176,8 @@ class SingleFactorizationOneBody(BlockEncoding):
         return ()
 
     @property
-    def signal_state(self) -> PrepareOracle:
-        return PrepareIdentity(self.selection_registers)
+    def signal_state(self) -> BlackBoxPrepare:
+        return BlackBoxPrepare(PrepareIdentity(self.selection_registers))
 
     @cached_property
     def signature(self) -> Signature:
@@ -381,8 +381,8 @@ class SingleFactorizationBlockEncoding(BlockEncoding):
         )
 
     @property
-    def signal_state(self) -> PrepareOracle:
-        return PrepareIdentity(self.selection_registers)
+    def signal_state(self) -> BlackBoxPrepare:
+        return BlackBoxPrepare(PrepareIdentity(self.selection_registers))
 
     def build_composite_bloq(
         self,


### PR DESCRIPTION
The `BlackBoxPrepare` signature, with its single `junk` and `selection` registers, is appropriate to use for us to implement `signal_state`.
