### PR TITLE
[QECGatesCost] Adjustments to match t_complexity rotations, part 2

### DIFF
--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -136,6 +136,9 @@ class CZPowGate(CirqGateAsBloqBase):
     def adjoint(self) -> 'CZPowGate':
         return attrs.evolve(self, exponent=-self.exponent)
 
+    def __str__(self):
+        return f'CZ**{self.exponent}'
+
 
 @frozen
 class XPowGate(CirqGateAsBloqBase):

--- a/qualtran/bloqs/basic_gates/rotation_test.py
+++ b/qualtran/bloqs/basic_gates/rotation_test.py
@@ -96,6 +96,9 @@ def test_pretty_name():
     assert _rx().pretty_name() == "Rx"
     assert _rz().pretty_name() == "Rz"
 
+    assert str(CZPowGate(1.0)) == 'CZ**1.0'
+    assert str(CZPowGate(0.9)) == 'CZ**0.9'
+
 
 def test_rx(bloq_autotester):
     bloq_autotester(_rx)

--- a/qualtran/bloqs/basic_gates/su2_rotation.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation.py
@@ -174,9 +174,7 @@ class SU2RotationGate(GateWithRegisters):
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         if reg is None:
             if self.is_symbolic():
-                return Text(
-                    f'({self.theta},{self.phi},{self.lambd},{self.global_shift})'
-                )
+                return Text(f'({self.theta},{self.phi},{self.lambd},{self.global_shift})')
             return Text(
                 f'({self.theta:.2f},{self.phi:.2f},{self.lambd:.2f},{self.global_shift:.2f})'
             )

--- a/qualtran/bloqs/basic_gates/su2_rotation.py
+++ b/qualtran/bloqs/basic_gates/su2_rotation.py
@@ -167,10 +167,16 @@ class SU2RotationGate(GateWithRegisters):
         return 'SU_2'
 
     def __str__(self):
+        if self.is_symbolic():
+            return f'SU_2({self.theta},{self.phi},{self.lambd},{self.global_shift})'
         return f'SU_2({self.theta:.2f},{self.phi:.2f},{self.lambd:.2f},{self.global_shift:.2f})'
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         if reg is None:
+            if self.is_symbolic():
+                return Text(
+                    f'({self.theta},{self.phi},{self.lambd},{self.global_shift})'
+                )
             return Text(
                 f'({self.theta:.2f},{self.phi:.2f},{self.lambd:.2f},{self.global_shift:.2f})'
             )

--- a/qualtran/bloqs/basic_gates/x_basis_test.py
+++ b/qualtran/bloqs/basic_gates/x_basis_test.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from qualtran import BloqBuilder
 from qualtran.bloqs.basic_gates import MinusState, PlusEffect, PlusState, XGate
