### PR TITLE
Bugfix in `QROM.build_call_graph` for symbolic case

### DIFF
--- a/qualtran/bloqs/data_loading/qrom.py
+++ b/qualtran/bloqs/data_loading/qrom.py
@@ -224,7 +224,9 @@ class QROM(QROMBase, UnaryIterationGate):  # type: ignore[misc]
         if self.has_data():
             return super().build_call_graph(ssa=ssa)
         n_and = prod(self.data_shape) - 2 + self.num_controls
-        n_cnot = prod(self.target_bitsizes) * prod(self.data_shape)
+        n_cnot = prod(
+            bitsize * prod(sh) for bitsize, sh in zip(self.target_bitsizes, self.target_shapes)
+        ) * prod(self.data_shape)
         return {(And(), n_and), (And().adjoint(), n_and), (CNOT(), n_cnot)}
 
     def adjoint(self) -> 'QROM':

--- a/qualtran/bloqs/data_loading/qrom_test.py
+++ b/qualtran/bloqs/data_loading/qrom_test.py
@@ -224,11 +224,21 @@ def test_t_complexity(data):
 def test_t_complexity_symbolic():
     N, M = sympy.symbols('N M')
     b1, b2 = sympy.symbols('b1 b2')
+    t1, t2 = sympy.symbols('t1 t2')
     c = sympy.Symbol('c')
-    qrom_symb = QROM.build_from_bitsize((N, M), (b1, b2), num_controls=c)
+    qrom_symb = QROM.build_from_bitsize(
+        (N, M), (b1, b2), target_shapes=((t1,), (t2,)), num_controls=c
+    )
     t_counts = qrom_symb.t_complexity()
-    assert t_counts.t == 4 * (N * M - 2 + c)
-    assert t_counts
+    n_and = N * M - 2 + c
+    assert t_counts.t == 4 * n_and
+    from qualtran.bloqs.mcmt import And
+
+    assert (
+        t_counts.clifford
+        == N * M * b1 * b2 * t1 * t2
+        + (And().t_complexity().clifford + And().adjoint().t_complexity().clifford) * n_and
+    )
 
 
 def _assert_qrom_has_diagram(qrom: QROM, expected_diagram: str):

--- a/qualtran/bloqs/swap_network/swap_with_zero.py
+++ b/qualtran/bloqs/swap_network/swap_with_zero.py
@@ -213,6 +213,12 @@ class SwapWithZero(GateWithRegisters):
     def adjoint(self) -> 'SwapWithZero':
         return attrs.evolve(self, uncompute=not self.uncompute)
 
+    def pretty_name(self) -> str:
+        return 'SwapWithZero†' if self.uncompute else 'SwapWithZero'
+
+    def __str__(self) -> str:
+        return 'SwapWithZero†' if self.uncompute else 'SwapWithZero'
+
 
 @bloq_example(generalizer=ignore_split_join)
 def _swz() -> SwapWithZero:


### PR DESCRIPTION
The clifford cost due to `target_shapes` parameter was getting ignored. This PR fixes it. Also updates the `__str__` of `SwapWithZero` for better diagrams. 