### PR TITLE
Add explicit adjoint for `SwapWithZero` and classical simulation tests for decomposition of `SelectSwapQROM`

### DIFF
--- a/qualtran/bloqs/data_loading/select_swap_qrom.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom.py
@@ -341,8 +341,13 @@ class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
         return selection
 
     def _build_composite_bloq_with_swz(
-        self, bb: 'BloqBuilder', ctrl, selection, target, qrom_targets
-    ):
+        self,
+        bb: 'BloqBuilder',
+        ctrl: List['SoquetT'],
+        selection: List['SoquetT'],
+        target: List['SoquetT'],
+        qrom_targets: List['SoquetT'],
+    ) -> Tuple[List['SoquetT'], List['SoquetT'], List['SoquetT'], List['SoquetT']]:
         sel_l, sel_k = self._partition_sel_register(bb, selection)
         # Partition selection registers into l & k
         ctrl, sel_l, qrom_targets = self._add_qrom_bloq(bb, ctrl, sel_l, qrom_targets)
@@ -363,8 +368,13 @@ class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
         return ctrl, selection, target, qrom_targets
 
     def _build_composite_bloq_without_swz(
-        self, bb: 'BloqBuilder', ctrl, selection, target, qrom_targets
-    ):
+        self,
+        bb: 'BloqBuilder',
+        ctrl: List['SoquetT'],
+        selection: List['SoquetT'],
+        target: List['SoquetT'],
+        qrom_targets: List['SoquetT'],
+    ) -> Tuple[List['SoquetT'], List['SoquetT'], List['SoquetT'], List['SoquetT']]:
         ctrl, selection, qrom_targets = self._add_qrom_bloq(bb, ctrl, selection, qrom_targets)
         qrom_targets, target = self._add_cnot(bb, qrom_targets, target)
         ctrl, selection, qrom_targets = self._add_qrom_bloq(

--- a/qualtran/bloqs/swap_network/swap_with_zero.py
+++ b/qualtran/bloqs/swap_network/swap_with_zero.py
@@ -148,7 +148,6 @@ class SwapWithZero(GateWithRegisters):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', targets: NDArray['Soquet'], **sel: 'Soquet'  # type: ignore[type-var]
     ) -> Dict[str, 'SoquetT']:
-        # self.build_via_tree(bb, sel, targets, ())
         sel_soqs = [bb.split(sel[reg.name]) for reg in self.selection_registers]
         for i, sel_idx_small, idx_one, idx_two in self._swap_sequence:
             sel_idx_big = self.selection_bitsizes[i] - sel_idx_small - 1

