### PR TITLE
Ad bartiq and qref as dependencies for interop

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -25,9 +25,13 @@ dash
 # quimb simulation
 quimb
 
-#qsharp resource estimator interop
+# qsharp resource estimator interop
 qsharp
 qsharp-widgets
+
+# qref bartiq interop
+qref
+bartiq
 
 # serialization
 protobuf

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -10,6 +10,8 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 alabaster==1.0.0
     # via sphinx
+annotated-types==0.7.0
+    # via pydantic
 anyio==4.4.0
     # via
     #   httpx
@@ -52,6 +54,8 @@ babel==2.16.0
     #   sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
+bartiq==0.5.0
+    # via -r deps/runtime.txt
 beautifulsoup4==4.12.3
     # via
     #   nbconvert
@@ -157,6 +161,8 @@ fqdn==1.5.1
     # via jsonschema
 fxpmath==0.4.9
     # via -r deps/runtime.txt
+graphviz==0.20.3
+    # via qref
 greenlet==3.0.3
     # via sqlalchemy
 grpcio==1.65.4
@@ -485,6 +491,12 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
+pydantic==2.8.2
+    # via
+    #   bartiq
+    #   qref
+pydantic-core==2.20.1
+    # via pydantic
 pydata-sphinx-theme==0.15.4
     # via -r deps/docs.txt
 pydot==3.0.1
@@ -502,6 +514,7 @@ pylint==2.17.7
     # via -r deps/pylint.txt
 pyparsing==3.1.2
     # via
+    #   bartiq
     #   matplotlib
     #   pydot
 pyproject-hooks==1.1.0
@@ -545,6 +558,10 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
+qref==0.6.2
+    # via
+    #   -r deps/runtime.txt
+    #   bartiq
 qsharp==1.7.0
     # via -r deps/runtime.txt
 qsharp-widgets==1.7.0
@@ -643,6 +660,7 @@ sympy==1.12.1
     # via
     #   -r deps/mypy.txt
     #   -r deps/runtime.txt
+    #   bartiq
     #   cirq-core
     #   openfermion
 tabulate==0.9.0
@@ -720,6 +738,8 @@ typing-extensions==4.12.2
     #   ipython
     #   mypy
     #   myst-nb
+    #   pydantic
+    #   pydantic-core
     #   pydata-sphinx-theme
     #   sqlalchemy
 tzdata==2024.1

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -8,7 +8,7 @@ absl-py==2.1.0
     # via tensorflow-docs
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
-alabaster==0.7.16
+alabaster==1.0.0
     # via sphinx
 anyio==4.4.0
     # via
@@ -34,7 +34,7 @@ asttokens==2.4.1
     # via stack-data
 async-lru==2.0.4
     # via jupyterlab
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -r deps/runtime.txt
     #   cirq-core
@@ -45,7 +45,7 @@ autoray==0.6.12
     # via
     #   cotengra
     #   quimb
-babel==2.15.0
+babel==2.16.0
     # via
     #   jupyterlab-server
     #   pydata-sphinx-theme
@@ -71,7 +71,7 @@ certifi==2024.7.4
     #   httpcore
     #   httpx
     #   requests
-cffi==1.16.0
+cffi==1.17.0
     # via
     #   argon2-cffi-bindings
     #   cryptography
@@ -95,7 +95,7 @@ contourpy==1.2.1
     # via matplotlib
 cotengra==0.6.2
     # via quimb
-coverage[toml]==7.6.0
+coverage[toml]==7.6.1
     # via pytest-cov
 cryptography==43.0.0
     # via secretstorage
@@ -111,7 +111,7 @@ dash-html-components==2.0.0
     # via dash
 dash-table==5.0.0
     # via dash
-debugpy==1.8.2
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -159,9 +159,9 @@ fxpmath==0.4.9
     # via -r deps/runtime.txt
 greenlet==3.0.3
     # via sqlalchemy
-grpcio==1.65.1
+grpcio==1.65.4
     # via grpcio-tools
