### PR TITLE
Restrict controlled from non-thru registers

### DIFF
--- a/qualtran/Controlled.ipynb
+++ b/qualtran/Controlled.ipynb
@@ -241,6 +241,14 @@
     "ccx3 = OnEach(n=3, gate=x).controlled(CtrlSpec(cvs=(1,1)))\n",
     "show_bloq(ccx3.decompose_bloq(), type='musical_score')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24aa3d20-7803-4480-b717-5e3a2d5e6ba3",
+   "metadata": {},
+   "source": [
+    "Only bloqs with all-THRU registers can be controlled. Otherwise, it's not clear what the equivalent \"identity\" operation is."
+   ]
   }
  ],
  "metadata": {

--- a/qualtran/_infra/controlled.py
+++ b/qualtran/_infra/controlled.py
@@ -312,6 +312,11 @@ class Controlled(GateWithRegisters):
     subbloq: 'Bloq'
     ctrl_spec: 'CtrlSpec'
 
+    def __attrs_post_init__(self):
+        for reg in self.subbloq.signature:
+            if reg.side != Side.THRU:
+                raise ValueError(f"Cannot control non-thru bloqs. Found {reg} in {self.subbloq}")
+
     @classmethod
     def make_ctrl_system(cls, bloq: 'Bloq', ctrl_spec: 'CtrlSpec') -> Tuple[Bloq, AddControlledT]:
         """A factory method for creating both the Controlled and the adder function.

--- a/qualtran/_infra/gate_with_registers_test.py
+++ b/qualtran/_infra/gate_with_registers_test.py
@@ -151,7 +151,7 @@ t: ───t───────────────────Y───
 
 
 def test_non_unitary_controlled():
-    bloq = BloqWithDecompose()
+    bloq = _TestGate()
     assert bloq.controlled(control_values=[0]) == Controlled(bloq, CtrlSpec(cvs=0))
 
 


### PR DESCRIPTION
For #1304 

 - Only thru registers allowed in `Controlled`
 - Prevents triggering the bug in classical simulation where controlled allocations are not supported 