### PR TITLE
n_qubits for symbolic signature

### DIFF
--- a/qualtran/_infra/registers.py
+++ b/qualtran/_infra/registers.py
@@ -23,7 +23,7 @@ import numpy as np
 import sympy
 from attrs import field, frozen
 
-from qualtran.symbolics import is_symbolic, SymbolicInt
+from qualtran.symbolics import is_symbolic, smax, SymbolicInt
 
 from .data_types import QAny, QBit, QDType
 
@@ -204,7 +204,7 @@ class Signature:
         """
         left_size = sum(reg.total_bits() for reg in self.lefts())
         right_size = sum(reg.total_bits() for reg in self.rights())
-        return max(left_size, right_size)
+        return smax(left_size, right_size)
 
     def __repr__(self):
         return f'Signature({repr(self._registers)})'

--- a/qualtran/_infra/registers_test.py
+++ b/qualtran/_infra/registers_test.py
@@ -122,6 +122,13 @@ def test_signature():
         assert flat_named_qubits == expected_qubits
 
 
+def test_signature_symbolic():
+    n_x, n_y = sympy.symbols('n_x n_y')
+    signature = Signature.build(x=n_x, y=n_y)
+    assert signature.n_qubits() == n_x + n_y
+    assert str(signature.n_qubits()) == 'n_x + n_y'
+
+
 def test_signature_build():
     sig1 = Signature([Register("r1", QAny(5)), Register("r2", QAny(2))])
     sig2 = Signature.build(r1=5, r2=2)

--- a/qualtran/bloqs/arithmetic/addition_test.py
+++ b/qualtran/bloqs/arithmetic/addition_test.py
@@ -39,6 +39,7 @@ from qualtran.bloqs.arithmetic.addition import (
 from qualtran.bloqs.mcmt.and_bloq import And
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.cirq_interop.testing import assert_circuit_inp_out_cirqsim, GateHelper
+from qualtran.resource_counting import get_cost_value, QubitCount
 from qualtran.resource_counting.generalizers import ignore_split_join
 from qualtran.simulation.classical_sim import (
     format_classical_truth_table,
@@ -275,6 +276,12 @@ def test_add_classical():
     ret1 = bloq.call_classically(a=10, b=3)
     ret2 = bloq.decompose_bloq().call_classically(a=10, b=3)
     assert ret1 == ret2
+
+
+def test_add_symb():
+    bloq = _add_symb()
+    assert bloq.signature.n_qubits() == sympy.sympify('2*n')
+    assert get_cost_value(bloq, QubitCount()) == sympy.sympify('Max(3, 2*n)')
 
 
 def test_out_of_place_adder():


### PR DESCRIPTION
Use sympy-symbolic-supporting `smax` instead of `max` for `Signature.n_Qubits`. 

Fixes #1298 

Does not fix and therefore keeps open:  #1261 