-grpcio-tools==1.65.1
+grpcio-tools==1.65.4
     # via -r deps/packaging.txt
 h11==0.14.0
     # via httpcore
@@ -181,7 +181,7 @@ idna==3.7
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.1.0
+importlib-metadata==8.2.0
     # via
     #   dash
     #   jupyter-cache
@@ -218,11 +218,11 @@ jaraco-classes==3.4.0
     # via keyring
 jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.0.2
     # via keyring
-jax==0.4.30
+jax==0.4.31
     # via openfermion
-jaxlib==0.4.30
+jaxlib==0.4.31
     # via
     #   jax
     #   openfermion
@@ -292,7 +292,7 @@ jupyterlab-server==2.27.3
     #   notebook
 jupyterlab-widgets==3.0.11
     # via ipywidgets
-keyring==25.2.1
+keyring==25.3.0
     # via twine
 kiwisolver==1.4.5
     # via matplotlib
@@ -310,7 +310,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.1
+matplotlib==3.9.1.post1
     # via
     #   -r deps/runtime.txt
     #   ase
@@ -331,13 +331,13 @@ ml-dtypes==0.4.0
     # via
     #   jax
     #   jaxlib
-more-itertools==10.3.0
+more-itertools==10.4.0
     # via
     #   jaraco-classes
     #   jaraco-functools
 mpmath==1.3.0
     # via sympy
-mypy==1.11.0
+mypy==1.11.1
     # via -r deps/mypy.txt
 mypy-extensions==1.0.0
     # via
@@ -347,7 +347,7 @@ mypy-protobuf==3.6.0
     # via -r deps/mypy.txt
 myst-nb==1.1.1
     # via -r deps/docs.txt
-myst-parser==3.0.1
+myst-parser==4.0.0
     # via myst-nb
 nbclient==0.10.0
     # via
@@ -463,7 +463,7 @@ prometheus-client==0.20.0
     # via jupyter-server
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
     #   -r deps/runtime.txt
     #   grpcio-tools
@@ -510,7 +510,7 @@ pyproject-hooks==1.1.0
     #   pip-tools
 pyscf==2.6.2
     # via openfermion
-pytest==8.3.1
+pytest==8.3.2
     # via
     #   -r deps/pylint.txt
     #   -r deps/pytest.txt
@@ -533,21 +533,21 @@ python-json-logger==2.0.7
     # via jupyter-events
 pytz==2024.1
     # via pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   jupyter-cache
     #   jupyter-events
     #   myst-nb
     #   myst-parser
     #   tensorflow-docs
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qsharp==1.6.0
+qsharp==1.7.0
     # via -r deps/runtime.txt
-qsharp-widgets==1.6.0
+qsharp-widgets==1.7.0
     # via -r deps/runtime.txt
 quimb==1.8.4
     # via -r deps/runtime.txt
@@ -582,7 +582,7 @@ rfc3986-validator==0.1.1
     #   jupyter-events
 rich==13.7.1
     # via twine
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
@@ -616,26 +616,26 @@ sortedcontainers==2.4.0
     # via cirq-core
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.4.7
+sphinx==8.0.2
     # via
     #   -r deps/docs.txt
     #   -r deps/pylint.txt
     #   myst-nb
     #   myst-parser
     #   pydata-sphinx-theme
-sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -647,7 +647,7 @@ sympy==1.12.1
     #   openfermion
 tabulate==0.9.0
     # via jupyter-cache
-tenacity==8.5.0
+tenacity==9.0.0
     # via plotly
 tensorflow-docs==2023.5.24.56664
     # via
@@ -683,7 +683,7 @@ tornado==6.4.1
     #   jupyterlab
     #   notebook
     #   terminado
-tqdm==4.66.4
+tqdm==4.66.5
     # via
     #   cirq-core
     #   quimb
@@ -710,6 +710,7 @@ types-python-dateutil==2.9.0.20240316
     # via arrow
 typing-extensions==4.12.2
     # via
+    #   -r deps/runtime.txt
     #   anyio
     #   anywidget
     #   astroid
@@ -745,7 +746,7 @@ werkzeug==3.0.3
     # via
     #   dash
     #   flask