+from qualtran.resource_counting import GateCounts, get_cost_value, QECGatesCost
 from qualtran.simulation.classical_sim import (
     format_classical_truth_table,
     get_classical_truth_table,
@@ -43,6 +44,8 @@ def test_plus_effect():
     # Everything is squeezed. Keep track manually or use compositebloq.
     should_be = np.array([1, 1]) / np.sqrt(2)
     np.testing.assert_allclose(should_be, vector)
+
+    assert get_cost_value(bloq, QECGatesCost()) == GateCounts()
 
 
 def test_plus_state_effect():

--- a/qualtran/bloqs/basic_gates/z_basis_test.py
+++ b/qualtran/bloqs/basic_gates/z_basis_test.py
@@ -38,6 +38,7 @@ from qualtran.bloqs.basic_gates.z_basis import (
     _zgate,
 )
 from qualtran.cirq_interop.t_complexity_protocol import t_complexity, TComplexity
+from qualtran.resource_counting import GateCounts, get_cost_value, QECGatesCost
 from qualtran.resource_counting.classify_bloqs import bloq_is_clifford
 
 
@@ -79,6 +80,8 @@ def test_zero_state_manual():
 
     (x,) = bloq.call_classically()
     assert x == 0
+
+    assert get_cost_value(bloq, QECGatesCost()) == GateCounts()
 
 
 def test_multiq_zero_state():

--- a/qualtran/bloqs/chemistry/trotter/grid_ham/qvr.py
+++ b/qualtran/bloqs/chemistry/trotter/grid_ham/qvr.py
@@ -20,7 +20,6 @@ from attrs import frozen
 
 from qualtran import Bloq, bloq_example, BloqDocSpec, QAny, Register, Signature
 from qualtran.bloqs.basic_gates import Rz
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 
 if TYPE_CHECKING:
     from qualtran.resource_counting import BloqCountT, SympySymbolAllocator

--- a/qualtran/bloqs/chemistry/trotter/grid_ham/qvr.py
+++ b/qualtran/bloqs/chemistry/trotter/grid_ham/qvr.py
@@ -56,10 +56,6 @@ class QuantumVariableRotation(Bloq):
     def pretty_name(self) -> str:
         return 'e^{i*phi}'
 
-    def _t_complexity_(self) -> 'TComplexity':
-        # Upper bounding for the moment with just phi_bitsize * Rz rotation gates.
-        return self.phi_bitsize * Rz(0.0).t_complexity()
-
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
         theta = ssa.new_symbol('theta')
         # need to update rotation bloq.

--- a/qualtran/bloqs/chemistry/trotter/grid_ham/qvr_test.py
+++ b/qualtran/bloqs/chemistry/trotter/grid_ham/qvr_test.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 import pytest
 
-from qualtran.bloqs.basic_gates import Rz
 from qualtran.bloqs.chemistry.trotter.grid_ham.qvr import _qvr, QuantumVariableRotation
 
 

--- a/qualtran/bloqs/chemistry/trotter/grid_ham/qvr_test.py
+++ b/qualtran/bloqs/chemistry/trotter/grid_ham/qvr_test.py
@@ -24,4 +24,4 @@ def test_kinetic_energy(bloq_autotester):
 @pytest.mark.parametrize('bitsize', [8, 16, 32])
 def test_qvr_t_complexity(bitsize: int):
     bloq = QuantumVariableRotation(bitsize)
-    assert bloq.t_complexity() == bitsize * Rz(0.0).t_complexity()
+    assert bloq.t_complexity().rotations == bitsize

--- a/qualtran/bloqs/phase_estimation/lp_resource_state.py
+++ b/qualtran/bloqs/phase_estimation/lp_resource_state.py
@@ -34,7 +34,6 @@ from qualtran import (
 )
 from qualtran.bloqs.basic_gates import CZPowGate, GlobalPhase, Hadamard, OnEach, Ry, Rz, XGate
 from qualtran.bloqs.mcmt import MultiControlZ
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.symbolics import acos, HasLength, is_symbolic, pi, SymbolicInt
 
 if TYPE_CHECKING:

--- a/qualtran/bloqs/phase_estimation/lp_resource_state.py
+++ b/qualtran/bloqs/phase_estimation/lp_resource_state.py
@@ -25,7 +25,6 @@ from qualtran import Bloq, bloq_example, BloqDocSpec, GateWithRegisters, QBit, S
 from qualtran.bloqs.basic_gates import CZ, Hadamard, OnEach, Ry, Rz, XGate
 from qualtran.bloqs.phase_estimation.qpe_window_state import QPEWindowStateBase
 from qualtran.bloqs.reflections.reflection_using_prepare import ReflectionUsingPrepare
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.symbolics import acos, ceil, is_symbolic, log2, pi, SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:

--- a/qualtran/bloqs/phase_estimation/lp_resource_state.py
+++ b/qualtran/bloqs/phase_estimation/lp_resource_state.py
@@ -94,12 +94,6 @@ class LPRSInterimPrep(GateWithRegisters):
             }
         return ret
 
-    def _t_complexity_(self) -> 'TComplexity':
-        # Uses self.bitsize controlled-Rz rotations which decomposes into
-        # 2 single-qubit rotations and 3 cliffords
-        # TODO: Once a CRz exists, this can be updated.
-        return TComplexity(rotations=2 * self.bitsize + 1, clifford=2 + 3 * self.bitsize)
-
 
 @attrs.frozen
 class LPResourceState(GateWithRegisters):

