### PR TITLE
Update dependencies for newer qref & bartiq versions

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -30,8 +30,8 @@ qsharp
 qsharp-widgets
 
 # qref bartiq interop
-qref
-bartiq
+qref>=0.7.0
+bartiq>=0.5.1
 
 # serialization
 protobuf

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -18,6 +18,8 @@ anyio==4.4.0
     #   jupyter-server
 anywidget==0.9.13
     # via qsharp-widgets
+appnope==0.1.4
+    # via ipykernel
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -54,7 +56,7 @@ babel==2.16.0
     #   sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
-bartiq==0.5.0
+bartiq==0.5.1
     # via -r deps/runtime.txt
 beautifulsoup4==4.12.3
     # via
@@ -76,9 +78,7 @@ certifi==2024.7.4
     #   httpx
     #   requests
 cffi==1.17.0
-    # via
-    #   argon2-cffi-bindings
-    #   cryptography
+    # via argon2-cffi-bindings
 charset-normalizer==3.3.2
     # via requests
 cirq-core==1.4.0
@@ -101,8 +101,6 @@ cotengra==0.6.2
     # via quimb
 coverage[toml]==7.6.1
     # via pytest-cov
-cryptography==43.0.0
-    # via secretstorage
 cycler==0.12.1
     # via matplotlib
 cytoolz==0.12.3
@@ -163,8 +161,6 @@ fxpmath==0.4.9
     # via -r deps/runtime.txt
 graphviz==0.20.3
     # via qref
-greenlet==3.0.3
-    # via sqlalchemy
 grpcio==1.65.4
     # via grpcio-tools
 grpcio-tools==1.65.4
@@ -234,10 +230,6 @@ jaxlib==0.4.31
     #   openfermion
 jedi==0.19.1
     # via ipython
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.4
     # via
     #   flask
@@ -558,7 +550,7 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qref==0.6.2
+qref==0.7.0
     # via
     #   -r deps/runtime.txt
     #   bartiq
@@ -612,8 +604,6 @@ scipy==1.14.0
     #   openfermion
     #   pyscf
     #   quimb
-secretstorage==3.3.3
-    # via keyring
 send2trash==1.8.3
     # via jupyter-server
 six==1.16.0

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -18,8 +18,6 @@ anyio==4.4.0
     #   jupyter-server
 anywidget==0.9.13
     # via qsharp-widgets
-appnope==0.1.4
-    # via ipykernel
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -78,7 +76,9 @@ certifi==2024.7.4
     #   httpx
     #   requests
 cffi==1.17.0
-    # via argon2-cffi-bindings
+    # via
+    #   argon2-cffi-bindings
+    #   cryptography
 charset-normalizer==3.3.2
     # via requests
 cirq-core==1.4.0
@@ -101,6 +101,8 @@ cotengra==0.6.2
     # via quimb
 coverage[toml]==7.6.1
     # via pytest-cov
+cryptography==43.0.0
+    # via secretstorage
 cycler==0.12.1
     # via matplotlib
 cytoolz==0.12.3
@@ -161,6 +163,8 @@ fxpmath==0.4.9
     # via -r deps/runtime.txt
 graphviz==0.20.3
     # via qref
+greenlet==3.0.3
+    # via sqlalchemy
 grpcio==1.65.4
     # via grpcio-tools
 grpcio-tools==1.65.4
@@ -230,6 +234,10 @@ jaxlib==0.4.31
     #   openfermion
 jedi==0.19.1
     # via ipython
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.4
     # via
     #   flask
@@ -308,7 +316,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.1.post1
+matplotlib==3.9.2
     # via
     #   -r deps/runtime.txt
     #   ase
@@ -604,6 +612,8 @@ scipy==1.14.0
     #   openfermion
     #   pyscf
     #   quimb
+secretstorage==3.3.3
+    # via keyring
 send2trash==1.8.3
     # via jupyter-server
 six==1.16.0
@@ -621,7 +631,7 @@ snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
     # via cirq-core
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 sphinx==8.0.2
     # via
@@ -679,7 +689,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   sphinx
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via pylint
 toolz==0.12.1
     # via cytoolz
@@ -744,7 +754,7 @@ virtualenv==20.26.3
     # via -r deps/packaging.txt
 wcwidth==0.2.13
     # via prompt-toolkit
-webcolors==24.6.0
+webcolors==24.8.0
     # via jsonschema
 webencodings==0.5.1
     # via
@@ -764,7 +774,7 @@ widgetsnbextension==4.0.11
     # via ipywidgets
 wrapt==1.16.0
     # via astroid
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -29,10 +29,6 @@ anywidget==0.9.13
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
-appnope==0.1.4
-    # via
-    #   -c envs/dev.env.txt
-    #   ipykernel
 argon2-cffi==23.1.0
     # via
     #   -c envs/dev.env.txt
@@ -212,6 +208,10 @@ graphviz==0.20.3
     # via
     #   -c envs/dev.env.txt
     #   qref
+greenlet==3.0.3
+    # via
+    #   -c envs/dev.env.txt
+    #   sqlalchemy
 h11==0.14.0
     # via
     #   -c envs/dev.env.txt
@@ -376,7 +376,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.1.post1
+matplotlib==3.9.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -686,7 +686,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-soupsieve==2.5
+soupsieve==2.6
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
@@ -830,7 +830,7 @@ wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit
-webcolors==24.6.0
+webcolors==24.8.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -852,7 +852,7 @@ widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-zipp==3.19.2
+zipp==3.20.0
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -29,6 +29,10 @@ anywidget==0.9.13
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
+appnope==0.1.4
+    # via
+    #   -c envs/dev.env.txt
+    #   ipykernel
 argon2-cffi==23.1.0
     # via
     #   -c envs/dev.env.txt