--- a/qualtran/bloqs/swap_network/swap_with_zero.py
+++ b/qualtran/bloqs/swap_network/swap_with_zero.py
@@ -53,6 +53,27 @@ def _to_tuple(x: Union[SymbolicInt, Iterable[SymbolicInt]]) -> Tuple[SymbolicInt
 def _swap_with_zero_swap_sequence(
     selection_bitsizes: Tuple[int, ...], target_shape: Tuple[int, ...], idx: Tuple[int, ...] = ()
 ) -> Iterator[Tuple[int, int, Tuple[int, ...], Tuple[int, ...]]]:
+    """Yields tuples of indices that should be swapped in that order to realize a swap with zero.
+
+    The method recursively iterates over all combinations of `S = np.prod(selection_bitsizes)`
+    indices, where each index is multidimensional with `n=len(selection_bitsizes)` dimensions.
+    The method yields a sequence of O(S) pairs of target indices which should be swapped controlled
+    on a qubit from one of the `n` selection registers being True.
+
+    Args:
+        selection_bitsizes: Bitsizes of the selection index.
+        target_shape: Shape of the target register.
+        idx: A tuple representing a prefix of n-dimensional selection index,
+            used as part of the recursion.
+
+    Yields:
+        - i: Integer in range `[0, n)`, representing index of the selection register from which a qubit
+            should be used as a control.
+        - sel_idx: Little endian index of the qubit in the `i`'th selection register that should be
+            used as a control for the swap.
+        - idx_one: An n-dimensional tuple representing a unique selection index that should be swapped.
+        - idx_two: An n-dimensional tuple representing a unique selection index that should be swapped.
+    """
     if len(idx) == len(selection_bitsizes):
         return
     idx_len = len(idx)

--- a/qualtran/bloqs/swap_network/swap_with_zero.py
+++ b/qualtran/bloqs/swap_network/swap_with_zero.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Iterable, Set, Tuple, TYPE_CHECKING, Union
+from typing import cast, Dict, Iterable, Iterator, Set, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import cirq
@@ -39,6 +39,7 @@ from qualtran.symbolics import is_symbolic, prod, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.simulation.classical_sim import ClassicalValT
 
 
 def _to_tuple(x: Union[SymbolicInt, Iterable[SymbolicInt]]) -> Tuple[SymbolicInt, ...]:
@@ -47,6 +48,39 @@ def _to_tuple(x: Union[SymbolicInt, Iterable[SymbolicInt]]) -> Tuple[SymbolicInt
     if isinstance(x, Iterable):
         return tuple(x)
     return (x,)
+
+
+def _swap_with_zero_swap_sequence(
+    selection_bitsizes: Tuple[int, ...], target_shape: Tuple[int, ...], idx: Tuple[int, ...] = ()
+) -> Iterator[Tuple[int, int, Tuple[int, ...], Tuple[int, ...]]]:
+    if len(idx) == len(selection_bitsizes):
+        return
+    idx_len = len(idx)
+    dim = target_shape[idx_len]
+    for x in range(dim):
+        # First make sure that value to be searched is present at the LEFT most position
+        # of the composite index by recursively swapping the subtrees attached on leaf nodes of
+        # the current segment tree.
+        yield from _swap_with_zero_swap_sequence(selection_bitsizes, target_shape, idx + (x,))
+    mid_point = 1
+    for sel_idx in range(selection_bitsizes[idx_len]):
+        # Imagine a complete binary tree of depth `logN` with `N` leaves, each denoting a target
+        # register. If the selection register stores index `r`, we want to bring the value stored
+        # in leaf indexed `r` to the leaf indexed `0`. At each node of the binary tree, the left
+        # subtree contains node with current bit 0 and right subtree contains nodes with current
+        # bit 1. Thus, leaf indexed `0` is the leftmost node in the tree.
+        # Start iterating from the root of the tree. If the j'th bit is set in the selection
+        # register (i.e. the control would be activated); we know that the value we are searching
+        # for is in the right subtree. In order to (eventually) bring the desired value to node
+        # 0; we swap all values in the right subtree with all values in the left subtree. This
+        # takes (N / (2 ** (j + 1)) swaps at level `j`.
+        # Therefore, in total, we need $\sum_{j=0}^{logN-1} \frac{N}{2 ^ {j + 1}}$ controlled swaps.
+        for x in range(0, dim - mid_point, 2 * mid_point):
+            zero_pad = (0,) * (len(selection_bitsizes) - idx_len - 1)
+            idx_one = idx + (x,) + zero_pad
+            idx_two = idx + (x + mid_point,) + zero_pad
+            yield idx_len, sel_idx, idx_one, idx_two
+        mid_point <<= 1
 
 
 @attrs.frozen
@@ -72,6 +106,7 @@ class SwapWithZero(GateWithRegisters):
     selection_bitsizes: Tuple[SymbolicInt, ...] = attrs.field(converter=_to_tuple)
     target_bitsize: SymbolicInt
     n_target_registers: Tuple[SymbolicInt, ...] = attrs.field(converter=_to_tuple)
+    uncompute: bool = False
 
     def __attrs_post_init__(self):
         assert len(self.n_target_registers) == len(self.selection_bitsizes)
@@ -101,54 +136,28 @@ class SwapWithZero(GateWithRegisters):
     def cswap_n(self) -> 'CSwapApprox':
         return CSwapApprox(self.target_bitsize)
 
-    def build_via_tree(
-        self,
-        bb: 'BloqBuilder',
-        sel: Dict[str, 'Soquet'],
-        targets: NDArray['Soquet'],  # type: ignore[type-var]
-        idx: Tuple[int, ...],
-    ) -> None:
-        sel_idx = len(idx)
-        if sel_idx == len(self.selection_bitsizes):
-            return
-
-        n_target_registers = self.n_target_registers[sel_idx]
-        assert isinstance(n_target_registers, int)
-        for i in range(n_target_registers):
-            # First make sure that value to be searched is present at the LEFT most position
-            # of the composite index by recursively swapping the subtrees attached on leaf nodes of
-            # the current segment tree.
-            self.build_via_tree(bb, sel, targets, idx + (i,))
-
-        sel_reg = self.selection_registers[sel_idx]  # type: ignore[type-var]
-        sel_soqs = bb.split(sel[sel_reg.name])
-        sel_bitsize = self.selection_registers[sel_idx].bitsize
-        for j in range(sel_bitsize):
-            # Imagine a complete binary tree of depth `logN` with `N` leaves, each denoting a target
-            # register. If the selection register stores index `r`, we want to bring the value stored
-            # in leaf indexed `r` to the leaf indexed `0`. At each node of the binary tree, the left
-            # subtree contains node with current bit 0 and right subtree contains nodes with current
-            # bit 1. Thus, leaf indexed `0` is the leftmost node in the tree.
-            # Start iterating from the root of the tree. If the j'th bit is set in the selection
-            # register (i.e. the control would be activated); we know that the value we are searching
-            # for is in the right subtree. In order to (eventually) bring the desired value to node
-            # 0; we swap all values in the right subtree with all values in the left subtree. This
-            # takes (N / (2 ** (j + 1)) swaps at level `j`.
-            # Therefore, in total, we need $\sum_{j=0}^{logN-1} \frac{N}{2 ^ {j + 1}}$ controlled swaps.
-            sel_i = sel_bitsize - j - 1
-            for i in range(0, self.n_target_registers[sel_idx] - 2**j, 2 ** (j + 1)):
-                zero_pad = (0,) * (len(self.n_target_registers) - len(idx) - 1)
-                left_idx = idx + (i,) + zero_pad
-                right_idx = idx + (i + 2**j,) + zero_pad
-                sel_soqs[sel_i], targets[left_idx], targets[right_idx] = bb.add(
-                    self.cswap_n, ctrl=sel_soqs[sel_i], x=targets[left_idx], y=targets[right_idx]
-                )
-        sel[sel_reg.name] = bb.join(sel_soqs, dtype=sel_reg.dtype)
+    @cached_property
+    def _swap_sequence(self) -> Tuple[Tuple[int, int, Tuple[int, ...], Tuple[int, ...]], ...]:
+        if is_symbolic(*self.selection_bitsizes) or is_symbolic(*self.n_target_registers):
+            raise ValueError(f"Cannot produce swap sequence for symbolic {self=}")
+        selection_bitsizes = cast(Tuple[int, ...], self.selection_bitsizes)
+        n_target_registers = cast(Tuple[int, ...], self.n_target_registers)
+        ret = [*_swap_with_zero_swap_sequence(selection_bitsizes, n_target_registers)]
+        return tuple(ret[::-1] if self.uncompute else ret)
 
     def build_composite_bloq(
         self, bb: 'BloqBuilder', targets: NDArray['Soquet'], **sel: 'Soquet'  # type: ignore[type-var]
     ) -> Dict[str, 'SoquetT']:
-        self.build_via_tree(bb, sel, targets, ())
+        # self.build_via_tree(bb, sel, targets, ())
+        sel_soqs = [bb.split(sel[reg.name]) for reg in self.selection_registers]
+        for i, sel_idx_small, idx_one, idx_two in self._swap_sequence:
+            sel_idx_big = self.selection_bitsizes[i] - sel_idx_small - 1
+            sel_soqs[i][sel_idx_big], targets[idx_one], targets[idx_two] = bb.add(
+                self.cswap_n, ctrl=sel_soqs[i][sel_idx_big], x=targets[idx_one], y=targets[idx_two]
+            )
+        sel = {
+            reg.name: bb.join(sel_soq) for sel_soq, reg in zip(sel_soqs, self.selection_registers)
+        }
         return sel | {'targets': targets}
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
@@ -170,6 +179,19 @@ class SwapWithZero(GateWithRegisters):
             subscript = "".join(f"_{i}" for i in idx)
             return TextBox(f'swap{subscript}')
         raise ValueError(f'Unrecognized register name {name}')
+
+    def on_classical_vals(
+        self, *, targets: 'ClassicalValT', **selection: 'ClassicalValT'
+    ) -> Dict[str, 'ClassicalValT']:
+        assert isinstance(targets, np.ndarray)
+        selection_idx = tuple(selection.values())
+        for i, sel_idx_small, idx_one, idx_two in self._swap_sequence:
+            if selection_idx[i] & (1 << sel_idx_small) != 0:
+                targets[idx_one], targets[idx_two] = targets[idx_two], targets[idx_one]
+        return selection | {'targets': targets}
+
+    def adjoint(self) -> 'SwapWithZero':
+        return attrs.evolve(self, uncompute=not self.uncompute)
 
 
 @bloq_example(generalizer=ignore_split_join)


### PR DESCRIPTION
Part of a series of PRs to address #368 

This PR adds:

- Explicit on_classical_vals and adjoint for `SwapWithZero` bloq. 
- Lots of tests to verify classical simulation of `SelectSwapQROM` (and it's decomposition) and `SwapWithZero`. 


