### PR TITLE
Add qref and bartiq dependencies

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -29,6 +29,10 @@ quimb
 qsharp
 qsharp-widgets
 
+#qref bartiq interop
+qref==0.7.0
+bartiq==0.5.0
+
 # serialization
 protobuf
 


### PR DESCRIPTION
As requested in #1194 by @mpharrigan , I added bartiq and qref dependency.
Let me know if I should add it anywhere else as well.

I used `==`, as given `qref` and `bartiq` are not stable, their update could potentially break some tests in Qualtran, which would be unnecessarily disrupting.