-wheel==0.43.0
+wheel==0.44.0
     # via
     #   -r deps/packaging.txt
     #   pip-tools

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -16,6 +16,10 @@ alabaster==1.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
+annotated-types==0.7.0
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
 anyio==4.4.0
     # via
     #   -c envs/dev.env.txt
@@ -68,6 +72,10 @@ babel==2.16.0
     #   jupyterlab-server
     #   pydata-sphinx-theme
     #   sphinx
+bartiq==0.5.0
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
 beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
@@ -196,6 +204,10 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+graphviz==0.20.3
+    # via
+    #   -c envs/dev.env.txt
+    #   qref
 greenlet==3.0.3
     # via
     #   -c envs/dev.env.txt
@@ -536,6 +548,15 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
+pydantic==2.8.2
+    # via
+    #   -c envs/dev.env.txt
+    #   bartiq
+    #   qref
+pydantic-core==2.20.1
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
 pydata-sphinx-theme==0.15.4
     # via
     #   -c envs/dev.env.txt
@@ -555,6 +576,7 @@ pygments==2.18.0
 pyparsing==3.1.2
     # via
     #   -c envs/dev.env.txt
+    #   bartiq
     #   matplotlib
     #   pydot
 python-dateutil==2.9.0.post0
@@ -586,6 +608,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
+qref==0.6.2
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
+    #   bartiq
 qsharp==1.7.0
     # via
     #   -c envs/dev.env.txt
@@ -706,6 +733,7 @@ sympy==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   bartiq
     #   cirq-core
 tabulate==0.9.0
     # via
@@ -782,6 +810,8 @@ typing-extensions==4.12.2
     #   dash
     #   ipython
     #   myst-nb
+    #   pydantic
+    #   pydantic-core
     #   pydata-sphinx-theme
     #   sqlalchemy
 tzdata==2024.1

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -12,7 +12,7 @@ accessible-pygments==0.0.5
     # via
     #   -c envs/dev.env.txt
     #   pydata-sphinx-theme
-alabaster==0.7.16
+alabaster==1.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
@@ -49,7 +49,7 @@ async-lru==2.0.4
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -62,7 +62,7 @@ autoray==0.6.12
     #   -c envs/dev.env.txt
     #   cotengra
     #   quimb
-babel==2.15.0
+babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
@@ -91,7 +91,7 @@ certifi==2024.7.4
     #   httpcore
     #   httpx
     #   requests
-cffi==1.16.0
+cffi==1.17.0
     # via
     #   -c envs/dev.env.txt
     #   argon2-cffi-bindings
@@ -145,7 +145,7 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-debugpy==1.8.2
+debugpy==1.8.5
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -223,7 +223,7 @@ imagesize==1.4.1
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-importlib-metadata==8.1.0
+importlib-metadata==8.2.0
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -364,7 +364,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.1
+matplotlib==3.9.1.post1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -394,7 +394,7 @@ myst-nb==1.1.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
-myst-parser==3.0.1
+myst-parser==4.0.0
     # via
     #   -c envs/dev.env.txt
     #   myst-nb
@@ -509,7 +509,7 @@ prompt-toolkit==3.0.47
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -572,7 +572,7 @@ pytz==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-cache
@@ -580,17 +580,17 @@ pyyaml==6.0.1
     #   myst-nb
     #   myst-parser
     #   tensorflow-docs
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qsharp==1.6.0
+qsharp==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.6.0
+qsharp-widgets==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -624,7 +624,7 @@ rfc3986-validator==0.1.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jupyter-events
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -663,22 +663,22 @@ soupsieve==2.5
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
-sphinx==7.4.7
+sphinx==8.0.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
     #   myst-nb
     #   myst-parser
     #   pydata-sphinx-theme
-sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-applehelp==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
@@ -686,15 +686,15 @@ sphinxcontrib-jsmath==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via
     #   -c envs/dev.env.txt
     #   jupyter-cache
