### PR TITLE
Add `QROAMCleanAdjointWrapper` to match signature of `QROAMClean` and delegate implementation to `QROAMCleanAdjoint`

### DIFF
--- a/qualtran/bloqs/data_loading/qroam_clean_test.py
+++ b/qualtran/bloqs/data_loading/qroam_clean_test.py
@@ -20,7 +20,6 @@ from qualtran.bloqs.data_loading.qroam_clean import (
     _qroam_clean_multi_dim,
     get_optimal_log_block_size_clean_ancilla,
     QROAMClean,
-    QROAMCleanAdjoint,
     QROAMCleanAdjointWrapper,
 )
 from qualtran.symbolics import ceil


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Qualtran/issues/1315

This also fixes https://github.com/quantumlib/Qualtran/issues/1292 since construction of `batched_data_permuted` is now done lazily; only when the decomposition is required. Duplication of call graph mitigates the slow computation for the moment. 

cc @fdmalone  