--- a/qualtran/bloqs/phase_estimation/lp_resource_state_test.py
+++ b/qualtran/bloqs/phase_estimation/lp_resource_state_test.py
@@ -130,7 +130,7 @@ def test_t_complexity(n):
     qlt_testing.assert_equivalent_bloq_counts(
         bloq, [ignore_split_join, ignore_alloc_free, generalize_rotation_angle]
     )
-    lprs_interim_count = 3 * TComplexity(rotations=2 * n + 1, clifford=2 + 3 * n)
+    lprs_interim_count = 3 * TComplexity(rotations=n + 1, clifford=2 + n)
     multi_control_pauli_count = TComplexity(t=4 * n, clifford=17 * n + 5)
     misc_count = TComplexity(rotations=3, clifford=5)
 
@@ -140,5 +140,5 @@ def test_t_complexity(n):
 @pytest.mark.parametrize('bitsize', [*range(1, 14, 2)])
 def test_interim_lp2s_interim_prep_t_complexity(bitsize: int):
     assert t_complexity(LPRSInterimPrep(bitsize)) == TComplexity(
-        rotations=2 * bitsize + 1, clifford=2 + 3 * bitsize
+        rotations=bitsize + 1, clifford=2 + bitsize
     )

--- a/qualtran/bloqs/phase_estimation/lp_resource_state_test.py
+++ b/qualtran/bloqs/phase_estimation/lp_resource_state_test.py
@@ -94,7 +94,7 @@ def test_t_complexity(n):
     qlt_testing.assert_equivalent_bloq_counts(
         bloq, [ignore_split_join, ignore_alloc_free, generalize_rotation_angle]
     )
-    lprs_interim_count = 3 * TComplexity(rotations=2 * n + 1, clifford=2 + 3 * n)
+    lprs_interim_count = 3 * TComplexity(rotations=n + 1, clifford=2 + n)
     reflection_using_prepare = TComplexity(t=4 * n + 4, clifford=17 * n + 22)
     misc_count = TComplexity(rotations=3, clifford=5)
 

--- a/qualtran/resource_counting/_bloq_counts.py
+++ b/qualtran/resource_counting/_bloq_counts.py
@@ -24,7 +24,12 @@ from qualtran.symbolics import SymbolicInt
 
 from ._call_graph import get_bloq_callee_counts
 from ._costing import CostKey
-from .classify_bloqs import bloq_is_clifford, bloq_is_rotation, bloq_is_t_like
+from .classify_bloqs import (
+    bloq_is_clifford,
+    bloq_is_rotation,
+    bloq_is_state_or_effect,
+    bloq_is_t_like,
+)
 
 if TYPE_CHECKING:
     from qualtran import Bloq
@@ -268,6 +273,10 @@ class QECGatesCost(CostKey[GateCounts]):
         # Cliffords
         if bloq_is_clifford(bloq):
             return GateCounts(clifford=1)
+
+        # States and effects
+        if bloq_is_state_or_effect(bloq):
+            return GateCounts()
 
         # Bookkeeping, empty bloqs
         if isinstance(bloq, _BookkeepingBloq) or isinstance(bloq, (GlobalPhase, Identity)):

--- a/qualtran/resource_counting/classify_bloqs.py
+++ b/qualtran/resource_counting/classify_bloqs.py
@@ -271,3 +271,10 @@ def bloq_is_rotation(b: Bloq) -> bool:
         return True
 
     return False
+
+
+def bloq_is_state_or_effect(b: Bloq) -> bool:
+    from qualtran.bloqs.basic_gates.x_basis import _XVector
+    from qualtran.bloqs.basic_gates.z_basis import _ZVector
+
+    return isinstance(b, (_XVector, _ZVector))


### PR DESCRIPTION
Following #1313 -- some more changes to how we count.

 - there's a QVR stub. The permanent fix would be to use qvr, but removing the erroneous t complexity is a start
 - LPRSInterimPrep has a bad _t_complexity_ annotation, based on the current convention for counting CRz as one rotation
 - states and effects can be counted (these would throw an error in `t_complexity`)
 - drive by fixes to some str representations so it's clearer what the bloq is