@@ -711,7 +711,7 @@ tabulate==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-cache
-tenacity==8.5.0
+tenacity==9.0.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
@@ -746,7 +746,7 @@ tornado==6.4.1
     #   jupyterlab
     #   notebook
     #   terminado
-tqdm==4.66.4
+tqdm==4.66.5
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -774,6 +774,7 @@ types-python-dateutil==2.9.0.20240316
 typing-extensions==4.12.2
     # via
     #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
     #   anyio
     #   anywidget
     #   async-lru

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/format.env.txt deps/format.txt deps/runtime.txt
 #
+annotated-types==0.7.0
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
 anyio==4.4.0
     # via
     #   -c envs/dev.env.txt
@@ -53,6 +57,10 @@ babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
+bartiq==0.5.0
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
 beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
@@ -182,6 +190,10 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+graphviz==0.20.3
+    # via
+    #   -c envs/dev.env.txt
+    #   qref
 h11==0.14.0
     # via
     #   -c envs/dev.env.txt
@@ -484,6 +496,15 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
+pydantic==2.8.2
+    # via
+    #   -c envs/dev.env.txt
+    #   bartiq
+    #   qref
+pydantic-core==2.20.1
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
 pydot==3.0.1
     # via
     #   -c envs/dev.env.txt
@@ -496,6 +517,7 @@ pygments==2.18.0
 pyparsing==3.1.2
     # via
     #   -c envs/dev.env.txt
+    #   bartiq
     #   matplotlib
     #   pydot
 python-dateutil==2.9.0.post0
@@ -523,6 +545,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
+qref==0.6.2
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
+    #   bartiq
 qsharp==1.7.0
     # via
     #   -c envs/dev.env.txt
@@ -603,6 +630,7 @@ sympy==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   bartiq
     #   cirq-core
 tenacity==9.0.0
     # via
@@ -671,6 +699,8 @@ typing-extensions==4.12.2
     #   cirq-core
     #   dash
     #   ipython
+    #   pydantic
+    #   pydantic-core
 tzdata==2024.1
     # via
     #   -c envs/dev.env.txt

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -37,7 +37,7 @@ async-lru==2.0.4
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -49,7 +49,7 @@ autoray==0.6.12
     #   -c envs/dev.env.txt
     #   cotengra
     #   quimb
-babel==2.15.0
+babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
@@ -79,7 +79,7 @@ certifi==2024.7.4
     #   httpcore
     #   httpx
     #   requests
-cffi==1.16.0
+cffi==1.17.0
     # via
     #   -c envs/dev.env.txt
     #   argon2-cffi-bindings
@@ -133,7 +133,7 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-debugpy==1.8.2
+debugpy==1.8.5
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -201,7 +201,7 @@ idna==3.7
     #   httpx
     #   jsonschema
     #   requests
-importlib-metadata==8.1.0
+importlib-metadata==8.2.0
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -329,7 +329,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.1
+matplotlib==3.9.1.post1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -458,7 +458,7 @@ prompt-toolkit==3.0.47
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -513,21 +513,21 @@ pytz==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qsharp==1.6.0
+qsharp==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.6.0
+qsharp-widgets==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -560,7 +560,7 @@ rfc3986-validator==0.1.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jupyter-events
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -604,7 +604,7 @@ sympy==1.12.1
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-tenacity==8.5.0
+tenacity==9.0.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
@@ -636,7 +636,7 @@ tornado==6.4.1
     #   jupyterlab
     #   notebook
     #   terminado
-tqdm==4.66.4
+tqdm==4.66.5
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -664,6 +664,7 @@ types-python-dateutil==2.9.0.20240316
 typing-extensions==4.12.2
     # via
     #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
     #   anyio
     #   anywidget
     #   async-lru

--- a/dev_tools/requirements/envs/pip-tools.env.txt
+++ b/dev_tools/requirements/envs/pip-tools.env.txt
@@ -30,7 +30,7 @@ tomli==2.0.1
     #   -c envs/dev.env.txt
     #   build
     #   pip-tools
