### PR TITLE
[QECGatesCost] strict & account for more leaf bloqs

### DIFF
--- a/qualtran/bloqs/basic_gates/hadamard.py
+++ b/qualtran/bloqs/basic_gates/hadamard.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     import quimb.tensor as qtn
 
     from qualtran.cirq_interop import CirqQuregT
+    from qualtran.resource_counting import CostKey
 
 _HADAMARD = np.array([[1, 1], [1, -1]], dtype=np.complex128) / np.sqrt(2)
 
@@ -179,6 +180,17 @@ class CHadamard(Bloq):
         # The other two are considered 'rotations'.
         # https://github.com/quantumlib/Qualtran/issues/237
         return TComplexity(rotations=2, clifford=4)
+
+    def my_static_costs(self, cost_key: 'CostKey'):
+        from qualtran.resource_counting import GateCounts, QECGatesCost
+
+        if cost_key == QECGatesCost():
+            # This is based on the decomposition provided by `cirq.decompose_multi_controlled_rotation`
+            # which uses three cirq.MatrixGate's to do a controlled version of any single-qubit gate.
+            # The first MatrixGate happens to be a clifford, Hadamard operation in this case.
+            # The other two are considered 'rotations'.
+            # https://github.com/quantumlib/Qualtran/issues/237
+            return GateCounts(rotation=2, clifford=4)
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         if reg is None:

--- a/qualtran/bloqs/basic_gates/hadamard.py
+++ b/qualtran/bloqs/basic_gates/hadamard.py
@@ -192,6 +192,8 @@ class CHadamard(Bloq):
             # https://github.com/quantumlib/Qualtran/issues/237
             return GateCounts(rotation=2, clifford=4)
 
+        return NotImplemented
+
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         if reg is None:
             return Text('')

--- a/qualtran/resource_counting/_bloq_counts.py
+++ b/qualtran/resource_counting/_bloq_counts.py
@@ -24,7 +24,7 @@ from qualtran.symbolics import SymbolicInt
 
 from ._call_graph import get_bloq_callee_counts
 from ._costing import CostKey
-from .classify_bloqs import bloq_is_clifford, bloq_is_rotation, bloq_is_t_gate
+from .classify_bloqs import bloq_is_clifford, bloq_is_rotation, bloq_is_t_like
 
 if TYPE_CHECKING:
     from qualtran import Bloq
@@ -244,7 +244,7 @@ class QECGatesCost(CostKey[GateCounts]):
         from qualtran.bloqs.mcmt.and_bloq import And
 
         # T gates
-        if bloq_is_t_gate(bloq):
+        if bloq_is_t_like(bloq):
             return GateCounts(t=1)
 
         # Toffolis

--- a/qualtran/resource_counting/_bloq_counts.py
+++ b/qualtran/resource_counting/_bloq_counts.py
@@ -273,7 +273,7 @@ class QECGatesCost(CostKey[GateCounts]):
 
         # Recursive case
         totals = GateCounts()
-        callees = get_bloq_callee_counts(bloq)
+        callees = get_bloq_callee_counts(bloq, ignore_decomp_failure=False)
         logger.info("Computing %s for %s from %d callee(s)", self, bloq, len(callees))
         for callee, n_times_called in callees:
             callee_cost = get_callee_cost(callee)

--- a/qualtran/resource_counting/_bloq_counts_test.py
+++ b/qualtran/resource_counting/_bloq_counts_test.py
@@ -85,7 +85,7 @@ def test_qec_gates_cost():
             rotations.phase_gradient.PhaseGradientUnitary(
                 bitsize=10, exponent=1, is_controlled=False, eps=1e-10
             ),
-            GateCounts(rotation=10),
+            GateCounts(clifford=2, t=1, rotation=7),
         ],
         # Recursive
         [mcmt.MultiControlX(cvs=(1, 1, 1)), GateCounts(and_bloq=2, measurement=2, clifford=3)],

