### PR TITLE
Make `Identity` an `n` qubit bloq

### DIFF
--- a/qualtran/bloqs/basic_gates/identity.ipynb
+++ b/qualtran/bloqs/basic_gates/identity.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "92a37b86",
+   "id": "6cc35310",
    "metadata": {
     "cq.autogen": "title_cell"
    },
@@ -13,7 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c6021f9f",
+   "id": "0097397d",
    "metadata": {
     "cq.autogen": "top_imports"
    },
@@ -30,22 +30,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "422855fc",
+   "id": "79691443",
    "metadata": {
     "cq.autogen": "Identity.bloq_doc.md"
    },
    "source": [
     "## `Identity`\n",
-    "The identity gate on one qubit.\n",
+    "The identity gate on `n` qubits.\n",
+    "\n",
+    "#### Parameters\n",
+    " - `bitsize`: number of qubits `n`, defaults to 1. \n",
     "\n",
     "#### Registers\n",
-    " - `q`: The qubit\n"
+    " - `q`: register of `n` qubits\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae7e658c",
+   "id": "f93ce35e",
    "metadata": {
     "cq.autogen": "Identity.bloq_doc.py"
    },
@@ -56,7 +59,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "beb2c934",
+   "id": "af0c1bd3",
    "metadata": {
     "cq.autogen": "Identity.example_instances.md"
    },
@@ -67,7 +70,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69ab2ac9",
+   "id": "6c3e5fe5",
+   "metadata": {
+    "cq.autogen": "Identity.identity_symb"
+   },
+   "outputs": [],
+   "source": [
+    "import sympy\n",
+    "\n",
+    "n = sympy.Symbol(\"n\")\n",
+    "identity_symb = Identity(n)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f741716a",
    "metadata": {
     "cq.autogen": "Identity.identity"
    },
@@ -77,8 +95,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3caceb77",
+   "metadata": {
+    "cq.autogen": "Identity.identity_n"
+   },
+   "outputs": [],
+   "source": [
+    "n = 4\n",
+    "identity_n = Identity(n)"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "7d5b3859",
+   "id": "11cdf868",
    "metadata": {
     "cq.autogen": "Identity.graphical_signature.md"
    },
@@ -89,20 +120,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "376ca25a",
+   "id": "b3fcc484",
    "metadata": {
     "cq.autogen": "Identity.graphical_signature.py"
    },
    "outputs": [],
    "source": [
     "from qualtran.drawing import show_bloqs\n",
-    "show_bloqs([identity],\n",
-    "           ['`identity`'])"
+    "show_bloqs([identity_symb, identity, identity_n],\n",
+    "           ['`identity_symb`', '`identity`', '`identity_n`'])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5099be1d",
+   "id": "17e96642",
    "metadata": {
     "cq.autogen": "Identity.call_graph.md"
    },
@@ -113,16 +144,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d7ccccc",
+   "id": "303fa191",
    "metadata": {
     "cq.autogen": "Identity.call_graph.py"
    },
    "outputs": [],
    "source": [
     "from qualtran.resource_counting.generalizers import ignore_split_join\n",
-    "identity_g, identity_sigma = identity.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
-    "show_call_graph(identity_g)\n",
-    "show_counts_sigma(identity_sigma)"
+    "identity_symb_g, identity_symb_sigma = identity_symb.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
+    "show_call_graph(identity_symb_g)\n",
+    "show_counts_sigma(identity_symb_sigma)"
    ]
   }
  ],

--- a/qualtran/bloqs/basic_gates/identity.py
+++ b/qualtran/bloqs/basic_gates/identity.py
@@ -129,4 +129,20 @@ def _identity() -> Identity:
     return identity
 
 
-_IDENTITY_DOC = BloqDocSpec(bloq_cls=Identity, examples=[_identity])
+@bloq_example
+def _identity_n() -> Identity:
+    n = 4
+    identity_n = Identity(n)
+    return identity_n
+
+
+@bloq_example
+def _identity_symb() -> Identity:
+    import sympy
+
+    n = sympy.Symbol("n")
+    identity_symb = Identity(n)
+    return identity_symb
+
+
+_IDENTITY_DOC = BloqDocSpec(bloq_cls=Identity, examples=[_identity_symb, _identity, _identity_n])

--- a/qualtran/bloqs/basic_gates/identity.py
+++ b/qualtran/bloqs/basic_gates/identity.py
@@ -73,10 +73,9 @@ class Identity(Bloq):
 
         return [
             qtn.Tensor(
-                data=np.eye(2**self.bitsize),
-                inds=[(outgoing['q'], 0), (incoming['q'], 0)],
-                tags=[str(self)],
+                data=np.eye(2), inds=[(outgoing['q'], i), (incoming['q'], i)], tags=[str(self)]
             )
+            for i in range(int(self.bitsize))
         ]
 
     def as_cirq_op(

--- a/qualtran/bloqs/basic_gates/identity_test.py
+++ b/qualtran/bloqs/basic_gates/identity_test.py
@@ -19,7 +19,7 @@ from attrs import frozen
 
 from qualtran import Bloq, BloqBuilder, CtrlSpec, QInt, QUInt, Signature, Soquet, SoquetT
 from qualtran.bloqs.basic_gates import OneState
-from qualtran.bloqs.basic_gates.identity import _identity, Identity
+from qualtran.bloqs.basic_gates.identity import _identity, _identity_n, _identity_symb, Identity
 from qualtran.simulation.classical_sim import (
     format_classical_truth_table,
     get_classical_truth_table,
@@ -55,6 +55,11 @@ q2: ───I───
 
 def test_identity(bloq_autotester):
     bloq_autotester(_identity)
+    bloq_autotester(_identity_n)
+
+
+def test_examples_symb(bloq_autotester):
+    bloq_autotester(_identity_symb)
 
 
 def test_unitary_vs_cirq():

--- a/qualtran/bloqs/basic_gates/identity_test.py
+++ b/qualtran/bloqs/basic_gates/identity_test.py
@@ -70,6 +70,12 @@ def test_unitary_vs_cirq():
     np.testing.assert_allclose(unitary, cirq_unitary)
 
 
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_tensor(n: int):
+    tensor = Identity(n).tensor_contract()
+    np.testing.assert_allclose(tensor, np.eye(2**n))
+
+
 def test_i_truth_table():
     classical_truth_table = format_classical_truth_table(*get_classical_truth_table(Identity()))
     assert (

--- a/qualtran/bloqs/basic_gates/identity_test.py
+++ b/qualtran/bloqs/basic_gates/identity_test.py
@@ -13,14 +13,18 @@
 #  limitations under the License.
 import cirq
 import numpy as np
+import pytest
+import sympy
+from attrs import frozen
 
-from qualtran import BloqBuilder
+from qualtran import Bloq, BloqBuilder, CtrlSpec, QInt, QUInt, Signature, Soquet, SoquetT
 from qualtran.bloqs.basic_gates import OneState
 from qualtran.bloqs.basic_gates.identity import _identity, Identity
 from qualtran.simulation.classical_sim import (
     format_classical_truth_table,
     get_classical_truth_table,
 )
+from qualtran.symbolics import SymbolicInt
 
 
 def test_to_cirq():
@@ -33,6 +37,20 @@ def test_to_cirq():
     vec1 = cbloq.tensor_contract()
     vec2 = cirq.final_state_vector(circuit)
     np.testing.assert_allclose(vec1, vec2)
+
+
+def test_to_cirq_n_qubit_id():
+    circuit = Identity(3).as_composite_bloq().to_cirq_circuit()
+    cirq.testing.assert_has_diagram(
+        circuit,
+        '''
+q0: ───I───
+       │
+q1: ───I───
+       │
+q2: ───I───
+    ''',
+    )
 
 
 def test_identity(bloq_autotester):
@@ -56,3 +74,46 @@ q  |  q
 0 -> 0
 1 -> 1"""
     )
+
+
+def test_identity_controlled():
+    assert Identity(3).controlled() == Identity(4)
+
+    n = sympy.Symbol("n")
+    assert Identity(n).controlled() == Identity(n + 1)
+
+
+@frozen
+class TestIdentityDecomposition(Bloq):
+    """helper to test Identity.get_ctrl_system"""
+
+    bitsize: SymbolicInt
+
+    @property
+    def signature(self) -> 'Signature':
+        return Signature.build(q=self.bitsize)
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', q: Soquet) -> dict[str, 'SoquetT']:
+        q = bb.add(Identity(self.bitsize), q=q)
+        q = bb.add(Identity(self.bitsize), q=q)
+        return {'q': q}
+
+
+@pytest.mark.parametrize("n", [4, sympy.Symbol("n")])
+@pytest.mark.parametrize(
+    "ctrl_spec",
+    [
+        CtrlSpec(cvs=(np.array([1, 0, 1]),)),
+        CtrlSpec(qdtypes=(QUInt(3), QInt(3)), cvs=(np.array(0b010), np.array(0b001))),
+    ],
+)
+def test_identity_get_ctrl_system(n: SymbolicInt, ctrl_spec: CtrlSpec):
+    m = ctrl_spec.num_qubits
+
+    bloq = TestIdentityDecomposition(n)
+    ctrl_bloq = bloq.controlled(ctrl_spec)
+
+    _ = ctrl_bloq.decompose_bloq()
+
+    _, sigma = ctrl_bloq.call_graph()
+    assert sigma == {Identity(n + m): 2}

--- a/qualtran/bloqs/basic_gates/identity_test.py
+++ b/qualtran/bloqs/basic_gates/identity_test.py
@@ -25,6 +25,7 @@ from qualtran.simulation.classical_sim import (
     get_classical_truth_table,
 )
 from qualtran.symbolics import SymbolicInt
+from qualtran.testing import execute_notebook
 
 
 def test_to_cirq():
@@ -122,3 +123,8 @@ def test_identity_get_ctrl_system(n: SymbolicInt, ctrl_spec: CtrlSpec):
 
     _, sigma = ctrl_bloq.call_graph()
     assert sigma == {Identity(n + m): 2}
+
+
+@pytest.mark.notebook
+def test_notebook():
+    execute_notebook('identity')

--- a/qualtran/bloqs/reflections/prepare_identity.py
+++ b/qualtran/bloqs/reflections/prepare_identity.py
@@ -19,7 +19,6 @@ from attrs import field, frozen
 
 from qualtran import bloq_example, BloqDocSpec, QAny, Register, Soquet
 from qualtran.bloqs.basic_gates import Identity
-from qualtran.bloqs.basic_gates.on_each import OnEach
 from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
 from qualtran.resource_counting.generalizers import ignore_split_join
 from qualtran.symbolics.types import SymbolicInt
@@ -65,7 +64,7 @@ class PrepareIdentity(PrepareOracle):
 
     def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: Soquet) -> Dict[str, Soquet]:
         for label, soq in soqs.items():
-            soqs[label] = bb.add(OnEach(soq.reg.bitsize, Identity()), q=soq)
+            soqs[label] = bb.add(Identity(soq.reg.bitsize), q=soq)
         return soqs
 
 

--- a/qualtran/bloqs/reflections/prepare_identity_test.py
+++ b/qualtran/bloqs/reflections/prepare_identity_test.py
@@ -11,9 +11,16 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-from qualtran.bloqs.reflections.prepare_identity import _prepare_identity
+from qualtran import Signature
+from qualtran.bloqs.basic_gates import Identity
+from qualtran.bloqs.reflections.prepare_identity import _prepare_identity, PrepareIdentity
 
 
 def test_prepare_identity(bloq_autotester):
     bloq_autotester(_prepare_identity)
+
+
+def test_prepare_identity_call_graph():
+    bloq = PrepareIdentity(tuple(Signature.build(a=4, b=4, c=5)))
+    _, sigma = bloq.call_graph()
+    assert sigma == {Identity(4): 2, Identity(5): 1}

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -29,7 +29,6 @@ from qualtran import (
     BloqBuilder,
     CompositeBloq,
     ConnectionT,
-    Controlled,
     CtrlSpec,
     DecomposeNotImplementedError,
     DecomposeTypeError,

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -390,8 +390,8 @@ def cirq_gate_to_bloq(gate: cirq.Gate) -> Bloq:
         return CIRQ_GATE_TO_BLOQ_MAP[gate]
 
     if isinstance(gate, cirq.ControlledGate):
-        return Controlled(
-            cirq_gate_to_bloq(gate.sub_gate), CtrlSpec.from_cirq_cv(gate.control_values)
+        return cirq_gate_to_bloq(gate.sub_gate).controlled(
+            ctrl_spec=CtrlSpec.from_cirq_cv(gate.control_values)
         )
 
     # Check specific basic gates types.

--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -18,7 +18,7 @@ import attrs
 import cachetools
 import cirq
 
-from qualtran import Bloq, Controlled, DecomposeNotImplementedError, DecomposeTypeError
+from qualtran import Bloq, DecomposeNotImplementedError, DecomposeTypeError
 from qualtran.resource_counting import SympySymbolAllocator
 from qualtran.symbolics import ceil, log2, SymbolicFloat, SymbolicInt
 

--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -94,7 +94,7 @@ def _from_explicit_annotation(stc: Any) -> Optional[TComplexity]:
 
 def _from_directly_countable_bloqs(bloq: Bloq) -> Optional[TComplexity]:
     """Directly count a clifford, T or Rotation (if it is one)."""
-    from qualtran.bloqs.basic_gates import Identity, TGate
+    from qualtran.bloqs.basic_gates import TGate
     from qualtran.resource_counting.classify_bloqs import bloq_is_clifford, bloq_is_rotation
 
     if isinstance(bloq, TGate):
@@ -105,11 +105,6 @@ def _from_directly_countable_bloqs(bloq: Bloq) -> Optional[TComplexity]:
 
     if bloq_is_rotation(bloq):
         return TComplexity(rotations=1)
-
-    # TODO: https://github.com/quantumlib/Qualtran/issues/1207). This logic should
-    #       be implemented by `Identity` directly
-    if isinstance(bloq, Controlled) and bloq.subbloq == Identity():
-        return TComplexity()
 
     # Else
     return None


### PR DESCRIPTION
fixes #1207 

- `Identity` now accepts a `bitsize`, and has a single register `q` of `QAny(bitsize)`.
- `Identity(n).controlled(m)` is `Identity(n + m)`.

more discussion: https://github.com/quantumlib/Qualtran/pull/1322#issuecomment-2299989824