### PR TITLE
Add shim for measurement gate

### DIFF
--- a/qualtran/bloqs/basic_gates/_shims.py
+++ b/qualtran/bloqs/basic_gates/_shims.py
@@ -1,0 +1,46 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import TYPE_CHECKING, Union
+
+import numpy as np
+from attrs import frozen
+
+from qualtran import Bloq, DecomposeTypeError, QBit, Register, Side, Signature
+
+if TYPE_CHECKING:
+    import cirq
+
+    from qualtran.cirq_interop import CirqQuregT
+
+
+@frozen
+class Measure(Bloq):
+    """Single qubit measurement gate."""
+
+    @property
+    def signature(self) -> 'Signature':
+        return Signature([Register("q", QBit(), side=Side.LEFT)])
+
+    def decompose_bloq(self):
+        raise DecomposeTypeError(f"{self} is atomic")
+
+    def as_cirq_op(
+        self, qubit_manager: 'cirq.QubitManager', q: 'CirqQuregT'
+    ) -> tuple[Union['cirq.Operation', None], dict[str, 'CirqQuregT']]:
+        import cirq
+
+        measure = cirq.MeasurementGate(num_qubits=1)
+
+        (q,) = q
+        return measure(q), {'q': np.array([q])}

--- a/qualtran/resource_counting/_bloq_counts.py
+++ b/qualtran/resource_counting/_bloq_counts.py
@@ -239,6 +239,7 @@ class QECGatesCost(CostKey[GateCounts]):
 
     def compute(self, bloq: 'Bloq', get_callee_cost: Callable[['Bloq'], GateCounts]) -> GateCounts:
         from qualtran.bloqs.basic_gates import TGate, Toffoli, TwoBitCSwap
+        from qualtran.bloqs.basic_gates._shims import Measure
         from qualtran.bloqs.mcmt.and_bloq import And
 
         # T gates
@@ -248,6 +249,10 @@ class QECGatesCost(CostKey[GateCounts]):
         # Toffolis
         if isinstance(bloq, Toffoli):
             return GateCounts(toffoli=1)
+
+        # Measurement
+        if isinstance(bloq, Measure):
+            return GateCounts(measurement=1)
 
         # 'And' bloqs
         if isinstance(bloq, And):

--- a/qualtran/resource_counting/_bloq_counts_test.py
+++ b/qualtran/resource_counting/_bloq_counts_test.py
@@ -16,6 +16,7 @@ import sympy
 
 from qualtran.bloqs import basic_gates, mcmt, rotations
 from qualtran.bloqs.basic_gates import Hadamard, TGate, Toffoli
+from qualtran.bloqs.basic_gates._shims import Measure
 from qualtran.bloqs.for_testing.costing import make_example_costing_bloqs
 from qualtran.resource_counting import BloqCount, GateCounts, get_cost_value, QECGatesCost
 
@@ -72,6 +73,8 @@ def test_qec_gates_cost():
         [basic_gates.TGate(is_adjoint=False), GateCounts(t=1)],
         # Toffoli
         [basic_gates.Toffoli(), GateCounts(toffoli=1)],
+        # Measure
+        [Measure(), GateCounts(measurement=1)],
         # CSwap
         [basic_gates.TwoBitCSwap(), GateCounts(cswap=1)],
         # And


### PR DESCRIPTION
Introduces a simple shim bloq `Measure` for single qubit measurements. Useful for resource counting, e.g. #1135