### PR TITLE
Fix `PRGAViaPhaseGradient.build_call_graph` to use `Counter` instead of `Dict`

### DIFF
--- a/qualtran/bloqs/state_preparation/state_preparation_via_rotation_test.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_via_rotation_test.py
@@ -38,6 +38,14 @@ def test_state_prep_via_rotation(bloq_autotester):
     bloq_autotester(_state_prep_via_rotation)
 
 
+def test_state_prep_via_rotation_symb_quick():
+    bloq = _state_prep_via_rotation_symb.make()
+    L, phase = bloq.n_coeff, bloq.phase_bitsize
+    expected_t_count_expr = 16 * L + 8 * phase - 32
+    assert isinstance(expected_t_count_expr, sympy.Expr)
+    assert bloq.t_complexity().t == expected_t_count_expr
+
+
 @pytest.mark.slow
 def test_state_prep_via_rotation_symb():
     bloq = _state_prep_via_rotation_symb.make()


### PR DESCRIPTION
Fix failing test due to https://github.com/quantumlib/Qualtran/pull/1276

We should use counters to add up bloqs in `build_call_graph` methods. Pattern like `return {bloq: 1, bloq.adjoint(): 1}` leads to undercounting when `bloq` and `bloq.adjoint()` are same (i.e. a bloq is self-inverse, which is what happened here with `QROM`)