### PR TITLE
`SU2RotationGate`: add helper to construct from Euler ZXZ angles

### DIFF
--- a/qualtran/bloqs/basic_gates/su2_rotation.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation.py
@@ -21,7 +21,6 @@ from numpy.typing import NDArray
 
 from qualtran import bloq_example, BloqDocSpec, ConnectionT, GateWithRegisters, Register, Signature
 from qualtran.bloqs.basic_gates import GlobalPhase, Rx, Rz
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Text, TextBox
 from qualtran.symbolics import is_symbolic, pi, SymbolicFloat
 

--- a/qualtran/bloqs/basic_gates/su2_rotation.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation.py
@@ -20,7 +20,7 @@ from attrs import frozen
 from numpy.typing import NDArray
 
 from qualtran import bloq_example, BloqDocSpec, ConnectionT, GateWithRegisters, Register, Signature
-from qualtran.bloqs.basic_gates import GlobalPhase, Ry, ZPowGate
+from qualtran.bloqs.basic_gates import GlobalPhase, Hadamard, Rz, ZPowGate
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Text, TextBox
 from qualtran.symbolics import is_symbolic, pi, SymbolicFloat
@@ -129,12 +129,14 @@ class SU2RotationGate(GateWithRegisters):
             GlobalPhase(exponent=1 + self.global_shift / pi(self.global_shift), eps=self.eps / 4)
         )
         q = bb.add(
-            ZPowGate(exponent=1 - self.lambd / pi(self.lambd), global_shift=-1, eps=self.eps / 4),
+            ZPowGate(exponent=0.5 - self.lambd / pi(self.lambd), global_shift=-1, eps=self.eps / 4),
             q=q,
         )
-        q = bb.add(Ry(angle=2 * self.theta, eps=self.eps / 4), q=q)
+        q = bb.add(Hadamard(), q=q)
+        q = bb.add(Rz(angle=2 * self.theta, eps=self.eps / 4), q=q)
+        q = bb.add(Hadamard(), q=q)
         q = bb.add(
-            ZPowGate(exponent=-self.phi / pi(self.phi), global_shift=-1, eps=self.eps / 4), q=q
+            ZPowGate(exponent=0.5 - self.phi / pi(self.phi), global_shift=-1, eps=self.eps / 4), q=q
         )
         return {'q': q}
 

--- a/qualtran/bloqs/basic_gates/su2_rotation.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation.py
@@ -126,18 +126,21 @@ class SU2RotationGate(GateWithRegisters):
 
     def build_composite_bloq(self, bb: 'BloqBuilder', q: 'SoquetT') -> Dict[str, 'SoquetT']:
         bb.add(
-            GlobalPhase(exponent=1 + self.global_shift / pi(self.global_shift), eps=self.eps / 4)
+            GlobalPhase(
+                exponent=(
+                    0.5
+                    + self.global_shift / pi(self.global_shift)
+                    + self.lambd / (2 * pi(self.lambd))
+                    + self.phi / (2 * pi(self.phi))
+                ),
+                eps=self.eps / 4,
+            )
         )
-        q = bb.add(
-            ZPowGate(exponent=0.5 - self.lambd / pi(self.lambd), global_shift=-1, eps=self.eps / 4),
-            q=q,
-        )
+        q = bb.add(Rz(pi(self.lambd) / 2 - self.lambd, eps=self.eps / 4), q=q)
         q = bb.add(Hadamard(), q=q)
-        q = bb.add(Rz(angle=2 * self.theta, eps=self.eps / 4), q=q)
+        q = bb.add(Rz(2 * self.theta, eps=self.eps / 4), q=q)
         q = bb.add(Hadamard(), q=q)
-        q = bb.add(
-            ZPowGate(exponent=0.5 - self.phi / pi(self.phi), global_shift=-1, eps=self.eps / 4), q=q
-        )
+        q = bb.add(Rz(pi(self.phi) / 2 - self.phi, eps=self.eps / 4), q=q)
         return {'q': q}
 
     def adjoint(self) -> 'SU2RotationGate':

--- a/qualtran/bloqs/basic_gates/su2_rotation.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation.py
@@ -193,7 +193,7 @@ class SU2RotationGate(GateWithRegisters):
         )
 
     def _t_complexity_(self) -> TComplexity:
-        return TComplexity(rotations=3)
+        return TComplexity(rotations=3, clifford=2)
 
     def is_symbolic(self) -> bool:
         return is_symbolic(self.theta, self.phi, self.lambd, self.global_shift)

--- a/qualtran/bloqs/basic_gates/su2_rotation.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation.py
@@ -166,6 +166,7 @@ class SU2RotationGate(GateWithRegisters):
 
     def build_composite_bloq(self, bb: 'BloqBuilder', q: 'SoquetT') -> Dict[str, 'SoquetT']:
         # TODO implement controlled version, and pass eps/4 to each rotation (incl. global phase)
