### PR TITLE
SparseStatePrep: fix bug in using `scipy.sparse.dok_array`

### DIFF
--- a/qualtran/bloqs/state_preparation/sparse_state_preparation_via_rotations.py
+++ b/qualtran/bloqs/state_preparation/sparse_state_preparation_via_rotations.py
@@ -98,8 +98,8 @@ class SparseStatePreparationViaRotations(Bloq):
         import scipy
 
         N = len(coeffs)
-        sparse_coeffs = scipy.sparse.dok_array(coeffs)
-        sparse_coeffs_as_dict = dict(sparse_coeffs.items())
+        sparse_coeffs = scipy.sparse.dok_array(np.atleast_2d(coeffs))
+        sparse_coeffs_as_dict = {i: c for ((_, i), c) in sparse_coeffs.items()}
 
         return cls.from_coefficient_map(N, sparse_coeffs_as_dict, phase_bitsize)
 


### PR DESCRIPTION
[`dok_array`](https://docs.scipy.org/doc/scipy-1.14.0/reference/generated/scipy.sparse.dok_array.html) should only accept only 2D arrays (based on docs), but seems to support 1D arrays in newer versions.

This bugfix assumes it only works with 2D, and invokes it correctly. Tested against scipy v1.10.0.

discussion: https://github.com/quantumlib/Qualtran/pull/1205#discussion_r1722411733