### PR TITLE
Remove _t_complexity_

### DIFF
--- a/qualtran/_infra/adjoint.py
+++ b/qualtran/_infra/adjoint.py
@@ -181,21 +181,3 @@ class Adjoint(GateWithRegisters):
             return self.subbloq.wire_symbol(reg=None).adjoint()
 
         return self.subbloq.wire_symbol(reg=reg.adjoint(), idx=idx).adjoint()
-
-    def _t_complexity_(self):
-        """The cirq-style `_t_complexity_` delegates to the subbloq's method with a special shim.
-
-        The cirq-style t complexity protocol does not leverage the heirarchical decomposition
-        of high-level bloqs, so we need to shim in an extra `adjoint` boolean flag.
-        """
-        # TODO: https://github.com/quantumlib/Qualtran/issues/735
-        if not hasattr(self.subbloq, '_t_complexity_'):
-            return NotImplemented
-
-        try:
-            return self.subbloq._t_complexity_(adjoint=True)  # type: ignore[call-arg]
-        except TypeError as e:
-            if 'adjoint' in str(e):
-                return self.subbloq._t_complexity_()
-            else:
-                raise e

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -432,9 +432,6 @@ class Bloq(metaclass=abc.ABCMeta):
 
         return t_complexity(self)
 
-    def _t_complexity_(self) -> 'TComplexity':
-        return NotImplemented
-
     def as_cirq_op(
         self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'
     ) -> Tuple[Union['cirq.Operation', None], Dict[str, 'CirqQuregT']]:

--- a/qualtran/bloqs/arithmetic/conversions/contiguous_index.py
+++ b/qualtran/bloqs/arithmetic/conversions/contiguous_index.py
@@ -18,7 +18,6 @@ from attrs import frozen
 
 from qualtran import Bloq, bloq_example, BloqDocSpec, QUInt, Register, Signature
 from qualtran.bloqs.basic_gates import Toffoli
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import WireSymbol
 from qualtran.drawing.musical_score import Text, TextBox
 
@@ -69,10 +68,6 @@ class ToContiguousIndex(Bloq):
         self, mu: 'ClassicalValT', nu: 'ClassicalValT'
     ) -> Dict[str, 'ClassicalValT']:
         return {'mu': mu, 'nu': nu, 's': nu * (nu + 1) // 2 + mu}
-
-    def _t_complexity_(self) -> 'TComplexity':
-        num_toffoli = self.bitsize**2 + self.bitsize - 1
-        return TComplexity(t=4 * num_toffoli)
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> WireSymbol:
         if reg is None:

--- a/qualtran/bloqs/basic_gates/cnot.py
+++ b/qualtran/bloqs/basic_gates/cnot.py
@@ -33,7 +33,6 @@ from qualtran import (
     Signature,
     SoquetT,
 )
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, ModPlus, Text, WireSymbol
 
 if TYPE_CHECKING:
@@ -131,9 +130,6 @@ class CNOT(Bloq):
         elif reg.name == 'target':
             return ModPlus()
         raise ValueError(f'Unknown wire symbol register name: {reg.name}')
-
-    def _t_complexity_(self) -> 'TComplexity':
-        return TComplexity(clifford=1)
 
 
 @bloq_example

--- a/qualtran/bloqs/basic_gates/global_phase.py
+++ b/qualtran/bloqs/basic_gates/global_phase.py
@@ -32,7 +32,6 @@ from qualtran import (
 )
 from qualtran.bloqs.basic_gates.rotation import ZPowGate
 from qualtran.cirq_interop import CirqGateAsBloqBase
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.symbolics import pi, sarg, sexp, SymbolicComplex, SymbolicFloat
 
 if TYPE_CHECKING:
@@ -108,9 +107,6 @@ class GlobalPhase(CirqGateAsBloqBase):
 
     def __str__(self) -> str:
         return f'GPhase({self.coefficient})'
-
-    def _t_complexity_(self) -> 'TComplexity':
-        return TComplexity()
 
 
 @bloq_example

--- a/qualtran/bloqs/basic_gates/hadamard.py
+++ b/qualtran/bloqs/basic_gates/hadamard.py
@@ -32,7 +32,6 @@ from qualtran import (
     Signature,
     SoquetT,
 )
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, Text, TextBox, WireSymbol
 
 if TYPE_CHECKING:
@@ -106,9 +105,6 @@ class Hadamard(Bloq):
         (q,) = q
         return cirq.H(q), {'q': np.array([q])}
 
-    def _t_complexity_(self):
-        return TComplexity(clifford=1)
-
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         if reg is None:
             return Text('')
@@ -174,14 +170,6 @@ class CHadamard(Bloq):
             'ctrl': np.array([ctrl]),
             'target': np.array([target]),
         }