+        #      https://github.com/quantumlib/Qualtran/issues/1330
         bb.add(
             GlobalPhase(
                 exponent=(

--- a/qualtran/bloqs/basic_gates/su2_rotation_test.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation_test.py
@@ -16,10 +16,8 @@ import numpy as np
 import sympy
 
 from qualtran import Bloq
-from qualtran.bloqs.basic_gates import GlobalPhase, Hadamard, Rz, TGate, XGate, YGate, ZGate
+from qualtran.bloqs.basic_gates import GlobalPhase, Hadamard, Rx, Rz, TGate, XGate, YGate, ZGate
 from qualtran.cirq_interop import BloqAsCirqGate
-from qualtran.cirq_interop.testing import assert_decompose_is_consistent_with_t_complexity
-
 from .su2_rotation import _hadamard, _su2_rotation_gate, _t_gate, SU2RotationGate
 
 
@@ -33,15 +31,6 @@ def test_decompose_SU2_to_single_qubit_pauli_gates():
         np.testing.assert_allclose(
             cirq.unitary(BloqAsCirqGate(gate.decompose_bloq())), gate.rotation_matrix
         )
-
-
-def test_assert_decompose_is_consistent_with_t_complexity():
-    random_state = np.random.default_rng(42)
-
-    for _ in range(20):
-        theta, phi, lambd, global_shift = random_state.random(size=4) * 2 * np.pi
-        gate = SU2RotationGate(theta, phi, lambd, global_shift)
-        assert_decompose_is_consistent_with_t_complexity(gate)
 
 
 def test_tensors():
@@ -92,9 +81,8 @@ def test_call_graph():
     gate = SU2RotationGate(theta, phi, lambd, alpha, eps)
     _, sigma = gate.call_graph()
     assert sigma == {
-        GlobalPhase(exponent=alpha / pi + lambd / (2 * pi) + phi / (2 * pi) + 0.5, eps=eps / 4): 1,
-        Rz(-phi + pi / 2, eps=eps / 4): 1,
-        Rz(-lambd + pi / 2, eps=eps / 4): 1,
-        Rz(2 * theta, eps / 4): 1,
-        Hadamard(): 2,
+        GlobalPhase(exponent=alpha / pi + lambd / (2 * pi) + phi / (2 * pi) + 0.5): 1,
+        Rz(-phi + pi / 2, eps=eps / 3): 1,
+        Rz(-lambd + pi / 2, eps=eps / 3): 1,
+        Rx(2 * theta, eps / 3): 1,
     }

--- a/qualtran/bloqs/basic_gates/su2_rotation_test.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation_test.py
@@ -16,16 +16,7 @@ import numpy as np
 import sympy
 
 from qualtran import Bloq
-from qualtran.bloqs.basic_gates import (
-    GlobalPhase,
-    Hadamard,
-    Ry,
-    TGate,
-    XGate,
-    YGate,
-    ZGate,
-    ZPowGate,
-)
+from qualtran.bloqs.basic_gates import GlobalPhase, Hadamard, Rz, TGate, XGate, YGate, ZGate
 from qualtran.cirq_interop import BloqAsCirqGate
 from qualtran.cirq_interop.testing import assert_decompose_is_consistent_with_t_complexity
 
@@ -70,8 +61,10 @@ def test_su2_rotation_gates(bloq_autotester):
 
 
 def test_su2_rotation_gate_example_unitaries_match():
-    np.testing.assert_allclose(_t_gate().tensor_contract(), TGate().tensor_contract())
-    np.testing.assert_allclose(_hadamard().tensor_contract(), Hadamard().tensor_contract())
+    np.testing.assert_allclose(_t_gate().tensor_contract(), TGate().tensor_contract(), atol=1e-11)
+    np.testing.assert_allclose(
+        _hadamard().tensor_contract(), Hadamard().tensor_contract(), atol=1e-11
+    )
 
 
 def test_from_matrix_on_random_unitaries():
@@ -99,8 +92,9 @@ def test_call_graph():
     gate = SU2RotationGate(theta, phi, lambd, alpha, eps)
     _, sigma = gate.call_graph()
     assert sigma == {
-        GlobalPhase(exponent=1 + alpha / pi, eps=eps / 4): 1,
-        ZPowGate(-phi / pi, -1, eps / 4): 1,
-        ZPowGate(-lambd / pi + 1, -1, eps / 4): 1,
-        Ry(2 * theta, eps / 4): 1,
+        GlobalPhase(exponent=alpha / pi + lambd / (2 * pi) + phi / (2 * pi) + 0.5, eps=eps / 4): 1,
+        Rz(-phi + pi / 2, eps=eps / 4): 1,
+        Rz(-lambd + pi / 2, eps=eps / 4): 1,
+        Rz(2 * theta, eps / 4): 1,
+        Hadamard(): 2,
     }

--- a/qualtran/bloqs/basic_gates/su2_rotation_test.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation_test.py
@@ -18,6 +18,7 @@ import sympy
 from qualtran import Bloq
 from qualtran.bloqs.basic_gates import GlobalPhase, Hadamard, Rx, Rz, TGate, XGate, YGate, ZGate
 from qualtran.cirq_interop import BloqAsCirqGate
+
 from .su2_rotation import _hadamard, _su2_rotation_gate, _t_gate, SU2RotationGate
 
 


### PR DESCRIPTION
- add a helper `from_euler_zxz_angles`, which is another commonly used representation for SU2.
- simplify decomposition to use Rz and Rx gates.
- Use eps/3 per rotation, without any eps for global phase.