-wheel==0.43.0
+wheel==0.44.0
     # via
     #   -c envs/dev.env.txt
     #   pip-tools

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -12,6 +12,10 @@ alabaster==1.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
+annotated-types==0.7.0
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
 anyio==4.4.0
     # via
     #   -c envs/dev.env.txt
@@ -70,6 +74,10 @@ babel==2.16.0
     #   -c envs/dev.env.txt
     #   jupyterlab-server
     #   sphinx
+bartiq==0.5.0
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
 beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
@@ -208,6 +216,10 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+graphviz==0.20.3
+    # via
+    #   -c envs/dev.env.txt
+    #   qref
 h11==0.14.0
     # via
     #   -c envs/dev.env.txt
@@ -570,6 +582,15 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
+pydantic==2.8.2
+    # via
+    #   -c envs/dev.env.txt
+    #   bartiq
+    #   qref
+pydantic-core==2.20.1
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
 pydot==3.0.1
     # via
     #   -c envs/dev.env.txt
@@ -587,6 +608,7 @@ pylint==2.17.7
 pyparsing==3.1.2
     # via
     #   -c envs/dev.env.txt
+    #   bartiq
     #   matplotlib
     #   pydot
 pyscf==2.6.2
@@ -623,6 +645,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
+qref==0.6.2
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
+    #   bartiq
 qsharp==1.7.0
     # via
     #   -c envs/dev.env.txt
@@ -742,6 +769,7 @@ sympy==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   bartiq
     #   cirq-core
     #   openfermion
 tenacity==9.0.0
@@ -821,6 +849,8 @@ typing-extensions==4.12.2
     #   cirq-core
     #   dash
     #   ipython
+    #   pydantic
+    #   pydantic-core
 tzdata==2024.1
     # via
     #   -c envs/dev.env.txt

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -8,7 +8,7 @@ absl-py==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   tensorflow-docs
-alabaster==0.7.16
+alabaster==1.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
@@ -53,7 +53,7 @@ async-lru==2.0.4
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -65,7 +65,7 @@ autoray==0.6.12
     #   -c envs/dev.env.txt
     #   cotengra
     #   quimb
-babel==2.15.0
+babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
@@ -92,7 +92,7 @@ certifi==2024.7.4
     #   httpcore
     #   httpx
     #   requests
-cffi==1.16.0
+cffi==1.17.0
     # via
     #   -c envs/dev.env.txt
     #   argon2-cffi-bindings
@@ -146,7 +146,7 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-debugpy==1.8.2
+debugpy==1.8.5
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -236,7 +236,7 @@ imagesize==1.4.1
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-importlib-metadata==8.1.0
+importlib-metadata==8.2.0
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -271,11 +271,11 @@ itsdangerous==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   flask
-jax==0.4.30
+jax==0.4.31
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-jaxlib==0.4.30
+jaxlib==0.4.31
     # via
     #   -c envs/dev.env.txt
     #   jax
@@ -383,7 +383,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.1
+matplotlib==3.9.1.post1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -539,7 +539,7 @@ prompt-toolkit==3.0.47
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -593,7 +593,7 @@ pyscf==2.6.2
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-pytest==8.3.1
+pytest==8.3.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
@@ -612,22 +612,22 @@ pytz==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
     #   tensorflow-docs
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qsharp==1.6.0
+qsharp==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.6.0
+qsharp-widgets==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -662,7 +662,7 @@ rfc3986-validator==0.1.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jupyter-events
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -706,19 +706,19 @@ soupsieve==2.5
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
-sphinx==7.4.7
+sphinx==8.0.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
-sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-applehelp==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
@@ -726,11 +726,11 @@ sphinxcontrib-jsmath==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
@@ -744,7 +744,7 @@ sympy==1.12.1
     #   -r deps/runtime.txt
     #   cirq-core
     #   openfermion
-tenacity==8.5.0
+tenacity==9.0.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
@@ -785,7 +785,7 @@ tornado==6.4.1
     #   jupyterlab
     #   notebook
     #   terminado