-
-    def _t_complexity_(self) -> 'TComplexity':
-        # This is based on the decomposition provided by `cirq.decompose_multi_controlled_rotation`
-        # which uses three cirq.MatrixGate's to do a controlled version of any single-qubit gate.
-        # The first MatrixGate happens to be a clifford, Hadamard operation in this case.
-        # The other two are considered 'rotations'.
-        # https://github.com/quantumlib/Qualtran/issues/237
-        return TComplexity(rotations=2, clifford=4)
 
     def my_static_costs(self, cost_key: 'CostKey'):
         from qualtran.resource_counting import GateCounts, QECGatesCost

--- a/qualtran/bloqs/basic_gates/identity.py
+++ b/qualtran/bloqs/basic_gates/identity.py
@@ -32,7 +32,6 @@ from qualtran import (
     Signature,
     SoquetT,
 )
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Text, TextBox, WireSymbol
 from qualtran.symbolics import is_symbolic, SymbolicInt
 
@@ -88,9 +87,6 @@ class Identity(Bloq):
             raise ValueError(f"cirq.IdentityGate does not support symbolic {self.bitsize=}")
 
         return cirq.IdentityGate(self.bitsize).on(*q), {'q': q}
-
-    def _t_complexity_(self):
-        return TComplexity()
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         if reg is None:

--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -22,7 +22,6 @@ from attrs import frozen
 
 from qualtran import bloq_example, BloqDocSpec, CompositeBloq, DecomposeTypeError, Register
 from qualtran.cirq_interop import CirqGateAsBloqBase
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Text, TextBox, WireSymbol
 from qualtran.symbolics import SymbolicFloat
 
@@ -119,11 +118,6 @@ class CZPowGate(CirqGateAsBloqBase):
     @cached_property
     def cirq_gate(self) -> cirq.Gate:
         return cirq.CZPowGate(exponent=self.exponent, global_shift=self.global_shift)
-
-    def _t_complexity_(self) -> 'TComplexity':
-        if cirq.has_stabilizer_effect(self.cirq_gate):
-            return TComplexity(clifford=1)
-        return TComplexity(rotations=1)
 
     def __pow__(self, power):
         g = self.cirq_gate**power

--- a/qualtran/bloqs/basic_gates/s_gate.py
+++ b/qualtran/bloqs/basic_gates/s_gate.py
@@ -20,7 +20,6 @@ import numpy as np
 from attrs import frozen
 
 from qualtran import Bloq, bloq_example, BloqDocSpec, ConnectionT, Register, Signature
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Text, TextBox, WireSymbol
 
 if TYPE_CHECKING:
@@ -56,9 +55,6 @@ class SGate(Bloq):
     @cached_property
     def signature(self) -> 'Signature':
         return Signature.build(q=1)
