### PR TITLE
Raise `DecomposeTypeError` for symbolic register shapes

### DIFF
--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -846,6 +846,8 @@ class BloqBuilder:
             initial, left-dangling soquets for the register. Otherwise, this is a RIGHT register
             and will be used for error checking in `finalize()` and nothing is returned.
         """
+        from qualtran.symbolics import is_symbolic
+
         if not self.add_register_allowed:
             raise ValueError(
                 "This BloqBuilder was constructed from pre-specified registers. "
@@ -863,6 +865,11 @@ class BloqBuilder:
                     "`dtype` must be specified and must be an QDType if `reg` is a register name."
                 )
             reg = Register(name=reg, dtype=dtype)
+
+        if is_symbolic(*reg.shape_symbolic):
+            raise DecomposeTypeError(
+                f"cannot add register with symbolic shape {reg.shape_symbolic}"
+            )
 
         self._regs.append(reg)
         if reg.side & Side.LEFT:

--- a/qualtran/_infra/composite_bloq_test.py
+++ b/qualtran/_infra/composite_bloq_test.py
@@ -20,6 +20,7 @@ import cirq
 import networkx as nx
 import numpy as np
 import pytest
+import sympy
 from numpy.typing import NDArray
 
 import qualtran.testing as qlt_testing
@@ -30,6 +31,7 @@ from qualtran import (
     BloqInstance,
     CompositeBloq,
     Connection,
+    DecomposeTypeError,
     LeftDangle,
     Register,
     RightDangle,
@@ -45,6 +47,7 @@ from qualtran.bloqs.bookkeeping import Join
 from qualtran.bloqs.for_testing.atom import TestAtom, TestTwoBitOp
 from qualtran.bloqs.for_testing.many_registers import TestMultiTypedRegister, TestQFxp
 from qualtran.bloqs.for_testing.with_decomposition import TestParallelCombo, TestSerialCombo
+from qualtran.symbolics import SymbolicInt
 
 
 def _manually_make_test_cbloq_cxns():
@@ -595,6 +598,22 @@ def test_add_and_partition():
     cbloq = bb.finalize(a=a, b=b, c=c)
     assert isinstance(cbloq, CompositeBloq)
     assert len(cbloq.bloq_instances) == 1
+
+
+@attrs.frozen
+class TestSymbolicRegisterShape(Bloq):
+    n: 'SymbolicInt'
+
+    @property
+    def signature(self) -> 'Signature':
+        return Signature([Register('q', QBit(), shape=(self.n,))])
+
+
+def test_decompose_symbolic_register_shape_raises():
+    n = sympy.Symbol("n")
+    bloq = TestSymbolicRegisterShape(n)
+    with pytest.raises(DecomposeTypeError):
+        bloq.decompose_bloq()
 
 
 @pytest.mark.notebook

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -585,7 +585,7 @@ def decompose_from_cirq_style_method(
             yields the cirq-style decomposition.
     """
     if any(
-        cirq.is_parameterized(reg.bitsize) or cirq.is_parameterized(reg.side)
+        cirq.is_parameterized(reg.bitsize) or cirq.is_parameterized(reg.side) or reg.is_symbolic()
         for reg in bloq.signature
     ):
         # pylint: disable=raise-missing-from


### PR DESCRIPTION
fixes #1374 