@@ -72,7 +76,7 @@ babel==2.16.0
     #   jupyterlab-server
     #   pydata-sphinx-theme
     #   sphinx
-bartiq==0.5.0
+bartiq==0.5.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -208,10 +212,6 @@ graphviz==0.20.3
     # via
     #   -c envs/dev.env.txt
     #   qref
-greenlet==3.0.3
-    # via
-    #   -c envs/dev.env.txt
-    #   sqlalchemy
 h11==0.14.0
     # via
     #   -c envs/dev.env.txt
@@ -608,7 +608,7 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qref==0.6.2
+qref==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -17,10 +17,6 @@ anywidget==0.9.13
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
-appnope==0.1.4
-    # via
-    #   -c envs/dev.env.txt
-    #   ipykernel
 argon2-cffi==23.1.0
     # via
     #   -c envs/dev.env.txt
@@ -345,7 +341,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.1.post1
+matplotlib==3.9.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -622,7 +618,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-soupsieve==2.5
+soupsieve==2.6
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
@@ -721,7 +717,7 @@ wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit
-webcolors==24.6.0
+webcolors==24.8.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -743,7 +739,7 @@ widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-zipp==3.19.2
+zipp==3.20.0
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -17,6 +17,10 @@ anywidget==0.9.13
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
+appnope==0.1.4
+    # via
+    #   -c envs/dev.env.txt
+    #   ipykernel
 argon2-cffi==23.1.0
     # via
     #   -c envs/dev.env.txt
@@ -57,7 +61,7 @@ babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
-bartiq==0.5.0
+bartiq==0.5.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -545,7 +549,7 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qref==0.6.2
+qref==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -25,6 +25,10 @@ anywidget==0.9.13
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
+appnope==0.1.4
+    # via
+    #   -c envs/dev.env.txt
+    #   ipykernel
 argon2-cffi==23.1.0
     # via
     #   -c envs/dev.env.txt
@@ -74,7 +78,7 @@ babel==2.16.0
     #   -c envs/dev.env.txt
     #   jupyterlab-server
     #   sphinx
-bartiq==0.5.0
+bartiq==0.5.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -645,7 +649,7 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qref==0.6.2
+qref==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -25,10 +25,6 @@ anywidget==0.9.13
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
-appnope==0.1.4
-    # via
-    #   -c envs/dev.env.txt
-    #   ipykernel
 argon2-cffi==23.1.0
     # via
     #   -c envs/dev.env.txt
@@ -399,7 +395,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.1.post1
+matplotlib==3.9.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -733,7 +729,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-soupsieve==2.5
+soupsieve==2.6
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
@@ -800,7 +796,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   sphinx
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -c envs/dev.env.txt
     #   pylint
@@ -871,7 +867,7 @@ wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit
-webcolors==24.6.0
+webcolors==24.8.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -897,7 +893,7 @@ wrapt==1.16.0
     # via
     #   -c envs/dev.env.txt
     #   astroid
-zipp==3.19.2
+zipp==3.20.0
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -17,6 +17,10 @@ anywidget==0.9.13
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
+appnope==0.1.4
+    # via
+    #   -c envs/dev.env.txt
+    #   ipykernel
 argon2-cffi==23.1.0
     # via
     #   -c envs/dev.env.txt
@@ -57,7 +61,7 @@ babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
-bartiq==0.5.0
+bartiq==0.5.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -616,7 +620,7 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qref==0.6.2
+qref==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -17,10 +17,6 @@ anywidget==0.9.13
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
-appnope==0.1.4
-    # via
-    #   -c envs/dev.env.txt
-    #   ipykernel
 argon2-cffi==23.1.0
     # via
     #   -c envs/dev.env.txt
@@ -369,7 +365,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.1.post1
+matplotlib==3.9.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -699,7 +695,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-soupsieve==2.5
+soupsieve==2.6
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
@@ -799,7 +795,7 @@ wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit
-webcolors==24.6.0
+webcolors==24.8.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -821,7 +817,7 @@ widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-zipp==3.19.2
+zipp==3.20.0
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -17,10 +17,6 @@ anywidget==0.9.13
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
-appnope==0.1.4
-    # via
-    #   -c envs/dev.env.txt
-    #   ipykernel
 argon2-cffi==23.1.0
     # via
     #   -c envs/dev.env.txt
@@ -328,7 +324,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.1.post1
+matplotlib==3.9.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -596,7 +592,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-soupsieve==2.5
+soupsieve==2.6
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
@@ -693,7 +689,7 @@ wcwidth==0.2.13
     # via
     #   -c envs/dev.env.txt
     #   prompt-toolkit
-webcolors==24.6.0
+webcolors==24.8.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -715,7 +711,7 @@ widgetsnbextension==4.0.11
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-zipp==3.19.2
+zipp==3.20.0
     # via
     #   -c envs/dev.env.txt
     #   importlib-metadata

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -17,6 +17,10 @@ anywidget==0.9.13
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
+appnope==0.1.4
+    # via
+    #   -c envs/dev.env.txt
+    #   ipykernel
 argon2-cffi==23.1.0
     # via
     #   -c envs/dev.env.txt
@@ -53,7 +57,7 @@ babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
-bartiq==0.5.0
+bartiq==0.5.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -519,7 +523,7 @@ pyzmq==26.1.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qref==0.6.2
+qref==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt


### PR DESCRIPTION
Given compatibility issues that @mpharrigan mentioned [here](https://github.com/quantumlib/Qualtran/pull/1267#issuecomment-2278298079), I made a new Bartiq release that solves it and updated versions here.