-
-    def _t_complexity_(self) -> 'TComplexity':
-        return TComplexity(clifford=1)
 
     def my_tensors(
         self, incoming: Dict[str, 'ConnectionT'], outgoing: Dict[str, 'ConnectionT']

--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -36,7 +36,6 @@ from qualtran import (
     SoquetT,
 )
 from qualtran.cirq_interop import CirqQuregT
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, Text, TextBox, WireSymbol
 from qualtran.resource_counting.generalizers import ignore_split_join
 
@@ -83,9 +82,6 @@ class TwoBitSwap(Bloq):
         (x,) = x
         (y,) = y
         return cirq.SWAP.on(x, y), {'x': np.asarray([x]), 'y': np.asarray([y])}
-
-    def _t_complexity_(self) -> 'TComplexity':
-        return TComplexity(clifford=1)
 
     def my_tensors(
         self, incoming: Dict[str, 'ConnectionT'], outgoing: Dict[str, 'ConnectionT']

--- a/qualtran/bloqs/basic_gates/toffoli.py
+++ b/qualtran/bloqs/basic_gates/toffoli.py
@@ -30,7 +30,6 @@ from qualtran import (
     Register,
     Signature,
 )
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 
 if TYPE_CHECKING:
     import cirq
@@ -65,9 +64,6 @@ class Toffoli(Bloq):
 
     def decompose_bloq(self) -> 'CompositeBloq':
         raise DecomposeTypeError(f"{self} is atomic")
-
-    def _t_complexity_(self):
-        return TComplexity(t=4)
 
     def my_tensors(
         self,

--- a/qualtran/bloqs/basic_gates/x_basis.py
+++ b/qualtran/bloqs/basic_gates/x_basis.py
@@ -32,7 +32,6 @@ from qualtran import (
     Signature,
     SoquetT,
 )
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import directional_text_box, Text, WireSymbol
 
 if TYPE_CHECKING:
@@ -256,9 +255,6 @@ class XGate(Bloq):
 
         (q,) = q
         return cirq.X(q), {'q': np.asarray([q])}
-
-    def _t_complexity_(self):
-        return TComplexity(clifford=1)
 
     def wire_symbol(self, reg: Register, idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         from qualtran.drawing import ModPlus

--- a/qualtran/bloqs/basic_gates/y_gate.py
+++ b/qualtran/bloqs/basic_gates/y_gate.py
@@ -32,7 +32,6 @@ from qualtran import (
     Signature,
     SoquetT,
 )
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, Text, TextBox, WireSymbol
 
 if TYPE_CHECKING:
@@ -97,9 +96,6 @@ class YGate(Bloq):
 
         (q,) = q
         return cirq.Y(q), {'q': np.asarray([q])}
-
-    def _t_complexity_(self) -> 'TComplexity':
-        return TComplexity(clifford=1)
 
     def wire_symbol(
         self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -41,7 +41,6 @@ from qualtran import (
     SoquetT,
 )
 from qualtran.bloqs.bookkeeping import ArbitraryClifford
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, directional_text_box, Text, TextBox, WireSymbol
 
 if TYPE_CHECKING:
@@ -276,9 +275,6 @@ class ZGate(Bloq):
 
         (q,) = q
         return cirq.Z(q), {'q': np.asarray([q])}
-
-    def _t_complexity_(self) -> 'TComplexity':
-        return TComplexity(clifford=1)
 
     def wire_symbol(
         self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()

--- a/qualtran/bloqs/bookkeeping/_bookkeeping_bloq.py
+++ b/qualtran/bloqs/bookkeeping/_bookkeeping_bloq.py
@@ -16,7 +16,6 @@ import abc
 from typing import Dict, Iterable, Optional, Sequence, Tuple, TYPE_CHECKING
 
 from qualtran import Bloq, BloqBuilder, SoquetT
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 
 if TYPE_CHECKING:
 
@@ -42,6 +41,3 @@ class _BookkeepingBloq(Bloq, metaclass=abc.ABCMeta):
             return ctrl_soqs, out_soqs
 
         return self, add_controlled
-
-    def _t_complexity_(self) -> 'TComplexity':
-        return TComplexity()

--- a/qualtran/bloqs/bookkeeping/arbitrary_clifford.py
+++ b/qualtran/bloqs/bookkeeping/arbitrary_clifford.py
@@ -18,7 +18,6 @@ from attrs import frozen
 from sympy import Expr
 
 from qualtran import Bloq, QAny, Register, Signature
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 
 
 @frozen
@@ -39,9 +38,6 @@ class ArbitraryClifford(Bloq):
     @cached_property
     def signature(self) -> Signature:
         return Signature([Register('x', QAny(bitsize=self.n))])
-
-    def _t_complexity_(self) -> 'TComplexity':
-        return TComplexity(clifford=1)
 
     def __str__(self):
         return f'ArbitraryClifford(n={self.n})'

--- a/qualtran/bloqs/for_testing/atom.py
+++ b/qualtran/bloqs/for_testing/atom.py
@@ -27,7 +27,6 @@ from qualtran import (
     GateWithRegisters,
     Signature,
 )
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.resource_counting import CostKey, GateCounts, QECGatesCost
 
 if TYPE_CHECKING:
@@ -71,9 +70,6 @@ class TestAtom(Bloq):
         if isinstance(cost_key, QECGatesCost):
             return GateCounts(t=100)
         return NotImplemented
-
-    def _t_complexity_(self) -> 'TComplexity':
-        return TComplexity(100)
 
     def __repr__(self):
         if self.tag:
@@ -154,8 +150,10 @@ class TestGWRAtom(GateWithRegisters):
     def adjoint(self) -> 'TestGWRAtom':
         return attrs.evolve(self, is_adjoint=not self.is_adjoint)
 
-    def _t_complexity_(self) -> 'TComplexity':
-        return TComplexity(100)
+    def my_static_costs(self, cost_key: 'CostKey'):
+        if isinstance(cost_key, QECGatesCost):
+            return GateCounts(t=100)
+        return NotImplemented
 
     def __repr__(self):
         tag = f'{self.tag!r}' if self.tag else ''

--- a/qualtran/bloqs/mcmt/and_bloq.py
+++ b/qualtran/bloqs/mcmt/and_bloq.py
@@ -48,7 +48,6 @@ from qualtran import (
 from qualtran.bloqs.basic_gates import TGate, XGate
 from qualtran.bloqs.bookkeeping import ArbitraryClifford
 from qualtran.cirq_interop import decompose_from_cirq_style_method
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.drawing import Circle, directional_text_box, Text, WireSymbol
 from qualtran.resource_counting import (
     big_O,
@@ -125,19 +124,6 @@ class And(GateWithRegisters):
             return {ArbitraryClifford(n=2): 4 + 2 * pre_post_cliffords}
 
         return {ArbitraryClifford(n=2): 9 + 2 * pre_post_cliffords, TGate(): 4}
-
-    def _t_complexity_(self) -> 'TComplexity':
-        if not FLAG_AND_AS_LEAF:
-            return NotImplemented
-
-        if isinstance(self.cv1, sympy.Expr) or isinstance(self.cv2, sympy.Expr):
-            pre_post_cliffords: Union[sympy.Order, int] = 0
-        else:
-            pre_post_cliffords = 2 - self.cv1 - self.cv2
-        if self.uncompute:
-            return TComplexity(clifford=4 + 2 * pre_post_cliffords)
-
-        return TComplexity(t=4, clifford=9 + 2 * pre_post_cliffords)
 
     def on_classical_vals(
         self, *, ctrl: NDArray[np.uint8], target: Optional[int] = None

--- a/qualtran/cirq_interop/_bloq_to_cirq.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq.py
@@ -122,10 +122,6 @@ class BloqAsCirqGate(cirq.Gate):
         )
         return BloqAsCirqGate(bloq=bloq).on_registers(**all_quregs), out_quregs
 
-    def _t_complexity_(self):
-        """Delegate to the bloq's t complexity."""
-        return self._bloq.t_complexity()
-
     def _num_qubits_(self) -> int:
         return total_bits(self.signature)
 

--- a/qualtran/cirq_interop/_bloq_to_cirq_test.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq_test.py
@@ -25,7 +25,6 @@ from qualtran.bloqs.factoring import ModExp
 from qualtran.bloqs.mcmt.and_bloq import And, MultiAnd
 from qualtran.bloqs.state_preparation import PrepareUniformSuperposition
 from qualtran.cirq_interop._bloq_to_cirq import BloqAsCirqGate, CirqQuregT
-from qualtran.cirq_interop.t_complexity_protocol import t_complexity_compat
 from qualtran.testing import execute_notebook
 
 if TYPE_CHECKING:
@@ -235,7 +234,6 @@ def test_bloq_as_cirq_gate_for_mod_exp():
     # newly allocated RIGHT registers in the decomposition to the one's specified by the user
     # when constructing the original operation (in this case, register `x`).
     circuit = cirq.Circuit(op, cirq.decompose_once(op))
-    assert t_complexity_compat(circuit) == 2 * mod_exp.t_complexity()
     cirq.testing.assert_has_diagram(
         circuit,
         '''
@@ -260,7 +258,6 @@ x1: ──────────x──────────1───*=3�
     # Whereas when directly applying a cirq gate on qubits to get an operations, we need to
     # specify both input and output registers.
     circuit = cirq.Circuit(gate.on_registers(**out_regs), decomposed_circuit)
-    assert t_complexity_compat(circuit) == 2 * mod_exp.t_complexity()
     # Notice the newly allocated qubits _C(0) and _C(1) for output register x.
     cirq.testing.assert_has_diagram(
         circuit,

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -47,7 +47,7 @@ from qualtran._infra.gate_with_registers import (
     split_qubits,
 )
 from qualtran.cirq_interop._interop_qubit_manager import InteropQubitManager
-from qualtran.cirq_interop.t_complexity_protocol import _from_directly_countable_cirq, TComplexity
+from qualtran.cirq_interop.t_complexity_protocol import _from_directly_countable_cirq
 from qualtran.resource_counting import CostKey, GateCounts, QECGatesCost
 
 if TYPE_CHECKING:
@@ -146,12 +146,6 @@ class CirqGateAsBloq(CirqGateAsBloqBase):
     @property
     def cirq_gate(self) -> cirq.Gate:
         return self.gate
-
-    def _t_complexity_(self) -> 'TComplexity':
-        t_count = _from_directly_countable_cirq(self.cirq_gate)
-        if t_count is None:
-            raise ValueError(f"Cirq gate must be directly countable, not {self.cirq_gate}")
-        return t_count
 
     def my_static_costs(self, cost_key: 'CostKey'):
         if isinstance(cost_key, QECGatesCost):

--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -19,6 +19,7 @@ import cirq
 
 from qualtran import Bloq
 from qualtran.symbolics import ceil, log2, SymbolicFloat, SymbolicInt
+
 from .decompose_protocol import _decompose_once_considering_known_decomposition
 
 _T_GATESET = cirq.Gateset(cirq.T, cirq.T**-1, unroll_circuit_op=False)

--- a/qualtran/cirq_interop/t_complexity_protocol_test.py
+++ b/qualtran/cirq_interop/t_complexity_protocol_test.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import cirq
 import pytest
@@ -31,7 +31,7 @@ from qualtran.cirq_interop.testing import GateHelper
 from qualtran.testing import execute_notebook
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    pass
 
 
 class DoesNotSupportTComplexity: ...
@@ -66,23 +66,6 @@ class DoesNotSupportTComplexityBloq(Bloq):
         return Signature.build(q=1)
 
 
-@frozen
-class SupportsTComplexityBloqViaBuildCallGraph(Bloq):
-    @property
-    def signature(self) -> 'Signature':
-        return Signature.build(q=1)
-
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(SupportsTComplexityGateWithRegisters(), 5)}
-
-
-def test_t_complexity_for_bloq_via_build_call_graph():
-    bloq = SupportsTComplexityBloqViaBuildCallGraph()
-    _, sigma = bloq.call_graph(max_depth=1)
-    assert sigma != {}
-    assert t_complexity(bloq) == TComplexity(t=5, clifford=10)
-
-
 def test_t_complexity_for_bloq_does_not_support():
     with pytest.raises(DecomposeNotImplementedError):
         _ = t_complexity(DoesNotSupportTComplexityBloq())
@@ -100,7 +83,7 @@ def test_t_complexity_compat():
 
     g = GateHelper(SupportsTComplexityGateWithRegisters())
     assert g.gate._decompose_with_context_(g.operation.qubits) is NotImplemented  # type: ignore[attr-defined]
-    assert t_complexity(g.gate) == TComplexity(t=1, clifford=2)
+    assert t_complexity_compat(g.gate) == TComplexity(t=1, clifford=2)
     assert t_complexity_compat(g.operation) == TComplexity(t=1, clifford=2)
 
     assert t_complexity_compat([cirq.T, cirq.X]) == TComplexity(t=1, clifford=1)

--- a/qualtran/cirq_interop/t_complexity_protocol_test.py
+++ b/qualtran/cirq_interop/t_complexity_protocol_test.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import TYPE_CHECKING
 
 import cirq
 import pytest
@@ -29,9 +28,6 @@ from qualtran.cirq_interop.t_complexity_protocol import (
 )
 from qualtran.cirq_interop.testing import GateHelper
 from qualtran.testing import execute_notebook
-
-if TYPE_CHECKING:
-    pass
 
 
 class DoesNotSupportTComplexity: ...
@@ -64,6 +60,11 @@ class DoesNotSupportTComplexityBloq(Bloq):
     @property
     def signature(self) -> 'Signature':
         return Signature.build(q=1)
+
+
+def test_legacy_t_complexity_annotation():
+    # Test the deprecated `getattr(.., '_t_complexity_')
+    assert SupportsTComplexityGateWithRegisters().t_complexity() == TComplexity(t=1, clifford=2)
 
 
 def test_t_complexity_for_bloq_does_not_support():

--- a/qualtran/cirq_interop/testing_test.py
+++ b/qualtran/cirq_interop/testing_test.py
@@ -11,14 +11,13 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Dict, Iterator
+from typing import Iterator
 
 import cirq
 import numpy as np
 import pytest
 
-from qualtran import Bloq, BloqBuilder, QBit, Register, Side, Signature, SoquetT
-from qualtran.bloqs.basic_gates import XGate
+from qualtran import QBit, Register, Side, Signature
 from qualtran.bloqs.mcmt.and_bloq import MultiAnd
 from qualtran.cirq_interop import testing
 from qualtran.cirq_interop.t_complexity_protocol import TComplexity
@@ -59,9 +58,6 @@ def test_gate_helper():
 
 
 class DoesNotDecompose(cirq.Operation):
-    def _t_complexity_(self) -> TComplexity:
-        return TComplexity(t=1, clifford=2, rotations=3)
-
     @property
     def qubits(self):
         return []
@@ -85,23 +81,5 @@ class ConsistentDecompostion(cirq.Operation):
         pass
 
 
-class InconsistentDecompostion(Bloq):
-    @property
-    def signature(self) -> 'Signature':
-        return Signature.build(q=1)
-
-    def _t_complexity_(self) -> TComplexity:
-        return TComplexity(rotations=1)
-
-    def build_composite_bloq(self, bb: 'BloqBuilder', q: 'SoquetT') -> Dict[str, 'SoquetT']:
-        q = bb.add(XGate(), q=q)
-        return {'q': q}
-
-
 def test_assert_decompose_is_consistent_with_t_complexity():
     testing.assert_decompose_is_consistent_with_t_complexity(ConsistentDecompostion())
-
-
-def test_assert_decompose_is_consistent_with_t_complexity_raises():
-    with pytest.raises(AssertionError):
-        testing.assert_decompose_is_consistent_with_t_complexity(InconsistentDecompostion())

--- a/qualtran/resource_counting/_bloq_counts.py
+++ b/qualtran/resource_counting/_bloq_counts.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import logging
-import warnings
 from collections import defaultdict
 from typing import Callable, cast, Dict, Sequence, Tuple, TYPE_CHECKING
 
@@ -295,18 +294,6 @@ class QECGatesCost(CostKey[GateCounts]):
         from qualtran.bloqs.basic_gates._shims import Measure
         from qualtran.bloqs.bookkeeping._bookkeeping_bloq import _BookkeepingBloq
         from qualtran.bloqs.mcmt import And, MultiTargetCNOT
-
-        if self.legacy_shims:
-            legacy_val = bloq._t_complexity_()
-            if legacy_val is not NotImplemented:
-                warnings.warn(
-                    "Please migrate explicit cost annotations to the general "
-                    "`Bloq.my_static_costs` method override.",
-                    DeprecationWarning,
-                )
-                return GateCounts(
-                    t=legacy_val.t, clifford=legacy_val.clifford, rotation=legacy_val.rotations
-                )
 
         # T gates
         if bloq_is_t_like(bloq):

--- a/qualtran/resource_counting/_bloq_counts.py
+++ b/qualtran/resource_counting/_bloq_counts.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import logging
+import warnings
 from collections import defaultdict
 from typing import Callable, cast, Dict, Sequence, Tuple, TYPE_CHECKING
 
@@ -294,6 +295,21 @@ class QECGatesCost(CostKey[GateCounts]):
         from qualtran.bloqs.basic_gates._shims import Measure
         from qualtran.bloqs.bookkeeping._bookkeeping_bloq import _BookkeepingBloq
         from qualtran.bloqs.mcmt import And, MultiTargetCNOT
+
+        if self.legacy_shims:
+            if hasattr(bloq, '_t_complexity_'):
+                legacy_val = bloq._t_complexity_()
+            else:
+                legacy_val = NotImplemented
+            if legacy_val is not NotImplemented:
+                warnings.warn(
+                    "Please migrate explicit cost annotations to the general "
+                    "`Bloq.my_static_costs` method override.",
+                    DeprecationWarning,
+                )
+                return GateCounts(
+                    t=legacy_val.t, clifford=legacy_val.clifford, rotation=legacy_val.rotations
+                )
 
         # T gates
         if bloq_is_t_like(bloq):

--- a/qualtran/serialization/bloq_test.py
+++ b/qualtran/serialization/bloq_test.py
@@ -26,7 +26,6 @@ from qualtran._infra.composite_bloq_test import TestTwoCNOT
 from qualtran.bloqs.factoring.mod_exp import ModExp
 from qualtran.cirq_interop import CirqGateAsBloq
 from qualtran.cirq_interop._cirq_to_bloq_test import TestCNOT as TestCNOTCirq
-from qualtran.cirq_interop.t_complexity_protocol import TComplexity
 from qualtran.protos import registers_pb2
 from qualtran.resource_counting import CostKey, GateCounts, QECGatesCost
 from qualtran.serialization import bloq as bloq_serialization
@@ -95,9 +94,6 @@ class TestCSwap(Bloq):
     @property
     def signature(self) -> 'Signature':
         return Signature.build(ctrl=1, x=self.bitsize, y=self.bitsize)
-
-    def _t_complexity_(self) -> TComplexity:
-        return TComplexity(t=7 * self.bitsize, clifford=10 * self.bitsize)
 
     def my_static_costs(self, cost_key: 'CostKey'):
         if isinstance(cost_key, QECGatesCost):


### PR DESCRIPTION
Final part of #1251 

This PR removes the legacy `_t_complexity_` override from all bloqs. These were already redundant: during development of previous PRs I had removed use of these anyways. Those PRs did careful accounting of all `bloq_example` and unit test t complexity values and made sure they matched the `QECGatesCost` values (with some small, contained legacy shims). This PR shows that off!

See my inline comments, but I left in a `getattrs`-based shim so that the `_t_complexity_` override will still be used if `QECGatesCost()` is in legacy mode. The only thing left in qualtran that uses it is a specific unit test I added to test it. 