-tqdm==4.66.4
+tqdm==4.66.5
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -813,6 +813,7 @@ types-python-dateutil==2.9.0.20240316
 typing-extensions==4.12.2
     # via
     #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
     #   anyio
     #   anywidget
     #   astroid

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/pytest.env.txt deps/pytest.txt deps/runtime.txt
 #
+annotated-types==0.7.0
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
 anyio==4.4.0
     # via
     #   -c envs/dev.env.txt
@@ -53,6 +57,10 @@ babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
+bartiq==0.5.0
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
 beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
@@ -191,6 +199,10 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+graphviz==0.20.3
+    # via
+    #   -c envs/dev.env.txt
+    #   qref
 h11==0.14.0
     # via
     #   -c envs/dev.env.txt
@@ -532,6 +544,15 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
+pydantic==2.8.2
+    # via
+    #   -c envs/dev.env.txt
+    #   bartiq
+    #   qref
+pydantic-core==2.20.1
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
 pydot==3.0.1
     # via
     #   -c envs/dev.env.txt
@@ -544,6 +565,7 @@ pygments==2.18.0
 pyparsing==3.1.2
     # via
     #   -c envs/dev.env.txt
+    #   bartiq
     #   matplotlib
     #   pydot
 pyscf==2.6.2
@@ -594,6 +616,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
+qref==0.6.2
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
+    #   bartiq
 qsharp==1.7.0
     # via
     #   -c envs/dev.env.txt
@@ -680,6 +707,7 @@ sympy==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   bartiq
     #   cirq-core
     #   openfermion
 tenacity==9.0.0
@@ -749,6 +777,8 @@ typing-extensions==4.12.2
     #   cirq-core
     #   dash
     #   ipython
+    #   pydantic
+    #   pydantic-core
 tzdata==2024.1
     # via
     #   -c envs/dev.env.txt

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -37,7 +37,7 @@ async-lru==2.0.4
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -49,7 +49,7 @@ autoray==0.6.12
     #   -c envs/dev.env.txt
     #   cotengra
     #   quimb
-babel==2.15.0
+babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
@@ -75,7 +75,7 @@ certifi==2024.7.4
     #   httpcore
     #   httpx
     #   requests
-cffi==1.16.0
+cffi==1.17.0
     # via
     #   -c envs/dev.env.txt
     #   argon2-cffi-bindings
@@ -105,7 +105,7 @@ cotengra==0.6.2
     # via
     #   -c envs/dev.env.txt
     #   quimb
-coverage[toml]==7.6.0
+coverage[toml]==7.6.1
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -133,7 +133,7 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-debugpy==1.8.2
+debugpy==1.8.5
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -215,7 +215,7 @@ idna==3.7
     #   httpx
     #   jsonschema
     #   requests
-importlib-metadata==8.1.0
+importlib-metadata==8.2.0
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -247,11 +247,11 @@ itsdangerous==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   flask
-jax==0.4.30
+jax==0.4.31
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-jaxlib==0.4.30
+jaxlib==0.4.31
     # via
     #   -c envs/dev.env.txt
     #   jax
@@ -353,7 +353,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.1
+matplotlib==3.9.1.post1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -502,7 +502,7 @@ prompt-toolkit==3.0.47
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -550,7 +550,7 @@ pyscf==2.6.2
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-pytest==8.3.1
+pytest==8.3.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -584,21 +584,21 @@ pytz==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qsharp==1.6.0
+qsharp==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.6.0
+qsharp-widgets==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -632,7 +632,7 @@ rfc3986-validator==0.1.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jupyter-events
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -682,7 +682,7 @@ sympy==1.12.1
     #   -r deps/runtime.txt
     #   cirq-core
     #   openfermion
-tenacity==8.5.0
+tenacity==9.0.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
@@ -714,7 +714,7 @@ tornado==6.4.1
     #   jupyterlab
     #   notebook
     #   terminado
-tqdm==4.66.4
+tqdm==4.66.5
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -742,6 +742,7 @@ types-python-dateutil==2.9.0.20240316
 typing-extensions==4.12.2
     # via
     #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
     #   anyio
     #   anywidget
     #   async-lru

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -33,7 +33,7 @@ async-lru==2.0.4
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -45,7 +45,7 @@ autoray==0.6.12
     #   -c envs/dev.env.txt
     #   cotengra
     #   quimb