--- a/qualtran/resource_counting/classify_bloqs.py
+++ b/qualtran/resource_counting/classify_bloqs.py
@@ -127,6 +127,7 @@ _CLIFFORD_ANGLES = np.array(
 _CLIFFORD_EXPONENTS = np.array([1.0, 0.5, 1.5, -1.0, -0.5, -1.5, 0.0, -2, 2])
 _T_ANGLES = np.array([np.pi / 4, -np.pi / 4])
 _T_EXPONENTS = np.array([0.25, -0.25])
+_ANGLE_ATOL = 1e-12
 
 
 def bloq_is_t_gate(b: Bloq) -> bool:
@@ -144,14 +145,14 @@ def bloq_is_t_gate(b: Bloq) -> bool:
     if isinstance(b, (Rz, Rx, Ry)):
         if is_symbolic(b.angle):
             return False  # Symbolic rotation
-        if np.any(np.abs(b.angle - _T_ANGLES) < b.eps):
+        if np.any(np.abs(b.angle - _T_ANGLES) < _ANGLE_ATOL):
             return True  # T hidden in a rotation bloq
         return False
 
     if isinstance(b, (ZPowGate, XPowGate, YPowGate)):
         if is_symbolic(b.exponent):
             return False  # Symbolic rotation
-        if np.any(np.abs(b.exponent - _T_EXPONENTS) < b.eps):
+        if np.any(np.abs(b.exponent - _T_EXPONENTS) < _ANGLE_ATOL):
             return True  # T hidden in a rotation bloq
         return False
 
@@ -206,14 +207,14 @@ def bloq_is_clifford(b: Bloq) -> bool:
     if isinstance(b, (Rz, Rx, Ry)):
         if is_symbolic(b.angle):
             return False  # Symbolic rotation
-        if np.any(np.abs(b.angle - _CLIFFORD_ANGLES) < b.eps):
+        if np.any(np.abs(b.angle - _CLIFFORD_ANGLES) < _ANGLE_ATOL):
             return True  # Clifford hidden in a rotation bloq
         return False
 
     if isinstance(b, (ZPowGate, XPowGate, YPowGate)):
         if is_symbolic(b.exponent):
             return False  # Symbolic rotation
-        if np.any(np.abs(b.exponent - _CLIFFORD_EXPONENTS) < b.eps):
+        if np.any(np.abs(b.exponent - _CLIFFORD_EXPONENTS) < _ANGLE_ATOL):
             return True  # Clifford hidden in a rotation bloq
         return False
 
@@ -254,18 +255,18 @@ def bloq_is_rotation(b: Bloq) -> bool:
     if isinstance(b, (Rz, Rx, Ry)):
         if is_symbolic(b.angle):
             return True
-        if np.any(np.abs(b.angle - _CLIFFORD_ANGLES) < b.eps):
+        if np.any(np.abs(b.angle - _CLIFFORD_ANGLES) < _ANGLE_ATOL):
             return False  # Clifford
-        if np.any(np.abs(b.angle - _T_ANGLES) < b.eps):
+        if np.any(np.abs(b.angle - _T_ANGLES) < _ANGLE_ATOL):
             return False  # T gate
         return True
 
     if isinstance(b, (ZPowGate, XPowGate, YPowGate)):
         if is_symbolic(b.exponent):
             return True
-        if np.any(np.abs(b.exponent - _CLIFFORD_EXPONENTS) < b.eps):
+        if np.any(np.abs(b.exponent - _CLIFFORD_EXPONENTS) < _ANGLE_ATOL):
             return False  # Clifford
-        if np.any(np.abs(b.exponent - _T_EXPONENTS) < b.eps):
+        if np.any(np.abs(b.exponent - _T_EXPONENTS) < _ANGLE_ATOL):
             return False  # T gate
         return True
 

--- a/qualtran/resource_counting/classify_bloqs.py
+++ b/qualtran/resource_counting/classify_bloqs.py
@@ -15,6 +15,7 @@ import collections.abc as abc
 from collections import defaultdict
 from typing import cast, Dict, List, Optional, Sequence, TYPE_CHECKING, Union
 
+import numpy as np
 import sympy
 
 from qualtran import Adjoint, Bloq, Controlled
@@ -24,6 +25,7 @@ from qualtran.resource_counting.generalizers import (
     ignore_split_join,
 )
 from qualtran.resource_counting.t_counts_from_sigma import t_counts_from_sigma
+from qualtran.symbolics import is_symbolic
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import GeneralizerT
@@ -109,7 +111,60 @@ def classify_t_count_by_bloq_type(
     return classified_bloqs
 
 
-def bloq_is_clifford(b: Bloq):
+_CLIFFORD_ANGLES = np.array(
+    [
+        np.pi,
+        np.pi / 2,
+        3 * np.pi / 2,
+        -np.pi,
+        -np.pi / 2,
+        -3 * np.pi / 2,
+        0.0,
+        -2 * np.pi,
+        2 * np.pi,
+    ]
+)
+_CLIFFORD_EXPONENTS = np.array([1.0, 0.5, 1.5, -1.0, -0.5, -1.5, 0.0, -2, 2])
+_T_ANGLES = np.array([np.pi / 4, -np.pi / 4])
+_T_EXPONENTS = np.array([0.25, -0.25])
+
+
+def bloq_is_t_gate(b: Bloq) -> bool:
+    """Whether a bloq should be counted as a T gate.
+
+    This will return `True` for any instance of `TGate`. It will also consider
+    single-qubit rotations and return True if the angle corresponds to a T gate
+    (up to clifford reference frame).
+    """
+    from qualtran.bloqs.basic_gates import Rx, Ry, Rz, TGate, XPowGate, YPowGate, ZPowGate
+
+    if isinstance(b, TGate):
+        return True
+
+    if isinstance(b, (Rz, Rx, Ry)):
+        if is_symbolic(b.angle):
+            return False  # Symbolic rotation
+        if np.any(np.abs(b.angle - _T_ANGLES) < b.eps):
+            return True  # T hidden in a rotation bloq
+        return False
+
+    if isinstance(b, (ZPowGate, XPowGate, YPowGate)):
+        if is_symbolic(b.exponent):
+            return False  # Symbolic rotation
+        if np.any(np.abs(b.exponent - _T_EXPONENTS) < b.eps):
+            return True  # T hidden in a rotation bloq
+        return False
+
+
+def bloq_is_clifford(b: Bloq) -> bool:
+    """Whether the bloq represents a clifford operation.
+
+    This checks against an explicit list of clifford bloqs in the Qualtran standard library,
+    so it may return `False` for an unknown gate.
+
+    This inspects single qubit rotations. If the angles correspond to Clifford angles, this
+    returns `True`.
+    """
     from qualtran.bloqs.basic_gates import (
         CNOT,
         CYGate,
@@ -121,6 +176,7 @@ def bloq_is_clifford(b: Bloq):
         YGate,
         ZGate,
     )
+    from qualtran.bloqs.basic_gates.rotation import Rx, Ry, Rz, XPowGate, YPowGate, ZPowGate
     from qualtran.bloqs.bookkeeping import ArbitraryClifford
     from qualtran.bloqs.mcmt.multi_target_cnot import MultiTargetCNOT
 
@@ -145,12 +201,42 @@ def bloq_is_clifford(b: Bloq):
     ):
         return True
 
+    if isinstance(b, (Rz, Rx, Ry)):
+        if is_symbolic(b.angle):
+            return False  # Symbolic rotation
+        if np.any(np.abs(b.angle - _CLIFFORD_ANGLES) < b.eps):
+            return True  # Clifford hidden in a rotation bloq
+        return False
+
+    if isinstance(b, (ZPowGate, XPowGate, YPowGate)):
+        if is_symbolic(b.exponent):
+            return False  # Symbolic rotation
+        if np.any(np.abs(b.exponent - _CLIFFORD_EXPONENTS) < b.eps):
+            return True  # Clifford hidden in a rotation bloq
+        return False
+
     return False
 
 
 def bloq_is_rotation(b: Bloq):
+    """Whether a bloq represents a rotation operation.
+
+    This inspects the single qubit rotation bloqs and returns `True` unless the angle
+    represents a clifford or T-gate angle.
+
+    This function has a shim for counting Controlled[Rotation] gates as a rotation, which
+    will be remediated when the Qualtran standard library gains a bespoke bloq for each CRot.
+    """
     from qualtran.bloqs.basic_gates import GlobalPhase, SGate, TGate
-    from qualtran.bloqs.basic_gates.rotation import Rx, Ry, Rz, XPowGate, YPowGate, ZPowGate
+    from qualtran.bloqs.basic_gates.rotation import (
+        CZPowGate,
+        Rx,
+        Ry,
+        Rz,
+        XPowGate,
+        YPowGate,
+        ZPowGate,
+    )
 
     if isinstance(b, Controlled):
         # TODO https://github.com/quantumlib/Qualtran/issues/878
@@ -160,4 +246,23 @@ def bloq_is_rotation(b: Bloq):
 
         return bloq_is_rotation(b.subbloq)
 
-    return isinstance(b, (Rz, Rx, Ry, ZPowGate, XPowGate, YPowGate))
+    if isinstance(b, CZPowGate):
+        return True
+
+    if isinstance(b, (Rz, Rx, Ry)):
+        if is_symbolic(b.angle):
+            return True
+        if np.any(np.abs(b.angle - _CLIFFORD_ANGLES) < b.eps):
+            return False  # Clifford
+        if np.any(np.abs(b.angle - _T_ANGLES) < b.eps):
+            return False  # T gate
+        return True
+
+    if isinstance(b, (ZPowGate, XPowGate, YPowGate)):
+        if is_symbolic(b.exponent):
+            return True
+        if np.any(np.abs(b.exponent - _CLIFFORD_EXPONENTS) < b.eps):
+            return False  # Clifford
+        if np.any(np.abs(b.exponent - _T_EXPONENTS) < b.eps):
+            return False  # T gate
+        return True

--- a/qualtran/resource_counting/classify_bloqs.py
+++ b/qualtran/resource_counting/classify_bloqs.py
@@ -155,6 +155,8 @@ def bloq_is_t_gate(b: Bloq) -> bool:
             return True  # T hidden in a rotation bloq
         return False
 
+    return False
+
 
 def bloq_is_clifford(b: Bloq) -> bool:
     """Whether the bloq represents a clifford operation.
@@ -218,7 +220,7 @@ def bloq_is_clifford(b: Bloq) -> bool:
     return False
 
 
-def bloq_is_rotation(b: Bloq):
+def bloq_is_rotation(b: Bloq) -> bool:
     """Whether a bloq represents a rotation operation.
 
     This inspects the single qubit rotation bloqs and returns `True` unless the angle
@@ -266,3 +268,5 @@ def bloq_is_rotation(b: Bloq):
         if np.any(np.abs(b.exponent - _T_EXPONENTS) < b.eps):
             return False  # T gate
         return True
+
+    return False

--- a/qualtran/resource_counting/classify_bloqs.py
+++ b/qualtran/resource_counting/classify_bloqs.py
@@ -130,7 +130,7 @@ _T_EXPONENTS = np.array([0.25, -0.25])
 _ANGLE_ATOL = 1e-12
 
 
-def bloq_is_t_gate(b: Bloq) -> bool:
+def bloq_is_t_like(b: Bloq) -> bool:
     """Whether a bloq should be counted as a T gate.
 
     This will return `True` for any instance of `TGate`. It will also consider

--- a/qualtran/resource_counting/classify_bloqs_test.py
+++ b/qualtran/resource_counting/classify_bloqs_test.py
@@ -15,12 +15,13 @@ from functools import cached_property
 from typing import Set, Tuple, TYPE_CHECKING
 
 import attrs
+import numpy as np
 import pytest
 
 from qualtran import Bloq, QInt, Signature
 from qualtran.bloqs.arithmetic import Add
 from qualtran.bloqs.arithmetic.comparison import LessThanConstant
-from qualtran.bloqs.basic_gates import CSwap, TGate
+from qualtran.bloqs.basic_gates import CSwap, Rx, Rz, TGate, YPowGate
 from qualtran.bloqs.data_loading.qrom import QROM
 from qualtran.bloqs.mcmt.and_bloq import And
 from qualtran.bloqs.reflections.prepare_identity import PrepareIdentity
@@ -32,6 +33,7 @@ from qualtran.bloqs.state_preparation.prepare_uniform_superposition import (
 from qualtran.resource_counting import BloqCountT
 from qualtran.resource_counting.classify_bloqs import (
     _get_basic_bloq_classification,
+    bloq_is_t_like,
     classify_bloq,
     classify_t_count_by_bloq_type,
 )
@@ -108,3 +110,13 @@ def test_classify_bloq_counts_with_custom_bloq_classification():
     )
     assert classified_bloqs == {'swaps': 42 * 10 * 7, 'other': 3 * 4 * (4 - 1)}
     assert test_bloq.call_graph()[1].get(TGate()) == sum(classified_bloqs.values())
+
+
+def test_bloq_is_t_like():
+    assert bloq_is_t_like(TGate())
+    assert bloq_is_t_like(TGate().adjoint())
+    assert bloq_is_t_like(TGate(is_adjoint=True))
+    assert bloq_is_t_like(Rx(np.pi / 4))
+    assert bloq_is_t_like(YPowGate(1.0 / 4))
+    assert not bloq_is_t_like(Rz(np.pi / 2))
+    assert not bloq_is_t_like(And())

--- a/qualtran/surface_code/algorithm_summary_test.py
+++ b/qualtran/surface_code/algorithm_summary_test.py
@@ -43,7 +43,9 @@ from qualtran.surface_code import AlgorithmSummary
             rotations.phase_gradient.PhaseGradientUnitary(
                 bitsize=10, exponent=1, is_controlled=False, eps=1e-10
             ),
-            AlgorithmSummary(n_algo_qubits=10, n_logical_gates=GateCounts(rotation=10)),
+            AlgorithmSummary(
+                n_algo_qubits=10, n_logical_gates=GateCounts(clifford=2, t=1, rotation=7)
+            ),
         ],
         [
             mcmt.MultiControlX(cvs=(1, 1, 1)),


### PR DESCRIPTION
The first commit is #1311 ; which can't be merged independently because it reveals errors that this PR fixes.

 - account for bookeeping, identity, global phase gates
 - partition rotations into clifford, t, or rotation based on their angle