-babel==2.15.0
+babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
@@ -71,7 +71,7 @@ certifi==2024.7.4
     #   httpcore
     #   httpx
     #   requests
-cffi==1.16.0
+cffi==1.17.0
     # via
     #   -c envs/dev.env.txt
     #   argon2-cffi-bindings
@@ -124,7 +124,7 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-debugpy==1.8.2
+debugpy==1.8.5
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -188,7 +188,7 @@ idna==3.7
     #   httpx
     #   jsonschema
     #   requests
-importlib-metadata==8.1.0
+importlib-metadata==8.2.0
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -312,7 +312,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.1
+matplotlib==3.9.1.post1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -432,7 +432,7 @@ prompt-toolkit==3.0.47
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.27.2
+protobuf==5.27.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -487,21 +487,21 @@ pytz==2024.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
-pyzmq==26.0.3
+pyzmq==26.1.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qsharp==1.6.0
+qsharp==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.6.0
+qsharp-widgets==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -534,7 +534,7 @@ rfc3986-validator==0.1.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jupyter-events
-rpds-py==0.19.0
+rpds-py==0.20.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -578,7 +578,7 @@ sympy==1.12.1
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-tenacity==8.5.0
+tenacity==9.0.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
@@ -608,7 +608,7 @@ tornado==6.4.1
     #   jupyterlab
     #   notebook
     #   terminado
-tqdm==4.66.4
+tqdm==4.66.5
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -636,6 +636,7 @@ types-python-dateutil==2.9.0.20240316
 typing-extensions==4.12.2
     # via
     #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
     #   anyio
     #   anywidget
     #   async-lru

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/runtime.env.txt deps/runtime.txt
 #
+annotated-types==0.7.0
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
 anyio==4.4.0
     # via
     #   -c envs/dev.env.txt
@@ -49,6 +53,10 @@ babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
+bartiq==0.5.0
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
 beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
@@ -169,6 +177,10 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+graphviz==0.20.3
+    # via
+    #   -c envs/dev.env.txt
+    #   qref
 h11==0.14.0
     # via
     #   -c envs/dev.env.txt
@@ -458,6 +470,15 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
+pydantic==2.8.2
+    # via
+    #   -c envs/dev.env.txt
+    #   bartiq
+    #   qref
+pydantic-core==2.20.1
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
 pydot==3.0.1
     # via
     #   -c envs/dev.env.txt
@@ -470,6 +491,7 @@ pygments==2.18.0
 pyparsing==3.1.2
     # via
     #   -c envs/dev.env.txt
+    #   bartiq
     #   matplotlib
     #   pydot
 python-dateutil==2.9.0.post0
@@ -497,6 +519,11 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
+qref==0.6.2
+    # via
+    #   -c envs/dev.env.txt
+    #   -r deps/runtime.txt
+    #   bartiq
 qsharp==1.7.0
     # via
     #   -c envs/dev.env.txt
@@ -577,6 +604,7 @@ sympy==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
+    #   bartiq
     #   cirq-core
 tenacity==9.0.0
     # via
@@ -643,6 +671,8 @@ typing-extensions==4.12.2
     #   cirq-core
     #   dash
     #   ipython
+    #   pydantic
+    #   pydantic-core
 tzdata==2024.1
     # via
     #   -c envs/dev.env.txt


### PR DESCRIPTION
Supersedes #1267 

This adds unpinned bartiq and qref to the runtime dependencies and re-compiles our set of pinned dependencies (used for the ci). I split this into two commits so you can see the changes from 1) regularly updating the pinned dependencies and 2) changes due solely to the new packages.

Adding bartiq and qref doesn't really introduce any new dependencies. One note: the `graphviz` pypi package doesn't actually install graphviz the program, but is a Python utility library for manipulating graphviz files. In qualtran we use pydot which is the same idea, albeit with a less confusing name :)

cc @mstechly
