### PR TITLE
Change build_call_graph in bloqs to return dict

### DIFF
--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 
     from qualtran.bloqs.bookkeeping.auto_partition import Unused
     from qualtran.cirq_interop._cirq_to_bloq import CirqQuregInT, CirqQuregT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 # NDArrays must be bound to np.generic
@@ -237,7 +237,7 @@ class CompositeBloq(Bloq):
             "Consider using the composite bloq directly or using `.flatten()`."
         )
 
-    def build_call_graph(self, ssa: Optional['SympySymbolAllocator']) -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: Optional['SympySymbolAllocator']) -> 'BloqCountDictT':
         """Return the bloq counts by counting up all the subbloqs."""
         from qualtran.resource_counting import build_cbloq_call_graph
 

--- a/qualtran/bloqs/arithmetic/_shims.py
+++ b/qualtran/bloqs/arithmetic/_shims.py
@@ -19,13 +19,12 @@ so we don't have undefined symbols and can still merge the high-level algorithms
 will be fleshed out and moved to their final organizational location soon (written: 2024-05-06).
 """
 from functools import cached_property
-from typing import Set
 
 from attrs import frozen
 
 from qualtran import Bloq, QBit, QUInt, Register, Signature
 from qualtran.bloqs.basic_gates import Toffoli
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -36,8 +35,8 @@ class MultiCToffoli(Bloq):
     def signature(self) -> 'Signature':
         return Signature([Register('ctrl', QBit(), shape=(self.n,)), Register('target', QBit())])
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(Toffoli(), self.n - 2)}
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
+        return {Toffoli(): self.n - 2}
 
 
 @frozen
@@ -51,9 +50,9 @@ class Lt(Bloq):
             [Register('x', QUInt(self.n)), Register('y', QUInt(self.n)), Register('out', QBit())]
         )
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
         # litinski
-        return {(Toffoli(), self.n)}
+        return {Toffoli(): self.n}
 
 
 @frozen

--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -62,7 +62,12 @@ from qualtran.simulation.classical_sim import add_ints
 
 if TYPE_CHECKING:
     from qualtran.drawing import WireSymbol
-    from qualtran.resource_counting import BloqCountDictT, BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import (
+        BloqCountDictT,
+        BloqCountT,
+        MutableBloqCountDictT,
+        SympySymbolAllocator,
+    )
     from qualtran.simulation.classical_sim import ClassicalValT
     from qualtran.symbolics import SymbolicInt
 
@@ -209,10 +214,10 @@ class Add(Bloq):
         yield CNOT().on(input_bits[0], output_bits[0])
         context.qubit_manager.qfree(ancillas)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         n = self.b_dtype.bitsize
         n_cnot = (n - 2) * 6 + 3
-        return {(And(), n - 1), (And().adjoint(), n - 1), (CNOT(), n_cnot)}
+        return {And(): n - 1, And().adjoint(): n - 1, CNOT(): n_cnot}
 
 
 @bloq_example(generalizer=ignore_split_join)
@@ -330,8 +335,8 @@ class OutOfPlaceAdder(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[m
         ]
         return cirq.inverse(optree) if self.is_adjoint else optree
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(And(uncompute=self.is_adjoint), self.bitsize), (CNOT(), 5 * self.bitsize)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {And(uncompute=self.is_adjoint): self.bitsize, CNOT(): 5 * self.bitsize}
 
     def __pow__(self, power: int):
         if power == 1:
@@ -503,16 +508,16 @@ class AddK(Bloq):
     def build_call_graph(
         self, ssa: 'SympySymbolAllocator'
     ) -> Union['BloqCountDictT', Set['BloqCountT']]:
-        loading_cost: Tuple[Bloq, SymbolicInt]
+        loading_cost: MutableBloqCountDictT
         if len(self.cvs) == 0:
-            loading_cost = (XGate(), self.bitsize)  # upper bound; depends on the data.
+            loading_cost = {XGate(): self.bitsize}  # upper bound; depends on the data.
         elif len(self.cvs) == 1:
-            loading_cost = (CNOT(), self.bitsize)  # upper bound; depends on the data.
+            loading_cost = {CNOT(): self.bitsize}  # upper bound; depends on the data.
         else:
             # Otherwise, use the decomposition
             return super().build_call_graph(ssa=ssa)
-
-        return {loading_cost, (Add(QUInt(self.bitsize)), 1)}
+        loading_cost[Add(QUInt(self.bitsize))] = 1
+        return loading_cost
 
     def get_ctrl_system(self, ctrl_spec: 'CtrlSpec') -> Tuple['Bloq', 'AddControlledT']:
         if self.cvs:

--- a/qualtran/bloqs/arithmetic/bitwise.py
+++ b/qualtran/bloqs/arithmetic/bitwise.py
@@ -39,7 +39,7 @@ from qualtran.resource_counting.generalizers import ignore_split_join
 from qualtran.symbolics import is_symbolic, SymbolicInt
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -90,9 +90,9 @@ class XorK(Bloq):
 
         return {'x': x}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         num_flips = self.bitsize if self.is_symbolic() else sum(self._bits_k)
-        return {(XGate(), num_flips)}
+        return {XGate(): num_flips}
 
     def on_classical_vals(self, x: 'ClassicalValT') -> dict[str, 'ClassicalValT']:
         if isinstance(self.k, sympy.Expr):
@@ -156,8 +156,8 @@ class Xor(Bloq):
 
         return {'x': bb.join(xs, dtype=self.dtype), 'y': bb.join(ys, dtype=self.dtype)}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> set['BloqCountT']:
-        return {(CNOT(), self.dtype.num_qubits)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {CNOT(): self.dtype.num_qubits}
 
     def on_classical_vals(
         self, x: 'ClassicalValT', y: 'ClassicalValT'

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -14,18 +14,7 @@
 
 from collections import defaultdict
 from functools import cached_property
-from typing import (
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    TYPE_CHECKING,
-    Union,
-)
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import cirq
@@ -65,7 +54,11 @@ from qualtran.symbolics import HasLength, is_symbolic, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import (
+        BloqCountDictT,
+        MutableBloqCountDictT,
+        SympySymbolAllocator,
+    )
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -183,22 +176,22 @@ class LessThanConstant(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[
     def _has_unitary_(self):
         return True
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         if (
             not is_symbolic(self.less_than_val, self.bitsize)
             and self.less_than_val >= 2**self.bitsize
         ):
-            return {(XGate(), 1)}
+            return {XGate(): 1}
         num_set_bits = (
             int(self.less_than_val).bit_count()
             if not is_symbolic(self.less_than_val)
             else self.bitsize
         )
         return {
-            (And(), self.bitsize),
-            (And().adjoint(), self.bitsize),
-            (CNOT(), num_set_bits + 2 * self.bitsize),
-            (XGate(), 2 * (1 + num_set_bits)),
+            And(): self.bitsize,
+            And().adjoint(): self.bitsize,
+            CNOT(): num_set_bits + 2 * self.bitsize,
+            XGate(): 2 * (1 + num_set_bits),
         }
 
 
@@ -307,8 +300,8 @@ class BiQubitsMixer(GateWithRegisters):
             return self.adjoint()
         return NotImplemented  # pragma: no cover
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(XGate(), 1), (CNOT(), 9), (And(uncompute=self.is_adjoint), 2)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {XGate(): 1, CNOT(): 9, And(uncompute=self.is_adjoint): 2}
 
     def _has_unitary_(self):
         return not self.is_adjoint
@@ -380,8 +373,8 @@ class SingleQubitCompare(GateWithRegisters):
             return self.adjoint()
         return self
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(XGate(), 1), (CNOT(), 4), (And(uncompute=self.is_adjoint), 1)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {XGate(): 1, CNOT(): 4, And(uncompute=self.is_adjoint): 1}
 
 
 @bloq_example
@@ -575,13 +568,13 @@ class LessThanEqual(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[mis
         all_ancilla = set([q for op in adjoint for q in op.qubits if q not in input_qubits])
         context.qubit_manager.qfree(all_ancilla)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         if is_symbolic(self.x_bitsize, self.y_bitsize):
             return {
-                (BiQubitsMixer(), self.x_bitsize),
-                (BiQubitsMixer().adjoint(), self.x_bitsize),
-                (SingleQubitCompare(), 1),
-                (SingleQubitCompare().adjoint(), 1),
+                BiQubitsMixer(): self.x_bitsize,
+                BiQubitsMixer().adjoint(): self.x_bitsize,
+                SingleQubitCompare(): 1,
+                SingleQubitCompare().adjoint(): 1,
             }
 
         n = min(self.x_bitsize, self.y_bitsize)
@@ -613,7 +606,7 @@ class LessThanEqual(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[mis
             ret[And(1, 0).adjoint()] += 1
             ret[CNOT()] += 1
 
-        return set(ret.items())
+        return ret
 
     def _has_unitary_(self):
         return True
@@ -691,8 +684,8 @@ class GreaterThan(Bloq):
         target = bb.add(XGate(), q=target)
         return {'a': a, 'b': b, 'target': target}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(LessThanEqual(self.a_bitsize, self.b_bitsize), 1), (XGate(), 1)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {LessThanEqual(self.a_bitsize, self.b_bitsize): 1, XGate(): 1}
 
 
 @bloq_example
@@ -885,23 +878,23 @@ class LinearDepthGreaterThan(Bloq):
             return TextBox('t⨁(a>b)')
         raise ValueError(f'Unknown register name {reg.name}')
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         if self.bitsize == 1:
-            return {(MultiControlX(cvs=(1, 0)), 1)}
+            return {MultiControlX(cvs=(1, 0)): 1}
 
         if self.signed:
             return {
-                (CNOT(), 6 * self.bitsize - 7),
-                (XGate(), 2 * self.bitsize + 2),
-                (And(), self.bitsize - 1),
-                (And(uncompute=True), self.bitsize - 1),
+                CNOT(): 6 * self.bitsize - 7,
+                XGate(): 2 * self.bitsize + 2,
+                And(): self.bitsize - 1,
+                And(uncompute=True): self.bitsize - 1,
             }
 
         return {
-            (CNOT(), 6 * self.bitsize - 1),
-            (XGate(), 2 * self.bitsize + 4),
-            (And(), self.bitsize),
-            (And(uncompute=True), self.bitsize),
+            CNOT(): 6 * self.bitsize - 1,
+            XGate(): 2 * self.bitsize + 4,
+            And(): self.bitsize,
+            And(uncompute=True): self.bitsize,
         }
 
 
@@ -941,8 +934,8 @@ class GreaterThanConstant(Bloq):
             return TextBox(f"⨁(x > {self.val})")
         raise ValueError(f'Unknown register symbol {reg.name}')
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(LessThanConstant(self.bitsize, less_than_val=self.val), 1)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {LessThanConstant(self.bitsize, less_than_val=self.val): 1}
 
 
 @bloq_example
@@ -1007,8 +1000,8 @@ class EqualsAConstant(Bloq):
         x = bb.join(xs)
         return {'x': x, 'target': target}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(MultiControlX(self.bits_k), 1)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {MultiControlX(self.bits_k): 1}
 
 
 def _make_equals_a_constant():
@@ -1134,21 +1127,22 @@ class CLinearDepthGreaterThan(Bloq):
             return {'ctrl': ctrl, 'a': a, 'b': b, 'target': target ^ (a > b)}
         return {'ctrl': ctrl, 'a': a, 'b': b, 'target': target}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        signed_ops = []
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        signed_ops: 'MutableBloqCountDictT' = {}
         if isinstance(self.dtype, QInt):
-            signed_ops = [
-                (SignExtend(self.dtype, QInt(self.dtype.bitsize + 1)), 2),
-                (SignExtend(self.dtype, QInt(self.dtype.bitsize + 1)).adjoint(), 2),
-            ]
+            signed_ops = {
+                SignExtend(self.dtype, QInt(self.dtype.bitsize + 1)): 2,
+                SignExtend(self.dtype, QInt(self.dtype.bitsize + 1)).adjoint(): 2,
+            }
         dtype = attrs.evolve(self.dtype, bitsize=self.dtype.bitsize + 1)
         return {
-            (BitwiseNot(dtype), 2),
-            (BitwiseNot(QUInt(dtype.bitsize + 1)), 2),
-            (OutOfPlaceAdder(self.dtype.bitsize + 1).adjoint(), 1),
-            (OutOfPlaceAdder(self.dtype.bitsize + 1), 1),
-            (MultiControlX((self.cv, 1)), 1),
-        }.union(signed_ops)
+            BitwiseNot(dtype): 2,
+            BitwiseNot(QUInt(dtype.bitsize + 1)): 2,
+            OutOfPlaceAdder(self.dtype.bitsize + 1).adjoint(): 1,
+            OutOfPlaceAdder(self.dtype.bitsize + 1): 1,
+            MultiControlX((self.cv, 1)): 1,
+            **signed_ops,
+        }
 
 
 @bloq_example(generalizer=ignore_split_join)

--- a/qualtran/bloqs/arithmetic/controlled_addition.py
+++ b/qualtran/bloqs/arithmetic/controlled_addition.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Dict, Set, TYPE_CHECKING, Union
+from typing import Dict, TYPE_CHECKING, Union
 
 import numpy as np
 import sympy
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     import quimb.tensor as qtn
 
     from qualtran.drawing import WireSymbol
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -155,11 +155,11 @@ class CAdd(Bloq):
         ctrl = bb.join(np.array([ctrl_q]))
         return {'ctrl': ctrl, 'a': a, 'b': b}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return {
-            (And(self.cv, 1), self.a_dtype.bitsize),
-            (Add(self.a_dtype, self.b_dtype), 1),
-            (And(self.cv, 1).adjoint(), self.a_dtype.bitsize),
+            And(self.cv, 1): self.a_dtype.bitsize,
+            Add(self.a_dtype, self.b_dtype): 1,
+            And(self.cv, 1).adjoint(): self.a_dtype.bitsize,
         }
 
 

--- a/qualtran/bloqs/arithmetic/conversions/contiguous_index.py
+++ b/qualtran/bloqs/arithmetic/conversions/contiguous_index.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 from attrs import frozen
 
@@ -23,7 +23,7 @@ from qualtran.drawing import WireSymbol
 from qualtran.drawing.musical_score import Text, TextBox
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -85,9 +85,9 @@ class ToContiguousIndex(Bloq):
             text = r'⊕ν(ν-1)/2+μ'
             return TextBox(text)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         num_toffoli = self.bitsize**2 + self.bitsize - 1
-        return {(Toffoli(), num_toffoli)}
+        return {Toffoli(): num_toffoli}
 
 
 @bloq_example

--- a/qualtran/bloqs/arithmetic/conversions/ones_complement_to_twos_complement.py
+++ b/qualtran/bloqs/arithmetic/conversions/ones_complement_to_twos_complement.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -21,7 +21,7 @@ from qualtran import Bloq, bloq_example, BloqDocSpec, QInt, QIntOnesComp, Regist
 from qualtran.bloqs.basic_gates import Toffoli
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -51,10 +51,10 @@ class SignedIntegerToTwosComplement(Bloq):
             ]
         )
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Take the sign qubit as a control and cnot the remaining qubits, then
         # add it to the remaining n-1 bits.
-        return {(Toffoli(), (self.bitsize - 2))}
+        return {Toffoli(): (self.bitsize - 2)}
 
 
 @bloq_example

--- a/qualtran/bloqs/arithmetic/conversions/sign_extension.py
+++ b/qualtran/bloqs/arithmetic/conversions/sign_extension.py
@@ -23,7 +23,7 @@ from qualtran.symbolics import is_symbolic
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, Soquet, SoquetT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -91,8 +91,8 @@ class SignExtend(Bloq):
 
         return {'y': y}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> set['BloqCountT']:
-        return {(MultiTargetCNOT(self.extend_bitsize), 1)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {MultiTargetCNOT(self.extend_bitsize): 1}
 
     def on_classical_vals(self, x: 'ClassicalValT') -> dict[str, 'ClassicalValT']:
         return {'y': x}
@@ -173,8 +173,8 @@ class SignTruncate(Bloq):
 
         return {'y': x}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> set['BloqCountT']:
-        return {(MultiTargetCNOT(self.truncate_bitsize), 1)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {MultiTargetCNOT(self.truncate_bitsize): 1}
 
     def on_classical_vals(self, x: 'ClassicalValT') -> dict[str, 'ClassicalValT']:
         bits = self.inp_dtype.to_bits(int(x))

--- a/qualtran/bloqs/arithmetic/hamming_weight.py
+++ b/qualtran/bloqs/arithmetic/hamming_weight.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Iterator, List, Set, TYPE_CHECKING
+from typing import Iterator, List, TYPE_CHECKING
 
 import cirq
 from attrs import frozen
@@ -25,7 +25,7 @@ from qualtran.bloqs.mcmt.and_bloq import And
 from qualtran.symbolics import bit_length, is_symbolic, SymbolicInt
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -117,7 +117,7 @@ class HammingWeightCompute(GateWithRegisters):
         out: List[cirq.Qid] = [*quregs['out'][::-1]]
         yield self._decompose_using_three_to_two_adders(x, junk, out)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         num_and = self.junk_bitsize
         num_cnot = num_and * 5 + self.bit_count_of_bitsize
-        return {(And(), num_and), (CNOT(), num_cnot)}
+        return {And(): num_and, CNOT(): num_cnot}

--- a/qualtran/bloqs/arithmetic/multiplication.py
+++ b/qualtran/bloqs/arithmetic/multiplication.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Dict, Iterable, List, Sequence, Set, TYPE_CHECKING, Union
+from typing import Dict, Iterable, List, Sequence, TYPE_CHECKING, Union
 
 import cirq
 import numpy as np
@@ -39,7 +39,7 @@ from qualtran.symbolics import ceil, HasLength, is_symbolic, log2, smax, Symboli
 if TYPE_CHECKING:
     import quimb.tensor as qtn
 
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -131,9 +131,9 @@ class PlusEqualProduct(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[
 
         return _my_tensors_from_gate(self, self.signature, incoming=incoming, outgoing=outgoing)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # TODO: The T-complexity here is approximate.
-        return {(TGate(), 8 * smax(self.a_bitsize, self.b_bitsize) ** 2)}
+        return {TGate(): 8 * smax(self.a_bitsize, self.b_bitsize) ** 2}
 
 
 @bloq_example
@@ -189,12 +189,12 @@ class Square(Bloq):
     def pretty_name(self) -> str:
         return "a^2"
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # TODO Determine precise clifford count and/or ignore.
         # See: https://github.com/quantumlib/Qualtran/issues/219
         # See: https://github.com/quantumlib/Qualtran/issues/217
         num_toff = self.bitsize * (self.bitsize - 1)
-        return {(Toffoli(), num_toff)}
+        return {Toffoli(): num_toff}
 
     def my_tensors(
         self, incoming: Dict[str, 'ConnectionT'], outgoing: Dict[str, 'ConnectionT']
@@ -275,11 +275,11 @@ class SumOfSquares(Bloq):
     def pretty_name(self) -> str:
         return "SOS"
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         num_toff = self.k * self.bitsize**2 - self.bitsize
         if self.k % 3 == 0:
             num_toff -= 1
-        return {(Toffoli(), num_toff)}
+        return {Toffoli(): num_toff}
 
 
 @bloq_example
@@ -329,12 +329,12 @@ class Product(Bloq):
     def pretty_name(self) -> str:
         return "a*b"
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # TODO Determine precise clifford count and/or ignore.
         # See: https://github.com/quantumlib/Qualtran/issues/219
         # See: https://github.com/quantumlib/Qualtran/issues/217
         num_toff = 2 * self.a_bitsize * self.b_bitsize - max(self.a_bitsize, self.b_bitsize)
-        return {(Toffoli(), num_toff)}
+        return {Toffoli(): num_toff}
 
 
 @bloq_example
@@ -390,12 +390,12 @@ class ScaleIntByReal(Bloq):
     def pretty_name(self) -> str:
         return "r*i"
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Eq. D8, we are assuming dA(r_bitsize) and dB(i_bitsize) are inputs and
         # the user has ensured these are large enough for their desired
         # precision.
         num_toff = self.r_bitsize * (2 * self.i_bitsize - 1) - self.i_bitsize**2
-        return {(Toffoli(), num_toff)}
+        return {Toffoli(): num_toff}
 
 
 @bloq_example
@@ -447,10 +447,10 @@ class MultiplyTwoReals(Bloq):
     def pretty_name(self) -> str:
         return "a*b"
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Eq. D13, there it is suggested keeping both registers the same size is optimal.
         num_toff = self.bitsize**2 - self.bitsize - 1
-        return {(Toffoli(), num_toff)}
+        return {Toffoli(): num_toff}
 
 
 @bloq_example
@@ -506,10 +506,10 @@ class SquareRealNumber(Bloq):
     def pretty_name(self) -> str:
         return "a^2"
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Bottom of page 74
         num_toff = self.bitsize**2 // 2 - 4
-        return {(Toffoli(), num_toff)}
+        return {Toffoli(): num_toff}
 
 
 @bloq_example
@@ -562,7 +562,7 @@ class InvertRealNumber(Bloq):
     def pretty_name(self) -> str:
         return "1/a"
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # initial approximation: Figure 4
         num_int = self.bitsize - self.num_frac
         # Newton-Raphson: Eq. (1)
@@ -571,14 +571,14 @@ class InvertRealNumber(Bloq):
         # TODO: When decomposing we will potentially need to use larger registers.
         # Related issue: https://github.com/quantumlib/Qualtran/issues/655
         return {
-            (Toffoli(), num_int - 1),
-            (CNOT(), 2 + num_int - 1),
-            (MultiControlX(cvs=HasLength(num_int)), 1),
-            (XGate(), 1),
-            (SquareRealNumber(self.bitsize), num_iters),  # x^2
-            (MultiplyTwoReals(self.bitsize), num_iters),  # a * x^2
-            (ScaleIntByReal(self.bitsize, 2), num_iters),  # 2 * x
-            (Subtract(QUInt(self.bitsize)), num_iters),  # 2 * x - a * x^2
+            Toffoli(): num_int - 1,
+            CNOT(): 2 + num_int - 1,
+            MultiControlX(cvs=HasLength(num_int)): 1,
+            XGate(): 1,
+            SquareRealNumber(self.bitsize): num_iters,  # x^2
+            MultiplyTwoReals(self.bitsize): num_iters,  # a * x^2
+            ScaleIntByReal(self.bitsize, 2): num_iters,  # 2 * x
+            Subtract(QUInt(self.bitsize)): num_iters,  # 2 * x - a * x^2
         }
 
 

--- a/qualtran/bloqs/arithmetic/permutation.py
+++ b/qualtran/bloqs/arithmetic/permutation.py
@@ -129,8 +129,8 @@ class PermutationCycle(Bloq):
             x = ssa.new_symbol('x')
             cycle_len = slen(self.cycle)
             return {
-                (EqualsAConstant(self.bitsize, x), cycle_len + 1),
-                (XorK(QUInt(self.bitsize), x).controlled(), cycle_len),
+                EqualsAConstant(self.bitsize, x): cycle_len + 1,
+                XorK(QUInt(self.bitsize), x).controlled(): cycle_len,
             }
 
         return super().build_call_graph(ssa)
@@ -275,7 +275,7 @@ class Permutation(Bloq):
         if is_symbolic(self.cycles):
             # worst case cost: single cycle of length N
             cycle = Shaped((self.N,))
-            return {(PermutationCycle(self.N, cycle), 1)}
+            return {PermutationCycle(self.N, cycle): 1}
 
         return super().build_call_graph(ssa)
 

--- a/qualtran/bloqs/arithmetic/sorting.py
+++ b/qualtran/bloqs/arithmetic/sorting.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Dict, Set
+from typing import Dict
 
 import numpy as np
 import sympy
@@ -34,7 +34,7 @@ from qualtran import (
 )
 from qualtran.bloqs.arithmetic import GreaterThan
 from qualtran.bloqs.basic_gates import CSwap
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.symbolics import bit_length, is_symbolic, SymbolicInt
 
 
@@ -177,8 +177,8 @@ class ParallelComparators(Bloq):
 
         return {'xs': xs, 'junk': np.array(junk)}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(Comparator(self.bitsize), self.num_comparisons)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> BloqCountDictT:
+        return {Comparator(self.bitsize): self.num_comparisons}
 
 
 @bloq_example
@@ -281,8 +281,8 @@ class BitonicMerge(Bloq):
 
         return {'result': result, 'junk': np.array(junk)}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(Comparator(self.bitsize), self.num_comparisons)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> BloqCountDictT:
+        return {Comparator(self.bitsize): self.num_comparisons}
 
 
 @bloq_example
@@ -385,8 +385,8 @@ class BitonicSort(Bloq):
 
         return {'xs': xs, 'junk': junk}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> set['BloqCountT']:
-        return {(Comparator(self.bitsize), self.num_comparisons)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> BloqCountDictT:
+        return {Comparator(self.bitsize): self.num_comparisons}
 
 
 @bloq_example

--- a/qualtran/bloqs/arithmetic/trigonometric/arcsin.py
+++ b/qualtran/bloqs/arithmetic/trigonometric/arcsin.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Dict, Set
+from typing import Dict
 
 import numpy as np
 from attrs import frozen
@@ -20,7 +20,7 @@ from attrs import frozen
 from qualtran import Bloq, bloq_example, BloqDocSpec, QFxp, Register, Signature
 from qualtran.bloqs.basic_gates import Toffoli
 from qualtran.bloqs.rotations.phase_gradient import _fxp
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.simulation.classical_sim import ClassicalValT
 from qualtran.symbolics import is_symbolic, SymbolicInt
 
@@ -84,7 +84,7 @@ class ArcSin(Bloq):
         result ^= int(np.arcsin(x_fxp) * 2**self.bitsize)
         return {'x': x, 'result': result}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
         n = self.bitsize
         p = self.bitsize - self.num_frac
         d = self.degree
@@ -100,7 +100,7 @@ class ArcSin(Bloq):
             - 9 * p**2
             + 2
         )
-        return {(Toffoli(), toffolis)}
+        return {Toffoli(): toffolis}
 
 
 @bloq_example

--- a/qualtran/bloqs/arithmetic/trigonometric/arctan.py
+++ b/qualtran/bloqs/arithmetic/trigonometric/arctan.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from qualtran import GateWithRegisters, QFxp, Signature
 from qualtran.bloqs.arithmetic import PlusEqualProduct
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.symbolics import is_symbolic, SymbolicInt
 
 
@@ -76,12 +76,12 @@ class ArcTan(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[misc]
         )
         return input_val, target_sign ^ output_sign, target_val ^ output_bin
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> set['BloqCountT']:
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
         # Hack to propagate bigO(...). Here `c` is some constant.
         c = ssa.new_symbol("c")
 
         return {
-            (PlusEqualProduct(self.target_bitsize, self.target_bitsize, 2 * self.target_bitsize), c)
+            PlusEqualProduct(self.target_bitsize, self.target_bitsize, 2 * self.target_bitsize): c
         }
 
     def adjoint(self) -> 'ArcTan':

--- a/qualtran/bloqs/basic_gates/on_each.py
+++ b/qualtran/bloqs/basic_gates/on_each.py
@@ -14,7 +14,7 @@
 
 """Classes to apply single qubit bloq to multiple qubits."""
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple
+from typing import Dict, Optional, Tuple
 
 import attrs
 import sympy
@@ -32,7 +32,7 @@ from qualtran import (
 )
 from qualtran.drawing import Text, WireSymbol
 from qualtran.drawing.musical_score import TextBox
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.symbolics import SymbolicInt
 
 
@@ -78,8 +78,8 @@ class OnEach(Bloq):
             qs[i] = bb.add(self.gate, q=qs[i])
         return {'q': bb.join(qs, self.target_dtype)}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(self.gate, self.n)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {self.gate: self.n}
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> WireSymbol:
         one_reg = self.gate.wire_symbol(reg=reg, idx=idx)

--- a/qualtran/bloqs/basic_gates/power.py
+++ b/qualtran/bloqs/basic_gates/power.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Dict, Set, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING
 
 import numpy as np
 from attrs import frozen
@@ -23,7 +23,7 @@ from qualtran.symbolics import is_symbolic, SymbolicInt
 if TYPE_CHECKING:
     import cirq
 
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -66,8 +66,8 @@ class Power(GateWithRegisters):
             soqs = bb.add_d(self.bloq, **soqs)
         return soqs
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(self.bloq, self.power)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {self.bloq: self.power}
 
     def __pow__(self, power) -> 'Power':
         bloq = self.bloq.adjoint() if power < 0 else self.bloq

--- a/qualtran/bloqs/basic_gates/swap.py
+++ b/qualtran/bloqs/basic_gates/swap.py
@@ -13,18 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import (
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    TYPE_CHECKING,
-    Union,
-)
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import cirq
 import numpy as np
@@ -59,7 +48,7 @@ if TYPE_CHECKING:
     import quimb.tensor as qtn
 
     from qualtran import AddControlledT, CompositeBloq
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -203,8 +192,8 @@ class TwoBitCSwap(Bloq):
     def _t_complexity_(self) -> 'TComplexity':
         return TComplexity(t=7, clifford=10)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(TGate(), 7), (CNOT(), 8), (Hadamard(), 2)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {TGate(): 7, CNOT(): 8, Hadamard(): 2}
 
     def adjoint(self) -> 'Bloq':
         return self
@@ -250,8 +239,8 @@ class Swap(Bloq):
 
         return {'x': bb.join(xs), 'y': bb.join(ys)}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(TwoBitSwap(), self.bitsize)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {TwoBitSwap(): self.bitsize}
 
     def on_classical_vals(
         self, x: 'ClassicalValT', y: 'ClassicalValT'
@@ -329,8 +318,8 @@ class CSwap(GateWithRegisters):
 
         return {'ctrl': ctrl, 'x': bb.join(xs), 'y': bb.join(ys)}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(TwoBitCSwap(), self.bitsize)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {TwoBitCSwap(): self.bitsize}
 
     def on_classical_vals(
         self, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'

--- a/qualtran/bloqs/basic_gates/toffoli.py
+++ b/qualtran/bloqs/basic_gates/toffoli.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 import itertools
 from functools import cached_property
-from typing import Dict, List, Optional, Set, Tuple, TYPE_CHECKING, Union
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 from attrs import frozen
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
     from qualtran.cirq_interop import CirqQuregT
     from qualtran.drawing import WireSymbol
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -56,8 +56,8 @@ class Toffoli(Bloq):
     def adjoint(self) -> 'Bloq':
         return self
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(TGate(), 4)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {TGate(): 4}
 
     def _t_complexity_(self):
         return TComplexity(t=4)

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import cast, Dict, Iterable, List, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import cast, Dict, Iterable, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import numpy as np
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     import quimb.tensor as qtn
 
     from qualtran.cirq_interop import CirqQuregT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 _ZERO = np.array([1, 0], dtype=np.complex128)
 _ONE = np.array([0, 1], dtype=np.complex128)
@@ -431,8 +431,8 @@ class _IntVector(Bloq):
         assert val == self.val, val
         return {}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(ArbitraryClifford(self.bitsize), 1)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {ArbitraryClifford(self.bitsize): 1}
 
     def pretty_name(self) -> str:
         s = f'{self.val}'

--- a/qualtran/bloqs/block_encoding/chebyshev_polynomial.py
+++ b/qualtran/bloqs/block_encoding/chebyshev_polynomial.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Set, Tuple, TYPE_CHECKING, Union
+from typing import Dict, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import numpy as np
@@ -36,7 +36,11 @@ from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 from qualtran.symbolics import is_symbolic, SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import (
+        BloqCountDictT,
+        MutableBloqCountDictT,
+        SympySymbolAllocator,
+    )
 
 
 @attrs.frozen
@@ -138,14 +142,14 @@ class ChebyshevPolynomial(BlockEncoding):
             soqs |= bb.add_d(self.block_encoding, **soqs)
         return soqs
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         n = self.order
-        s: Set['BloqCountT'] = {
-            (self.block_encoding, n // 2 + n % 2),
-            (self.block_encoding.adjoint(), n // 2),
+        s: 'MutableBloqCountDictT' = {
+            self.block_encoding: n // 2 + n % 2,
+            self.block_encoding.adjoint(): n // 2,
         }
         if is_symbolic(self.ancilla_bitsize) or self.ancilla_bitsize > 0:
-            s.add((self.reflection_bloq, n - n % 2))
+            s[self.reflection_bloq] = n - n % 2
         return s
 
 

--- a/qualtran/bloqs/block_encoding/phase.py
+++ b/qualtran/bloqs/block_encoding/phase.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Set
+from typing import Dict
 
 from attrs import frozen
 
@@ -21,7 +21,7 @@ from qualtran import bloq_example, BloqBuilder, BloqDocSpec, QAny, Signature, So
 from qualtran.bloqs.basic_gates import GlobalPhase
 from qualtran.bloqs.block_encoding import BlockEncoding
 from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.symbolics import SymbolicFloat, SymbolicInt
 
 
@@ -82,8 +82,8 @@ class Phase(BlockEncoding):
     def signal_state(self) -> BlackBoxPrepare:
         return self.block_encoding.signal_state
 
-    def build_call_graph(self, ssa: SympySymbolAllocator) -> Set[BloqCountT]:
-        return {(self.block_encoding, 1), (GlobalPhase(exponent=self.phi, eps=self.eps), 1)}
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
+        return {self.block_encoding: 1, GlobalPhase(exponent=self.phi, eps=self.eps): 1}
 
     def build_composite_bloq(self, bb: BloqBuilder, **soqs: SoquetT) -> Dict[str, SoquetT]:
         bb.add(GlobalPhase(exponent=self.phi, eps=self.eps))

--- a/qualtran/bloqs/block_encoding/product.py
+++ b/qualtran/bloqs/block_encoding/product.py
@@ -14,7 +14,7 @@
 
 from collections import Counter
 from functools import cached_property
-from typing import cast, Dict, List, Sequence, Set, Tuple, Union
+from typing import cast, Dict, List, Sequence, Tuple, Union
 
 from attrs import field, frozen, validators
 from numpy.typing import NDArray
@@ -40,7 +40,7 @@ from qualtran.bloqs.bookkeeping.partition import Partition
 from qualtran.bloqs.mcmt import MultiControlX
 from qualtran.bloqs.reflections.prepare_identity import PrepareIdentity
 from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.resource_counting.generalizers import ignore_split_join
 from qualtran.symbolics import HasLength, is_symbolic, prod, smax, ssum, SymbolicFloat, SymbolicInt
 from qualtran.symbolics.math_funcs import is_zero
@@ -174,7 +174,7 @@ class Product(BlockEncoding):
             ret.append(AutoPartition(u, partition, left_only=False))
         return ret
 
-    def build_call_graph(self, ssa: SympySymbolAllocator) -> Set[BloqCountT]:
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
         counts = Counter[Bloq]()
         for bloq in self.constituents:
             counts[bloq] += 1
@@ -183,7 +183,7 @@ class Product(BlockEncoding):
             if not is_zero(u.ancilla_bitsize) and n - 1 > 0 and i != n - 1:
                 counts[MultiControlX(HasLength(u.ancilla_bitsize))] += 1
                 counts[XGate()] += 1
-        return set(counts.items())
+        return counts
 
     def build_composite_bloq(
         self, bb: BloqBuilder, system: SoquetT, **soqs: SoquetT

--- a/qualtran/bloqs/block_encoding/sparse_matrix.py
+++ b/qualtran/bloqs/block_encoding/sparse_matrix.py
@@ -14,7 +14,7 @@
 
 import abc
 from functools import cached_property
-from typing import Dict, Iterable, Set, Tuple
+from typing import Dict, Iterable, Tuple
 
 import numpy as np
 import sympy
@@ -46,7 +46,7 @@ from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 from qualtran.bloqs.state_preparation.prepare_uniform_superposition import (
     PrepareUniformSuperposition,
 )
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.simulation.classical_sim import ClassicalValT
 from qualtran.symbolics import is_symbolic, SymbolicFloat, SymbolicInt
 from qualtran.symbolics.math_funcs import bit_length
@@ -223,14 +223,14 @@ class SparseMatrix(BlockEncoding):
             ],
         )
 
-    def build_call_graph(self, ssa: SympySymbolAllocator) -> Set[BloqCountT]:
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
         return {
-            (self.diffusion, 1),
-            (self.col_oracle, 1),
-            (self.entry_oracle, 1),
-            (Swap(self.system_bitsize), 1),
-            (self.row_oracle.adjoint(), 1),
-            (self.diffusion.adjoint(), 1),
+            self.diffusion: 1,
+            self.col_oracle: 1,
+            self.entry_oracle: 1,
+            Swap(self.system_bitsize): 1,
+            self.row_oracle.adjoint(): 1,
+            self.diffusion.adjoint(): 1,
         }
 
     def build_composite_bloq(
@@ -331,10 +331,10 @@ class SymmetricBandedRowColumnOracle(RowColumnOracle):
             raise IndexError("l out of bounds")
         return ((l + i - self.bandsize) % (2**self.system_bitsize), i)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set[BloqCountT]:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> BloqCountDictT:
         return {
-            (Add(QUInt(self.system_bitsize), QUInt(self.system_bitsize)), 1),
-            (AddK(self.system_bitsize, -self.bandsize, signed=True), 1),
+            Add(QUInt(self.system_bitsize), QUInt(self.system_bitsize)): 1,
+            AddK(self.system_bitsize, -self.bandsize, signed=True): 1,
         }
 
     def build_composite_bloq(self, bb: BloqBuilder, l: SoquetT, i: SoquetT) -> Dict[str, SoquetT]:

--- a/qualtran/bloqs/block_encoding/tensor_product.py
+++ b/qualtran/bloqs/block_encoding/tensor_product.py
@@ -14,7 +14,7 @@
 
 from collections import Counter
 from functools import cached_property
-from typing import Dict, Set, Tuple
+from typing import Dict, Tuple
 
 from attrs import evolve, field, frozen, validators
 from typing_extensions import Self
@@ -32,7 +32,7 @@ from qualtran.bloqs.block_encoding import BlockEncoding
 from qualtran.bloqs.bookkeeping import Partition
 from qualtran.bloqs.reflections.prepare_identity import PrepareIdentity
 from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.symbolics import is_symbolic, prod, ssum, SymbolicFloat, SymbolicInt
 
 
@@ -109,8 +109,8 @@ class TensorProduct(BlockEncoding):
             # TODO: implement by taking tensor product of component signal states
             raise NotImplementedError
 
-    def build_call_graph(self, ssa: SympySymbolAllocator) -> Set[BloqCountT]:
-        return set(Counter(self.block_encodings).items())
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
+        return Counter(self.block_encodings)
 
     def build_composite_bloq(
         self, bb: BloqBuilder, system: SoquetT, **soqs: SoquetT

--- a/qualtran/bloqs/block_encoding/unitary.py
+++ b/qualtran/bloqs/block_encoding/unitary.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Set
+from typing import Dict
 
 from attrs import frozen
 
@@ -21,7 +21,7 @@ from qualtran import Bloq, bloq_example, BloqBuilder, BloqDocSpec, QAny, Side, S
 from qualtran.bloqs.block_encoding import BlockEncoding
 from qualtran.bloqs.reflections.prepare_identity import PrepareIdentity
 from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.symbolics import SymbolicFloat, SymbolicInt
 
 
@@ -77,8 +77,8 @@ class Unitary(BlockEncoding):
     def signal_state(self) -> BlackBoxPrepare:
         return BlackBoxPrepare(PrepareIdentity.from_bitsizes([self.ancilla_bitsize]))
 
-    def build_call_graph(self, ssa: SympySymbolAllocator) -> Set[BloqCountT]:
-        return {(self.U, 1)}
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
+        return {self.U: 1}
 
     def build_composite_bloq(
         self, bb: BloqBuilder, system: SoquetT, **soqs: SoquetT

--- a/qualtran/bloqs/chemistry/df/prepare.py
+++ b/qualtran/bloqs/chemistry/df/prepare.py
@@ -14,7 +14,7 @@
 r"""Bloqs for the state preparation of the DF Hamiltonian."""
 
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -27,7 +27,7 @@ from qualtran.bloqs.state_preparation.prepare_uniform_superposition import (
 )
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -71,12 +71,12 @@ class InnerPrepareDoubleFactorization(Bloq):
         nxi = (self.num_spin_orb // 2 - 1).bit_length()
         return Signature.build(xi=nxi, offset=nlxi, rot=self.num_bits_rot_aa, succ_p=1, p=nxi)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Step 3.
         num_bits_xi = (self.num_spin_orb // 2 - 1).bit_length()
         # uniform superposition state, requires controlled hadamards
         # https://github.com/quantumlib/Qualtran/issues/237
-        cost_a = (Toffoli(), 7 * num_bits_xi + 2 * self.num_bits_rot_aa - 6)
+        cost_a = 7 * num_bits_xi + 2 * self.num_bits_rot_aa - 6
         # add offset to get correct bit of QROM from [l + offset^l, l+offset^l+Xi^l]
         num_bits_lxi = (self.num_eig + self.num_spin_orb // 2 - 1).bit_length()
         cost_b = (Add(QUInt(num_bits_lxi)), 1)
@@ -84,8 +84,9 @@ class InnerPrepareDoubleFactorization(Bloq):
         bp = num_bits_xi + self.num_bits_state_prep + 2  # C31
         cost_c = (QROAM(self.num_eig + self.num_spin_orb // 2, bp), 1)
         # inequality tests + CSWAP
-        cost_d = (Toffoli(), self.num_bits_state_prep + num_bits_xi)
-        return {cost_a, cost_b, cost_c, cost_d}
+        cost_d = self.num_bits_state_prep + num_bits_xi
+        cost_a_and_d = (Toffoli(), cost_a + cost_d)
+        return dict([cost_a_and_d, cost_b, cost_c])
 
 
 @frozen
@@ -129,7 +130,7 @@ class OuterPrepareDoubleFactorization(Bloq):
     def signature(self) -> Signature:
         return Signature.build(l=self.num_aux.bit_length(), succ_l=1)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Listing 1 steps a-d
         num_bits_l = self.num_aux.bit_length()
         cost_a = (PrepareUniformSuperposition(self.num_aux + 1), 1)
@@ -137,10 +138,10 @@ class OuterPrepareDoubleFactorization(Bloq):
         output_size = num_bits_l + self.num_bits_state_prep
         cost_b = (QROAM(self.num_aux + 1, output_size), 1)
         # inequality test
-        cost_c = (Toffoli(), self.num_bits_state_prep)
+        cost_c = self.num_bits_state_prep
         # controlled swaps
-        cost_d = (Toffoli(), num_bits_l)
-        return {cost_a, cost_b, cost_c, cost_d}
+        cost_d = num_bits_l
+        return dict([cost_a, cost_b, (Toffoli(), cost_c + cost_d)])
 
 
 @frozen
@@ -192,12 +193,12 @@ class OutputIndexedData(Bloq):
             offset=nlxi,
         )
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # listing 2 C29/30 page 52
         num_bits_lxi = (self.num_eig + self.num_spin_orb // 2 - 1).bit_length()
         num_bits_xi = (self.num_spin_orb // 2 - 1).bit_length()
         bo = num_bits_xi + num_bits_lxi + self.num_bits_rot_aa + 1
-        return {(QROAM(self.num_aux + 1, bo), 1)}
+        return {QROAM(self.num_aux + 1, bo): 1}
 
 
 @bloq_example

--- a/qualtran/bloqs/chemistry/df/select_bloq.py
+++ b/qualtran/bloqs/chemistry/df/select_bloq.py
@@ -14,7 +14,7 @@
 r"""Bloqs for the applying number operators to system for the DF Hamiltonian."""
 
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -23,7 +23,7 @@ from qualtran.bloqs.basic_gates import Toffoli
 from qualtran.bloqs.chemistry.black_boxes import QROAM
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -73,7 +73,7 @@ class ProgRotGateArray(Bloq):
             ]
         )
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Step 4 in the reference.
         nlxi = (self.num_eig + self.num_spin_orb // 2 - 1).bit_length()
         nxi = (self.num_spin_orb // 2 - 1).bit_length()
@@ -81,6 +81,6 @@ class ProgRotGateArray(Bloq):
         data_size = self.num_eig + self.num_spin_orb // 2
         cost_c = self.num_spin_orb * (self.num_bits_rot - 2)  # apply rotations
         return {
-            (Toffoli(), (cost_a + cost_c)),
-            (QROAM(data_size, self.num_spin_orb * self.num_bits_rot // 2), 1),
+            Toffoli(): (cost_a + cost_c),
+            QROAM(data_size, self.num_spin_orb * self.num_bits_rot // 2): 1,
         }

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/prepare.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/prepare.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 r"""PREPARE for the first quantized chemistry Hamiltonian."""
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -21,7 +21,7 @@ from qualtran import Bloq, Signature
 from qualtran.bloqs.basic_gates import Toffoli
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -50,7 +50,7 @@ class UniformSuperpostionIJFirstQuantization(Bloq):
         n_eta = (self.eta - 1).bit_length()
         return Signature.build(i=n_eta, j=n_eta)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         n_eta = (self.eta - 1).bit_length()
         # Half of Eq. 62 which is the cost for prep and prep^\dagger
-        return {(Toffoli(), (7 * n_eta + 4 * self.num_bits_rot_aa - 18))}
+        return {Toffoli(): (7 * n_eta + 4 * self.num_bits_rot_aa - 18)}

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_nu.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_nu.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 r"""Bloqs for preparation of the U and V parts of the first quantized chemistry Hamiltonian."""
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 from attrs import evolve, frozen
 

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_nu.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_nu.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 r"""Bloqs for preparation of the U and V parts of the first quantized chemistry Hamiltonian."""
 from functools import cached_property
-from typing import Dict, Set, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING
 
 from attrs import evolve, frozen
 
@@ -25,7 +25,7 @@ from qualtran.bloqs.state_preparation.prepare_uniform_superposition import (
 )
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -60,8 +60,8 @@ class PrepareMuUnaryEncodedOneHot(Bloq):
     def pretty_name(self) -> str:
         return r'PREP √(2^μ)|μ⟩'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(Toffoli(), (self.num_bits_p - 1))}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {Toffoli(): (self.num_bits_p - 1)}
 
 
 @frozen
@@ -106,9 +106,9 @@ class PrepareNuSuperPositionState(Bloq):
     def pretty_name(self) -> str:
         return r'PREP (2^-μ)|μ⟩|ν⟩'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # controlled hadamards which cannot be inverted at zero Toffoli cost.
-        return {(Toffoli(), (3 * (self.num_bits_p - 1)))}
+        return {Toffoli(): (3 * (self.num_bits_p - 1))}
 
 
 @frozen
@@ -146,14 +146,14 @@ class FlagZeroAsFailure(Bloq):
     def adjoint(self) -> 'Bloq':
         return evolve(self, is_adjoint=not self.is_adjoint)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         if self.is_adjoint:
             # This can be inverted with cliffords.
-            return set()
+            return {}
         else:
             # Controlled Toffoli each having n_p + 1 controls and 2 Toffolis to
             # check the result of the Toffolis.
-            return {(Toffoli(), (3 * self.num_bits_p + 2))}
+            return {Toffoli(): (3 * self.num_bits_p + 2)}
 
 
 @frozen
@@ -192,13 +192,13 @@ class TestNuLessThanMu(Bloq):
     def pretty_name(self) -> str:
         return r'ν<2^(μ−2)'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         if self.is_adjoint:
             # This can be inverted with cliffords.
-            return {(Toffoli(), 0)}
+            return {Toffoli(): 0}
         else:
             # n_p controlled Toffolis with four controls.
-            return {(Toffoli(), 3 * self.num_bits_p)}
+            return {Toffoli(): 3 * self.num_bits_p}
 
 
 @frozen
@@ -263,9 +263,9 @@ class TestNuInequality(Bloq):
     def adjoint(self) -> 'Bloq':
         return evolve(self, is_adjoint=not self.is_adjoint)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         if self.is_adjoint:
-            return {(Toffoli(), 0)}
+            return {Toffoli(): 0}
         else:
             # 1. Compute $\nu_x^2 + \nu_y^2 + \nu_z^2$
             cost_1 = (SumOfSquares(self.num_bits_p, k=3), 1)
@@ -276,7 +276,7 @@ class TestNuInequality(Bloq):
             cost_3 = (GreaterThan(self.num_bits_m, 2 * self.num_bits_p + 2), 1)
             # 4. 3 Toffoli for overall success
             cost_4 = (Toffoli(), 3)
-            return {cost_1, cost_2, cost_3, cost_4}
+            return dict([cost_1, cost_2, cost_3, cost_4])
 
 
 @frozen
@@ -364,7 +364,7 @@ class PrepareNuState(Bloq):
         )
         return {'mu': mu, 'nu': nu, 'm': m, 'flag_nu': flag_nu}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # 1. Prepare unary encoded superposition state (Eq 77)
         cost_1 = (PrepareMuUnaryEncodedOneHot(self.num_bits_p), 1)
         n_m = (self.m_param - 1).bit_length()
@@ -377,4 +377,4 @@ class PrepareNuState(Bloq):
         # 5. Prepare superposition over $m$ which is a power of two so only clifford.
         # 6. Test that $(2^{\mu-2})^2\mathcal{M} > m (\nu_x^2 + \nu_y^2 + \nu_z^2)$
         cost_6 = (TestNuInequality(self.num_bits_p, n_m), 1)
-        return {cost_1, cost_2, cost_3, cost_4, cost_6}
+        return dict([cost_1, cost_2, cost_3, cost_4, cost_6])

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_t.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_t.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 r"""Bloqs for PREPARE T for the first quantized chemistry Hamiltonian."""
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 from attrs import frozen
 

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_t.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_t.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 r"""Bloqs for PREPARE T for the first quantized chemistry Hamiltonian."""
 from functools import cached_property
-from typing import Dict, Set, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING
 
 from attrs import frozen
 
@@ -24,7 +24,7 @@ from qualtran.bloqs.state_preparation.prepare_uniform_superposition import (
 )
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -58,8 +58,8 @@ class PreparePowerTwoState(Bloq):
     def pretty_name(self) -> str:
         return r'PREP 2^(r/2) |r⟩'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(Toffoli(), (self.bitsize - 2))}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {Toffoli(): (self.bitsize - 2)}
 
 
 @frozen
@@ -112,14 +112,13 @@ class PrepareTFirstQuantization(Bloq):
         s = bb.add(PreparePowerTwoState(self.num_bits_p), r=s)
         return {'w': w, 'r': r, 's': s}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # there is a cost for the uniform state preparation for the $w$
         # register. Adding a bloq is sort of overkill, should just tag the
         # correct cost on UniformSuperPosition bloq
-        # 13 is from assuming 8 bits for the rotation, and n = 2.
-        uni_prep_w = (Toffoli(), 13)
-        # Factor of two for r and s registers.
-        return {uni_prep_w, (PreparePowerTwoState(bitsize=self.num_bits_p), 2)}
+        # 13 Toffolis is from assuming 8 bits for the rotation, and n = 2.
+        # Factor of two for PreparePowerTwoState for r and s registers.
+        return {Toffoli(): 13, PreparePowerTwoState(bitsize=self.num_bits_p): 2}
 
 
 @bloq_example

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_uv.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_uv.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 r"""PREPARE the potential energy terms of the first quantized chemistry Hamiltonian."""
 from functools import cached_property
-from typing import Dict, Set, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING
 
 from attrs import frozen
 
@@ -32,7 +32,7 @@ from qualtran.bloqs.chemistry.pbc.first_quantization.prepare_nu import PrepareNu
 from qualtran.bloqs.chemistry.pbc.first_quantization.prepare_zeta import PrepareZetaState
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -93,12 +93,12 @@ class PrepareUVFirstQuantization(Bloq):
         l = bb.add(PrepareZetaState(self.num_atoms, self.lambda_zeta, self.num_bits_nuc_pos), l=l)
         return {'mu': mu, 'nu': nu, 'm': m, 'l': l, 'flag_nu': flag_nu}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # 1. Prepare the nu state
         # 2. Prepare the zeta_l state
         return {
-            (PrepareNuState(self.num_bits_p, self.m_param), 1),
-            (PrepareZetaState(self.num_atoms, self.lambda_zeta, self.num_bits_nuc_pos), 1),
+            PrepareNuState(self.num_bits_p, self.m_param): 1,
+            PrepareZetaState(self.num_atoms, self.lambda_zeta, self.num_bits_nuc_pos): 1,
         }
 
 

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_uv.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_uv.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 r"""PREPARE the potential energy terms of the first quantized chemistry Hamiltonian."""
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 from attrs import frozen
 

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_zeta.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/prepare_zeta.py
@@ -14,7 +14,7 @@
 r"""PREPARE the superposition over nuclear weights for the first quantized chemistry Hamiltonian.
 """
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import numpy as np
 from attrs import evolve, frozen
@@ -23,7 +23,7 @@ from qualtran import Bloq, QAny, Register, Signature
 from qualtran.bloqs.basic_gates import Toffoli
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -56,11 +56,11 @@ class PrepareZetaState(Bloq):
     def adjoint(self) -> 'Bloq':
         return evolve(self, is_adjoint=not self.is_adjoint)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         if self.is_adjoint:
             # Really Er(x), eq 91. In practice we will replace this with the
             # appropriate qrom call down the line.
-            return {(Toffoli(), int(np.ceil(self.lambda_zeta**0.5)))}
+            return {Toffoli(): int(np.ceil(self.lambda_zeta**0.5))}
         else:
 
-            return {(Toffoli(), self.lambda_zeta)}
+            return {Toffoli(): self.lambda_zeta}

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/prepare_uv.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/prepare_uv.py
@@ -14,7 +14,7 @@
 r"""PREPARE the potential energy terms of the first quantized chemistry Hamiltonian with projectile.
 """
 from functools import cached_property
-from typing import Dict, Set, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING
 
 from attrs import frozen
 
@@ -25,7 +25,7 @@ from qualtran.bloqs.chemistry.pbc.first_quantization.projectile.prepare_nu impor
 )
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -91,12 +91,12 @@ class PrepareUVFirstQuantizationWithProj(Bloq):
         l = bb.add(PrepareZetaState(self.num_atoms, self.lambda_zeta, self.num_bits_nuc_pos), l=l)
         return {'mu': mu, 'nu': nu, 'm': m, 'l': l, 'flag_nu': flag_nu}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # 1. Prepare the nu state
         # 2. Prepare the zeta_l state
         return {
-            (PrepareNuStateWithProj(self.num_bits_p, self.num_bits_n, self.m_param), 1),
-            (PrepareZetaState(self.num_atoms, self.lambda_zeta, self.num_bits_nuc_pos), 1),
+            PrepareNuStateWithProj(self.num_bits_p, self.num_bits_n, self.m_param): 1,
+            PrepareZetaState(self.num_atoms, self.lambda_zeta, self.num_bits_nuc_pos): 1,
         }
 
 

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_and_prepare.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_and_prepare.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 r"""SELECT and PREPARE for the first quantized chemistry Hamiltonian with a quantum projectile."""
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 from attrs import evolve, field, frozen
@@ -55,7 +55,7 @@ from qualtran.bloqs.swap_network import MultiplexedCSwap
 from qualtran.drawing import Circle, Text, TextBox, WireSymbol
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -106,12 +106,12 @@ class PrepareTUVSuperpositions(Bloq):
     def pretty_name(self) -> str:
         return 'PREP TUV'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         if self.is_adjoint:
             # inverting inequality tests at zero Toffoli.
-            return set()
+            return {}
         else:
-            return {(Toffoli(), 6 * self.num_bits_t + 2)}
+            return {Toffoli(): 6 * self.num_bits_t + 2}
 
 
 @frozen

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_t.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_t.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 r"""Bloqs for SELECT T for the first quantized chemistry Hamiltonian with a quantum projectile."""
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -21,7 +21,7 @@ from qualtran import Bloq, bloq_example, QAny, QBit, Register, Signature
 from qualtran.bloqs.basic_gates import Toffoli
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -72,11 +72,11 @@ class SelectTFirstQuantizationWithProj(Bloq):
     def pretty_name(self) -> str:
         return r'SEL T'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Modification of the SEL T costs from the first quantized bloq with n_p replace with n_n.
         # The + 1 is from an additional Toffoli for the selection between the
         # square and the product of the momentum offset of the projectile.
-        return {(Toffoli(), (5 * (self.num_bits_n - 1) + 2 + 1))}
+        return {Toffoli(): (5 * (self.num_bits_n - 1) + 2 + 1)}
 
 
 @bloq_example

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_uv.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_uv.py
@@ -80,17 +80,21 @@ class SelectUVFirstQuantizationWithProj(Bloq):
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         cost = Counter['Bloq']()
+        # tc_p and tc_n
         # C8 and C9, one of the registers of size num_bits_n so need to account for this.
         cost[SignedIntegerToTwosComplement(self.num_bits_p)] += 3
         cost[SignedIntegerToTwosComplement(self.num_bits_n)] += 3
         # Adding nu into p / q. Nu is one bit larger than p.
         cost[Add(QInt(self.num_bits_p + 1))] += 3
         cost[Add(QInt(self.num_bits_n + 1))] += 3
+        # ctrl_add_p and ctrl_add_n
         cost[Toffoli()] += 3 * (self.num_bits_p + 1)
         cost[Toffoli()] += 3 * (self.num_bits_n + 1)
+        # inv_tc_p and inv_tc_n
         # + 2 as these numbers are larger from addition of $\nu$
         cost[SignedIntegerToTwosComplement(self.num_bits_p + 2)] += 3
         cost[SignedIntegerToTwosComplement(self.num_bits_n + 2)] += 3
+        # cost for phase:
         # 2. Phase by $e^{ik\cdot R}$ in the case of $U$ only.
         cost[ApplyNuclearPhase(self.num_bits_n, self.num_bits_nuc_pos)] += 1
         return cost

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_uv.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_uv.py
@@ -24,7 +24,7 @@ from qualtran.bloqs.basic_gates import Toffoli
 from qualtran.bloqs.chemistry.pbc.first_quantization.select_uv import ApplyNuclearPhase
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, BloqCountT, SympySymbolAllocator
 
 
 @frozen

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_uv.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_uv.py
@@ -12,8 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 r"""Bloqs for SELECT for the U and V parts of the first quantized chemistry Hamiltonian."""
+from collections import Counter
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -77,32 +78,22 @@ class SelectUVFirstQuantizationWithProj(Bloq):
     def pretty_name(self) -> str:
         return r'SEL UV'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        cost = Counter['Bloq']()
         # C8 and C9, one of the registers of size num_bits_n so need to account for this.
-        cost_tc_p = (SignedIntegerToTwosComplement(self.num_bits_p), 3)
-        cost_tc_n = (SignedIntegerToTwosComplement(self.num_bits_n), 3)
+        cost[SignedIntegerToTwosComplement(self.num_bits_p)] += 3
+        cost[SignedIntegerToTwosComplement(self.num_bits_n)] += 3
         # Adding nu into p / q. Nu is one bit larger than p.
-        cost_add_p = (Add(QInt(self.num_bits_p + 1)), 3)
-        cost_add_n = (Add(QInt(self.num_bits_n + 1)), 3)
-        cost_ctrl_add_p = (Toffoli(), 3 * (self.num_bits_p + 1))
-        cost_ctrl_add_n = (Toffoli(), 3 * (self.num_bits_n + 1))
+        cost[Add(QInt(self.num_bits_p + 1))] += 3
+        cost[Add(QInt(self.num_bits_n + 1))] += 3
+        cost[Toffoli()] += 3 * (self.num_bits_p + 1)
+        cost[Toffoli()] += 3 * (self.num_bits_n + 1)
         # + 2 as these numbers are larger from addition of $\nu$
-        cost_inv_tc_p = (SignedIntegerToTwosComplement(self.num_bits_p + 2), 3)
-        cost_inv_tc_n = (SignedIntegerToTwosComplement(self.num_bits_n + 2), 3)
+        cost[SignedIntegerToTwosComplement(self.num_bits_p + 2)] += 3
+        cost[SignedIntegerToTwosComplement(self.num_bits_n + 2)] += 3
         # 2. Phase by $e^{ik\cdot R}$ in the case of $U$ only.
-        cost_phase = (ApplyNuclearPhase(self.num_bits_n, self.num_bits_nuc_pos), 1)
-        return {
-            cost_tc_p,
-            cost_tc_n,
-            cost_tc_n,
-            cost_add_p,
-            cost_add_n,
-            cost_ctrl_add_n,
-            cost_ctrl_add_p,
-            cost_inv_tc_p,
-            cost_inv_tc_n,
-            cost_phase,
-        }
+        cost[ApplyNuclearPhase(self.num_bits_n, self.num_bits_nuc_pos)] += 1
+        return cost
 
 
 @bloq_example

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/select_and_prepare.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/select_and_prepare.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 r"""SELECT and PREPARE for the first quantized chemistry Hamiltonian."""
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 from attrs import frozen
@@ -45,7 +45,7 @@ from qualtran.symbolics import SymbolicFloat
 
 if TYPE_CHECKING:
     from qualtran import Soquet
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -76,11 +76,11 @@ class PrepareTUVSuperpositions(Bloq):
     def pretty_name(self) -> str:
         return 'PREP TUV'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         n_eta_zeta = (self.eta + 2 * self.lambda_zeta - 1).bit_length()
         # The cost arises from rotating a qubit, and uniform state preparation
         # over eta + 2 lambda_zeta numbers along.
-        return {(Toffoli(), self.num_bits_t + 4 * n_eta_zeta + 2 * self.num_bits_rot_aa - 12)}
+        return {Toffoli(): self.num_bits_t + 4 * n_eta_zeta + 2 * self.num_bits_rot_aa - 12}
 
 
 @frozen
@@ -108,10 +108,10 @@ class UniformSuperpostionIJFirstQuantization(Bloq):
         n_eta = (self.eta - 1).bit_length()
         return Signature.build(i=n_eta, j=n_eta)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         n_eta = (self.eta - 1).bit_length()
         # Half of Eq. 62 which is the cost for prep and prep^\dagger
-        return {(Toffoli(), (7 * n_eta + 4 * self.num_bits_rot_aa - 18))}
+        return {Toffoli(): (7 * n_eta + 4 * self.num_bits_rot_aa - 18)}
 
 
 @frozen

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/select_t.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/select_t.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 r"""Bloqs for SELECT T for the first quantized chemistry Hamiltonian."""
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -21,7 +21,7 @@ from qualtran import Bloq, bloq_example, BloqDocSpec, QAny, QBit, Register, Sign
 from qualtran.bloqs.basic_gates import Toffoli
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -60,15 +60,15 @@ class SelectTFirstQuantization(Bloq):
     def pretty_name(self) -> str:
         return r'SEL T'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Cost is $5(n_{p} - 1) + 2$ which comes from copying each $w$ component of $p$
         # into an ancilla register ($3(n_{p}-1)$), copying the $r$ and $s$ bit of into an
         # ancilla ($2(n_{p}-1)$), controlling on both those bit perform phase flip on an
         # ancilla $|+\rangle$ state. This requires $1$ Toffoli, Then erase which costs
         # only Cliffords. There is an additional control bit controlling the application
         # of $T$ thus we come to our total.
-        # Eq 73. page
-        return {(Toffoli(), (5 * (self.num_bits_p - 1) + 2))}
+        # Eq 73, page 20.
+        return {Toffoli(): (5 * (self.num_bits_p - 1) + 2)}
 
 
 @bloq_example

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/select_uv.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/select_uv.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 r"""Bloqs for SELECT for the U and V parts of the first quantized chemistry Hamiltonian."""
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -22,7 +22,7 @@ from qualtran.bloqs.arithmetic import Add, SignedIntegerToTwosComplement
 from qualtran.bloqs.basic_gates import Toffoli
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -59,7 +59,7 @@ class ApplyNuclearPhase(Bloq):
     def pretty_name(self) -> str:
         return r'-e^(-k_ν⋅R_l)'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         n_p = self.num_bits_p
         n_n = self.num_bits_nuc
         # This is some complicated application of phase gradient gates.
@@ -68,7 +68,7 @@ class ApplyNuclearPhase(Bloq):
             cost = 3 * (2 * n_p * n_n - n_p * (n_p + 1) - 1)
         else:
             cost = 3 * n_n * (n_n - 1)
-        return {(Toffoli(), cost)}
+        return {Toffoli(): cost}
 
 
 @frozen
@@ -114,7 +114,7 @@ class SelectUVFirstQuantization(Bloq):
     def pretty_name(self) -> str:
         return r'SEL UV'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         cost_tc = (SignedIntegerToTwosComplement(self.num_bits_p), 6)
         cost_add = (Add(QInt(self.num_bits_p + 1)), 6)  # + 2?
         cost_ctrl_add = (Toffoli(), 6 * (self.num_bits_p + 1))
@@ -122,7 +122,7 @@ class SelectUVFirstQuantization(Bloq):
         cost_inv_tc = (SignedIntegerToTwosComplement(self.num_bits_p + 2), 6)
         # 2. Phase by $e^{ik\cdot R}$ in the case of $U$ only.
         cost_phase = (ApplyNuclearPhase(self.num_bits_p, self.num_bits_nuc_pos), 1)
-        return {cost_tc, cost_add, cost_ctrl_add, cost_inv_tc, cost_phase}
+        return dict([cost_tc, cost_add, cost_ctrl_add, cost_inv_tc, cost_phase])
 
 
 @bloq_example

--- a/qualtran/bloqs/chemistry/sf/prepare.py
+++ b/qualtran/bloqs/chemistry/sf/prepare.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -27,7 +27,7 @@ from qualtran.bloqs.state_preparation.prepare_uniform_superposition import (
 )
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -77,7 +77,7 @@ class InnerPrepareSingleFactorization(Bloq):
         n = (self.num_spin_orb // 2 - 1).bit_length()
         return Signature.build(l=self.num_aux.bit_length(), p=n, q=n, succ_pq=1)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         n = (self.num_spin_orb // 2 - 1).bit_length()
         # 2. a prep uniform upper triangular.
         cost_up_tri = (Toffoli(), 6 * n + 2 * self.num_bits_rot_aa - 7)
@@ -100,7 +100,7 @@ class InnerPrepareSingleFactorization(Bloq):
         # inequality test
         cost_ineq = (LessThanEqual(self.num_bits_state_prep, self.num_bits_state_prep), 1)
         cost_swap = (CSwap(2 * n), 1)
-        return {cost_up_tri, cost_contg_indx, cost_qroam, cost_ineq, cost_swap}
+        return dict([cost_up_tri, cost_contg_indx, cost_qroam, cost_ineq, cost_swap])
 
 
 @frozen
@@ -140,7 +140,7 @@ class OuterPrepareSingleFactorization(Bloq):
     def signature(self) -> Signature:
         return Signature.build(l=self.num_aux.bit_length(), succ_l=1, l_ne_zero=1, rot_aa=1)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # 1.a
         cost_uni = (PrepareUniformSuperposition(self.num_aux + 1), 1)
         num_bits_l = (self.num_aux + 1).bit_length()
@@ -151,7 +151,7 @@ class OuterPrepareSingleFactorization(Bloq):
         cost_ineq = (LessThanEqual(self.num_bits_state_prep, self.num_bits_state_prep), 1)
         # 1.d swap alt/keep values
         cost_swap = (CSwap(num_bits_l + 1), 1)
-        return {cost_uni, cost_qroam, cost_ineq, cost_swap}
+        return dict([cost_uni, cost_qroam, cost_ineq, cost_swap])
 
 
 @bloq_example

--- a/qualtran/bloqs/chemistry/sf/select_bloq.py
+++ b/qualtran/bloqs/chemistry/sf/select_bloq.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -21,7 +21,7 @@ from qualtran import Bloq, bloq_example, Signature
 from qualtran.bloqs.basic_gates import Toffoli
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -54,8 +54,8 @@ class SelectSingleFactorization(Bloq):
         n = (self.num_spin_orb // 2 - 1).bit_length()
         return Signature.build(p=n, q=n, spin=1, succ_pq=1, succ_l=1)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(Toffoli(), 2 * (self.num_spin_orb - 2))}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {Toffoli(): 2 * (self.num_spin_orb - 2)}
 
 
 @bloq_example

--- a/qualtran/bloqs/chemistry/sf/single_factorization.py
+++ b/qualtran/bloqs/chemistry/sf/single_factorization.py
@@ -23,7 +23,7 @@ electron repulsion integrals.
 """
 
 from functools import cached_property
-from typing import Dict, Iterable, Set, TYPE_CHECKING
+from typing import Dict, Iterable, TYPE_CHECKING
 
 import numpy as np
 from attrs import evolve, frozen
@@ -55,7 +55,7 @@ from qualtran.bloqs.reflections.reflection_using_prepare import ReflectionUsingP
 from qualtran.bloqs.state_preparation.black_box_prepare import BlackBoxPrepare
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -250,7 +250,7 @@ class SingleFactorizationOneBody(BlockEncoding):
             'sys': sys,
         }
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         iprep = InnerPrepareSingleFactorization(
             self.num_aux,
             self.num_spin_orb,
@@ -269,11 +269,11 @@ class SingleFactorizationOneBody(BlockEncoding):
         ).adjoint()
         n = (self.num_spin_orb // 2 - 1).bit_length()
         return {
-            (iprep, 1),
-            (iprep_dag, 1),
-            (CSwap(n), 2),
-            (SelectSingleFactorization(num_spin_orb=self.num_spin_orb), 1),
-            (Hadamard(), 4),
+            iprep: 1,
+            iprep_dag: 1,
+            CSwap(n): 2,
+            SelectSingleFactorization(num_spin_orb=self.num_spin_orb): 1,
+            Hadamard(): 4,
         }
 
 

--- a/qualtran/bloqs/chemistry/sparse/prepare.py
+++ b/qualtran/bloqs/chemistry/sparse/prepare.py
@@ -15,7 +15,7 @@
 
 import itertools
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 import attrs
 import numpy as np
@@ -51,7 +51,7 @@ from qualtran.symbolics import SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran import Bloq
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 def get_sparse_inputs_from_integrals(
@@ -422,15 +422,15 @@ class PrepareSparse(PrepareOracle):
         )
         return soqs
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return {
-            (PrepareUniformSuperposition(self.num_non_zero), 1),
-            (self.build_qrom_bloq(), 1),
-            (OnEach(self.num_bits_state_prep, Hadamard()), 1),
-            (Hadamard(), 3),
-            (CSwap(1), 1),
-            (CSwap(self.num_bits_spat_orb), 4 + 4),
-            (LessThanEqual(self.num_bits_state_prep, self.num_bits_state_prep), 1),
+            PrepareUniformSuperposition(self.num_non_zero): 1,
+            self.build_qrom_bloq(): 1,
+            OnEach(self.num_bits_state_prep, Hadamard()): 1,
+            Hadamard(): 3,
+            CSwap(1): 1,
+            CSwap(self.num_bits_spat_orb): 4 + 4,
+            LessThanEqual(self.num_bits_state_prep, self.num_bits_state_prep): 1,
         }
 
 

--- a/qualtran/bloqs/chemistry/sparse/select_bloq.py
+++ b/qualtran/bloqs/chemistry/sparse/select_bloq.py
@@ -14,7 +14,7 @@
 """SELECT for the sparse chemistry Hamiltonian in second quantization."""
 
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 import cirq
 from attrs import frozen
@@ -26,7 +26,7 @@ from qualtran.bloqs.multiplexers.select_base import SelectOracle
 from qualtran.bloqs.multiplexers.selected_majorana_fermion import SelectedMajoranaFermion
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -143,7 +143,7 @@ class SelectSparse(SpecializedSingleQubitControlledExtension, SelectOracle):  # 
             out_soqs['control'] = soqs['control']
         return out_soqs
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Pg 30, enumeration 1: 2 applications of SELECT in Fig. 13, one of
         # which is not controlled (for the two body part of the Ham). The figure
         # is a bit misleading as applying that circuit twice would square the
@@ -155,7 +155,7 @@ class SelectSparse(SpecializedSingleQubitControlledExtension, SelectOracle):  # 
         maj_y = SelectedMajoranaFermion(sel_pa, target_gate=cirq.Y, control_regs=())
         c_maj_x = SelectedMajoranaFermion(sel_pa, target_gate=cirq.X)
         c_maj_y = SelectedMajoranaFermion(sel_pa, target_gate=cirq.Y)
-        return {(SGate(), 1), (maj_x, 1), (c_maj_x, 1), (maj_y, 1), (c_maj_y, 1)}
+        return {SGate(): 1, maj_x: 1, c_maj_x: 1, maj_y: 1, c_maj_y: 1}
 
 
 @bloq_example

--- a/qualtran/bloqs/chemistry/thc/prepare.py
+++ b/qualtran/bloqs/chemistry/thc/prepare.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 """PREPARE for the molecular tensor hypercontraction (THC) hamiltonian"""
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 import cirq
 import numpy as np
@@ -53,7 +53,7 @@ from qualtran.resource_counting.generalizers import ignore_cliffords, ignore_spl
 from qualtran.symbolics import SymbolicFloat
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -462,7 +462,7 @@ class PrepareTHC(PrepareOracle):
         }
         return out_regs
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         cost_1 = (UniformSuperpositionTHC(self.num_mu, self.num_spin_orb), 1)
         nmu = self.num_mu.bit_length()
         data_size = self.num_spin_orb // 2 + self.num_mu * (self.num_mu + 1) // 2
@@ -478,7 +478,7 @@ class PrepareTHC(PrepareOracle):
         cost_5 = (LessThanEqual(self.keep_bitsize, self.keep_bitsize), 2)
         cost_6 = (CSwap(nmu), 3)
         cost_7 = (Toffoli(), 1)
-        return {cost_1, cost_2, cost_3, cost_4, cost_5, cost_6, cost_7}
+        return dict([cost_1, cost_2, cost_3, cost_4, cost_5, cost_6, cost_7])
 
 
 @bloq_example

--- a/qualtran/bloqs/chemistry/thc/select_bloq.py
+++ b/qualtran/bloqs/chemistry/thc/select_bloq.py
@@ -14,7 +14,7 @@
 
 """SELECT for the molecular tensor hypercontraction (THC) hamiltonian"""
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 from attrs import evolve, frozen
@@ -37,7 +37,7 @@ from qualtran.bloqs.chemistry.black_boxes import ApplyControlledZs
 from qualtran.bloqs.multiplexers.select_base import SelectOracle
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -95,7 +95,7 @@ class THCRotations(Bloq):
         dag = '†' if self.is_adjoint else ''
         return f"In_mu-R{dag}"
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # from listings on page 17 of Ref. [1]
         num_data_sets = self.num_mu + self.num_spin_orb // 2
         if self.is_adjoint:
@@ -116,7 +116,7 @@ class THCRotations(Bloq):
         # xref https://github.com/quantumlib/Qualtran/issues/370, the cost below
         # assume a phase gradient.
         rot_cost = self.num_spin_orb * (self.num_bits_theta - 2)
-        return {(Toffoli(), (rot_cost + toff_cost_qrom))}
+        return {Toffoli(): (rot_cost + toff_cost_qrom)}
 
 
 @frozen

--- a/qualtran/bloqs/chemistry/trotter/grid_ham/qvr.py
+++ b/qualtran/bloqs/chemistry/trotter/grid_ham/qvr.py
@@ -14,7 +14,7 @@
 """Quantum Variable Rotation."""
 
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -22,7 +22,7 @@ from qualtran import Bloq, bloq_example, BloqDocSpec, QAny, Register, Signature
 from qualtran.bloqs.basic_gates import Rz
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -55,10 +55,10 @@ class QuantumVariableRotation(Bloq):
     def pretty_name(self) -> str:
         return 'e^{i*phi}'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         theta = ssa.new_symbol('theta')
         # need to update rotation bloq.
-        return {(Rz(theta), self.phi_bitsize)}
+        return {Rz(theta): self.phi_bitsize}
 
 
 @bloq_example

--- a/qualtran/bloqs/chemistry/trotter/hubbard/interaction.py
+++ b/qualtran/bloqs/chemistry/trotter/hubbard/interaction.py
@@ -14,7 +14,7 @@
 r"""Bloqs implementing unitary evolution under the interacting part of the Hubbard Hamiltonian."""
 
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -24,7 +24,7 @@ from qualtran.bloqs.rotations.hamming_weight_phasing import HammingWeightPhasing
 from qualtran.symbolics import SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -62,9 +62,9 @@ class Interaction(Bloq):
     def signature(self) -> Signature:
         return Signature([Register('system', QAny(self.length), shape=(2,))])
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Page 13 paragraph 1.
-        return {(Rz(angle=self.angle * self.hubb_u, eps=self.eps), self.length**2)}
+        return {Rz(angle=self.angle * self.hubb_u, eps=self.eps): self.length**2}
 
 
 @frozen
@@ -105,9 +105,9 @@ class InteractionHWP(Bloq):
     def signature(self) -> Signature:
         return Signature([Register('system', QAny(self.length), shape=(2,))])
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return {
-            (HammingWeightPhasing(self.length**2 // 2, self.angle * self.hubb_u, eps=self.eps), 2)
+            HammingWeightPhasing(self.length**2 // 2, self.angle * self.hubb_u, eps=self.eps): 2
         }
 
 

--- a/qualtran/bloqs/data_loading/qroam_clean.py
+++ b/qualtran/bloqs/data_loading/qroam_clean.py
@@ -14,7 +14,7 @@
 import numbers
 from collections import defaultdict
 from functools import cached_property
-from typing import cast, Dict, List, Optional, Set, Tuple, Type, TYPE_CHECKING, Union
+from typing import cast, Dict, List, Optional, Tuple, Type, TYPE_CHECKING, Union
 
 import attrs
 import numpy as np
@@ -30,7 +30,7 @@ from qualtran.symbolics import ceil, is_symbolic, log2, prod, SymbolicFloat, Sym
 if TYPE_CHECKING:
     from qualtran import Bloq, BloqBuilder, SoquetT, QDType
     from qualtran.simulation.classical_sim import ClassicalValT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 from qualtran.bloqs.data_loading.select_swap_qrom import _alloc_anc_for_reg, SelectSwapQROM
 
@@ -174,11 +174,11 @@ class QROAMCleanAdjoint(QROMBase, GateWithRegisters):  # type: ignore[misc]
             assert all(1 <= 2**bs <= ilen for bs, ilen in zip(log_block_sizes, self.data_shape))
         return attrs.evolve(self, log_block_sizes=log_block_sizes)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         block_sizes = prod([2**k for k in self.log_block_sizes])
         data_size = prod(self.data_shape)
         n_toffoli = ceil(data_size / block_sizes) + block_sizes
-        return {(Toffoli(), n_toffoli)}
+        return {Toffoli(): n_toffoli}
 
     @cached_property
     def signature(self) -> Signature:
@@ -260,11 +260,11 @@ class QROAMCleanAdjointWrapper(Bloq):
         soqs = bb.add_d(self.qroam_clean_adjoint_bloq, **soqs)
         return soqs
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         block_sizes = prod([2**k for k in self.log_block_sizes])
         data_size = prod(self.qroam_clean.data_shape)
         n_toffoli = ceil(data_size / block_sizes) + block_sizes
-        return {(Toffoli(), n_toffoli)}
+        return {Toffoli(): n_toffoli}
 
     def adjoint(self) -> 'QROAMClean':
         return self.qroam_clean
@@ -437,13 +437,13 @@ class QROAMClean(SelectSwapQROM):
                 junk_regs += [attrs.evolve(reg, name='junk_' + reg.name, shape=(block_size - 1,))]
         return tuple(junk_regs)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         ret: Dict[Bloq, SymbolicInt] = defaultdict(lambda: 0)
         ret[self.qrom_bloq] += 1
         for swz in self.swap_with_zero_bloqs:
             if any(is_symbolic(s) or s > 0 for s in swz.selection_bitsizes):
                 ret[swz] += 1
-        return set(ret.items())
+        return ret
 
     def _build_composite_bloq_with_swz_clean(
         self,

--- a/qualtran/bloqs/data_loading/qrom.py
+++ b/qualtran/bloqs/data_loading/qrom.py
@@ -217,7 +217,7 @@ class QROM(QROMBase, UnaryIterationGate):  # type: ignore[misc]
         n_cnot = prod(
             bitsize * prod(sh) for bitsize, sh in zip(self.target_bitsizes, self.target_shapes)
         ) * prod(self.data_shape)
-        return {(And(), n_and), (And().adjoint(), n_and), (CNOT(), n_cnot)}
+        return {And(): n_and, And().adjoint(): n_and, CNOT(): n_cnot}
 
     def adjoint(self) -> 'QROM':
         return self

--- a/qualtran/bloqs/data_loading/select_swap_qrom.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom.py
@@ -14,7 +14,7 @@
 import numbers
 from collections import defaultdict
 from functools import cached_property
-from typing import cast, Dict, List, Optional, Set, Tuple, Type, TYPE_CHECKING, TypeVar, Union
+from typing import cast, Dict, List, Optional, Tuple, Type, TYPE_CHECKING, TypeVar, Union
 
 import attrs
 import cirq
@@ -33,7 +33,7 @@ from qualtran.symbolics import ceil, is_symbolic, log2, prod, SymbolicFloat, Sym
 
 if TYPE_CHECKING:
     from qualtran import Bloq, BloqBuilder, QDType, SoquetT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 SelSwapQROM_T = TypeVar('SelSwapQROM_T', bound='SelectSwapQROM')
 
@@ -255,7 +255,7 @@ class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
             for target_bitsize in self.target_bitsizes
         ]
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         ret: Dict[Bloq, SymbolicInt] = defaultdict(lambda: 0)
         toggle_overhead = 2 if self.use_dirty_ancilla else 1
         ret[self.qrom_bloq] += 1
@@ -266,7 +266,7 @@ class SelectSwapQROM(QROMBase, GateWithRegisters):  # type: ignore[misc]
             if any(is_symbolic(s) or s > 0 for s in swz.selection_bitsizes):
                 ret[swz] += toggle_overhead
                 ret[swz.adjoint()] += toggle_overhead
-        return set(ret.items())
+        return ret
 
     def _add_qrom_bloq(
         self,

--- a/qualtran/bloqs/factoring/ecc/ec_add.py
+++ b/qualtran/bloqs/factoring/ecc/ec_add.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Set
 
 import sympy
 from attrs import frozen
@@ -21,7 +20,7 @@ from qualtran import Bloq, bloq_example, BloqDocSpec, QUInt, Register, Signature
 from qualtran.bloqs.arithmetic._shims import MultiCToffoli
 from qualtran.bloqs.mod_arithmetic import CModAdd, CModNeg, CModSub, ModAdd, ModNeg, ModSub
 from qualtran.bloqs.mod_arithmetic._shims import ModDbl, ModInv, ModMul
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -64,19 +63,19 @@ class ECAdd(Bloq):
             ]
         )
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # litinksi
         return {
-            (MultiCToffoli(n=self.n), 18),
-            (ModAdd(bitsize=self.n, mod=self.mod), 3),
-            (CModAdd(QUInt(self.n), mod=self.mod), 2),
-            (ModSub(QUInt(self.n), mod=self.mod), 2),
-            (CModSub(QUInt(self.n), mod=self.mod), 4),
-            (ModNeg(QUInt(self.n), mod=self.mod), 2),
-            (CModNeg(QUInt(self.n), mod=self.mod), 1),
-            (ModDbl(QUInt(self.n), mod=self.mod), 2),
-            (ModMul(n=self.n, mod=self.mod), 10),
-            (ModInv(n=self.n, mod=self.mod), 4),
+            MultiCToffoli(n=self.n): 18,
+            ModAdd(bitsize=self.n, mod=self.mod): 3,
+            CModAdd(QUInt(self.n), mod=self.mod): 2,
+            ModSub(QUInt(self.n), mod=self.mod): 2,
+            CModSub(QUInt(self.n), mod=self.mod): 4,
+            ModNeg(QUInt(self.n), mod=self.mod): 2,
+            CModNeg(QUInt(self.n), mod=self.mod): 1,
+            ModDbl(QUInt(self.n), mod=self.mod): 2,
+            ModMul(n=self.n, mod=self.mod): 10,
+            ModInv(n=self.n, mod=self.mod): 4,
         }
 
 

--- a/qualtran/bloqs/factoring/ecc/ec_phase_estimate_r.py
+++ b/qualtran/bloqs/factoring/ecc/ec_phase_estimate_r.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Set
+from typing import Dict
 
 import sympy
 from attrs import frozen
@@ -31,7 +31,7 @@ from qualtran import (
     SoquetT,
 )
 from qualtran.bloqs.basic_gates import PlusState
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 from ._ecc_shims import MeasureQFT
 from .ec_add_r import ECAddR
@@ -67,8 +67,8 @@ class ECPhaseEstimateR(Bloq):
         bb.add(MeasureQFT(n=self.n), x=ctrl)
         return {'x': x, 'y': y}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(ECAddR(n=self.n, R=self.point), self.n), (MeasureQFT(n=self.n), 1)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {ECAddR(n=self.n, R=self.point): self.n, MeasureQFT(n=self.n): 1}
 
     def pretty_name(self) -> str:
         point_str = str(self.point)

--- a/qualtran/bloqs/factoring/ecc/find_ecc_private_key.py
+++ b/qualtran/bloqs/factoring/ecc/find_ecc_private_key.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Set
+from typing import Dict
 
 import sympy
 from attrs import frozen
@@ -21,7 +21,7 @@ from attrs import frozen
 from qualtran import Bloq, bloq_example, BloqBuilder, BloqDocSpec, QUInt, Signature, SoquetT
 from qualtran.bloqs.basic_gates import IntState
 from qualtran.bloqs.bookkeeping import Free
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.symbolics import SymbolicInt
 
 from .ec_phase_estimate_r import ECPhaseEstimateR
@@ -103,12 +103,12 @@ class FindECCPrivateKey(Bloq):
         bb.add(Free(QUInt(self.n)), reg=y)
         return {}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         Rx = ssa.new_symbol('Rx')
         Ry = ssa.new_symbol('Ry')
         generic_point = ECPoint(Rx, Ry, mod=self.mod, curve_a=self.curve_a)
 
-        return {(ECPhaseEstimateR(n=self.n, point=generic_point), 2)}
+        return {ECPhaseEstimateR(n=self.n, point=generic_point): 2}
 
     def cost_attrs(self):
         return [('n', self.n)]

--- a/qualtran/bloqs/factoring/mod_exp.py
+++ b/qualtran/bloqs/factoring/mod_exp.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 import math
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import attrs
 import numpy as np
@@ -36,7 +36,7 @@ from qualtran import (
 from qualtran.bloqs.basic_gates import IntState
 from qualtran.bloqs.mod_arithmetic import CModMulK
 from qualtran.drawing import Text, WireSymbol
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.resource_counting.generalizers import ignore_split_join
 
 
@@ -118,12 +118,9 @@ class ModExp(Bloq):
 
         return {'exponent': bb.join(exponent, dtype=QUInt(self.exp_bitsize)), 'x': x}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         k = ssa.new_symbol('k')
-        return {
-            (IntState(val=1, bitsize=self.x_bitsize), 1),
-            (self._CtrlModMul(k=k), self.exp_bitsize),
-        }
+        return {IntState(val=1, bitsize=self.x_bitsize): 1, self._CtrlModMul(k=k): self.exp_bitsize}
 
     def on_classical_vals(self, exponent: int):
         return {'exponent': exponent, 'x': (self.base**exponent) % self.mod}

--- a/qualtran/bloqs/for_testing/costing.py
+++ b/qualtran/bloqs/for_testing/costing.py
@@ -11,12 +11,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Any, Sequence, Set, Tuple
+from typing import Any, Sequence, Tuple
 
 from attrs import field, frozen
 
 from qualtran import Bloq, Signature
-from qualtran.resource_counting import BloqCountT, CostKey, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, BloqCountT, CostKey, SympySymbolAllocator
 
 
 def _convert_callees(callees: Sequence[BloqCountT]) -> Tuple[BloqCountT, ...]:
@@ -46,8 +46,8 @@ class CostingBloq(Bloq):
     def signature(self) -> 'Signature':
         return Signature.build(register=self.num_qubits)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return set(self.callees)
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return dict(self.callees)
 
     def my_static_costs(self, cost_key: 'CostKey'):
         return dict(self.static_costs).get(cost_key, NotImplemented)

--- a/qualtran/bloqs/for_testing/with_call_graph.py
+++ b/qualtran/bloqs/for_testing/with_call_graph.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Set, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from attrs import frozen
 
@@ -22,7 +22,7 @@ from qualtran.bloqs.for_testing.atom import TestAtom
 from qualtran.bloqs.for_testing.with_decomposition import TestParallelCombo, TestSerialCombo
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -33,6 +33,6 @@ class TestBloqWithCallGraph(Bloq):
     def signature(self) -> Signature:
         return Signature.build()
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         n = ssa.new_symbol('n')
-        return {(TestParallelCombo(), 1), (TestSerialCombo(), 1), (TestAtom(), n)}
+        return {TestParallelCombo(): 1, TestSerialCombo(): 1, TestAtom(): n}

--- a/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp.py
+++ b/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 from collections import Counter
 from functools import cached_property
-from typing import cast, Dict, Set, Tuple, TYPE_CHECKING, Union
+from typing import cast, Dict, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 from attrs import field, frozen
@@ -32,7 +32,7 @@ from qualtran.symbolics import is_symbolic, Shaped, SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, SoquetT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -182,7 +182,7 @@ class HamiltonianSimulationByGQSP(Bloq):
 
         return soqs
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         counts = Counter[Bloq]()
 
         d = self.degree
@@ -192,7 +192,7 @@ class HamiltonianSimulationByGQSP(Bloq):
         counts[self.walk_operator.adjoint().controlled()] += d
         counts[SU2RotationGate.arbitrary(ssa)] += 2 * d + 1
 
-        return set(counts.items())
+        return counts
 
 
 @bloq_example

--- a/qualtran/bloqs/mcmt/controlled_via_and.py
+++ b/qualtran/bloqs/mcmt/controlled_via_and.py
@@ -24,7 +24,7 @@ from qualtran.bloqs.mcmt.ctrl_spec_and import CtrlSpecAnd
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, SoquetT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -112,7 +112,7 @@ class ControlledViaAnd(Controlled):
 
         return soqs
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         counts: Counter[Bloq] = Counter()
         counts[self.subbloq.controlled()] += 1
 
@@ -124,7 +124,7 @@ class ControlledViaAnd(Controlled):
             counts[ctrl] += 1
             counts[ctrl.adjoint()] += 1
 
-        return set(counts.items())
+        return counts
 
 
 @bloq_example

--- a/qualtran/bloqs/mcmt/ctrl_spec_and.py
+++ b/qualtran/bloqs/mcmt/ctrl_spec_and.py
@@ -41,7 +41,7 @@ from qualtran.symbolics import HasLength, is_symbolic, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, SoquetT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -171,13 +171,13 @@ class CtrlSpecAnd(Bloq):
             pretty_text = reg.name
         return directional_text_box(text=pretty_text, side=reg.side)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         if not is_symbolic(self.n_ctrl_qubits) and self.n_ctrl_qubits == 2:
             assert isinstance(self._flat_cvs, tuple)
             cv1, cv2 = self._flat_cvs
-            return {(And(cv1, cv2), 1)}
+            return {And(cv1, cv2): 1}
 
-        return {(MultiAnd(self._flat_cvs), 1)}
+        return {MultiAnd(self._flat_cvs): 1}
 
 
 @bloq_example(generalizer=ignore_split_join)

--- a/qualtran/bloqs/mod_arithmetic/mod_addition.py
+++ b/qualtran/bloqs/mod_arithmetic/mod_addition.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING, Union
+from typing import Dict, Optional, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 import sympy
@@ -38,7 +38,7 @@ from qualtran.bloqs.arithmetic.controlled_addition import CAdd
 from qualtran.bloqs.basic_gates import XGate
 from qualtran.bloqs.bookkeeping import Cast
 from qualtran.drawing import Circle, Text, TextBox, WireSymbol
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.resource_counting.generalizers import ignore_split_join
 from qualtran.simulation.classical_sim import ClassicalValT
 from qualtran.symbolics import is_symbolic
@@ -143,13 +143,13 @@ class ModAdd(Bloq):
         # Return the output registers.
         return {'x': x, 'y': y}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return {
-            (Add(QUInt(self.bitsize + 1)), 1),
-            (AddK(self.bitsize + 1, k=-self.mod), 1),
-            (AddK(self.bitsize, k=self.mod).controlled(), 1),
-            (LinearDepthGreaterThan(self.bitsize), 1),
-            (XGate(), 1),
+            Add(QUInt(self.bitsize + 1)): 1,
+            AddK(self.bitsize + 1, k=-self.mod): 1,
+            AddK(self.bitsize, k=self.mod).controlled(): 1,
+            LinearDepthGreaterThan(self.bitsize): 1,
+            XGate(): 1,
         }
 
     def short_name(self) -> str:
@@ -229,8 +229,8 @@ class ModAddK(GateWithRegisters):
     def __pow__(self, power: int) -> 'ModAddK':
         return ModAddK(self.bitsize, self.mod, add_val=self.add_val * power, cvs=self.cvs)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(Add(QUInt(self.bitsize), QUInt(self.bitsize)), 5)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {Add(QUInt(self.bitsize), QUInt(self.bitsize)): 5}
 
 
 @bloq_example
@@ -279,9 +279,9 @@ class CModAddK(Bloq):
     def signature(self) -> 'Signature':
         return Signature([Register('ctrl', QBit()), Register('x', QUInt(self.bitsize))])
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         k = ssa.new_symbol('k')
-        return {(AddK(k=k, bitsize=self.bitsize).controlled(), 5)}
+        return {AddK(k=k, bitsize=self.bitsize).controlled(): 5}
 
     def short_name(self) -> str:
         return f'x += {self.k} % {self.mod}'
@@ -316,9 +316,9 @@ class CtrlScaleModAdd(Bloq):
             ]
         )
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         k = ssa.new_symbol('k')
-        return {(CModAddK(k=k, bitsize=self.bitsize, mod=self.mod), self.bitsize)}
+        return {CModAddK(k=k, bitsize=self.bitsize, mod=self.mod): self.bitsize}
 
     def on_classical_vals(
         self, ctrl: 'ClassicalValT', x: 'ClassicalValT', y: 'ClassicalValT'
@@ -424,13 +424,13 @@ class CModAdd(Bloq):
 
         return {'ctrl': ctrl, 'x': x, 'y': y}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return {
-            (CAdd(QUInt(self.dtype.bitsize), QUInt(self.dtype.bitsize + 1), cv=self.cv), 1),
-            (AddK(self.dtype.bitsize + 1, -self.mod, signed=False), 1),
-            (AddK(self.dtype.bitsize, self.mod, cvs=(1,), signed=False), 1),
-            (CLinearDepthGreaterThan(QUInt(self.dtype.bitsize), cv=self.cv), 1),
-            (XGate(), 1),
+            CAdd(QUInt(self.dtype.bitsize), QUInt(self.dtype.bitsize + 1), cv=self.cv): 1,
+            AddK(self.dtype.bitsize + 1, -self.mod, signed=False): 1,
+            AddK(self.dtype.bitsize, self.mod, cvs=(1,), signed=False): 1,
+            CLinearDepthGreaterThan(QUInt(self.dtype.bitsize), cv=self.cv): 1,
+            XGate(): 1,
         }
 
 

--- a/qualtran/bloqs/mod_arithmetic/mod_multiplication.py
+++ b/qualtran/bloqs/mod_arithmetic/mod_multiplication.py
@@ -14,7 +14,7 @@
 
 import numbers
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import attrs
 import numpy as np
@@ -38,7 +38,7 @@ from qualtran.bloqs.arithmetic.addition import AddK
 from qualtran.bloqs.basic_gates import CNOT, CSwap, XGate
 from qualtran.bloqs.mod_arithmetic.mod_addition import CtrlScaleModAdd
 from qualtran.drawing import Circle, directional_text_box, Text, WireSymbol
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.resource_counting.generalizers import ignore_alloc_free, ignore_split_join
 from qualtran.simulation.classical_sim import ClassicalValT
 from qualtran.symbolics import is_symbolic
@@ -134,12 +134,12 @@ class ModDbl(Bloq):
             return Text(f'x = 2 * x mod {self.mod}')
         return super().wire_symbol(reg, idx)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
         return {
-            (AddK(self.dtype.bitsize + 2, -self.mod, signed=False), 1),
-            (AddK(self.dtype.bitsize + 1, self.mod, cvs=(1,), signed=False), 1),
-            (CNOT(), 1),
-            (XGate(), 2),
+            AddK(self.dtype.bitsize + 2, -self.mod, signed=False): 1,
+            AddK(self.dtype.bitsize + 1, self.mod, cvs=(1,), signed=False): 1,
+            CNOT(): 1,
+            XGate(): 2,
         }
 
 
@@ -221,9 +221,9 @@ class CModMulK(Bloq):
         bb.free(y)
         return {'ctrl': ctrl, 'x': x}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
         k = ssa.new_symbol('k')
-        return {(self._Add(k=k), 2), (CSwap(self.dtype.bitsize), 1)}
+        return {self._Add(k=k): 2, CSwap(self.dtype.bitsize): 1}
 
     def on_classical_vals(self, ctrl, x) -> Dict[str, ClassicalValT]:
         if ctrl and x < self.mod:

--- a/qualtran/bloqs/mod_arithmetic/mod_subtraction.py
+++ b/qualtran/bloqs/mod_arithmetic/mod_subtraction.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Dict, Optional, Set, Tuple, TYPE_CHECKING, Union
+from typing import Dict, Optional, Tuple, TYPE_CHECKING, Union
 
 import sympy
 from attrs import frozen
@@ -39,7 +39,7 @@ from qualtran.drawing import Circle, Text, TextBox, WireSymbol
 from qualtran.symbolics import HasLength
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
     from qualtran.symbolics import SymbolicInt
 
@@ -100,18 +100,18 @@ class ModNeg(Bloq):
         bb.free(ancilla)
         return {'x': x}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         cvs: Union[list[int], HasLength]
         if isinstance(self.dtype.bitsize, int):
             cvs = [0] * self.dtype.bitsize
         else:
             cvs = HasLength(self.dtype.bitsize)
         return {
-            (MultiControlX(cvs), 1),
-            (MultiControlX(cvs).adjoint(), 1),
-            (MultiTargetCNOT(self.dtype.bitsize), 1),
-            (AddK(self.dtype.bitsize, k=self.mod + 1, cvs=(1), signed=False), 1),
-            (XGate(), 2),
+            MultiControlX(cvs): 1,
+            MultiControlX(cvs).adjoint(): 1,
+            MultiTargetCNOT(self.dtype.bitsize): 1,
+            AddK(self.dtype.bitsize, k=self.mod + 1, cvs=(1), signed=False): 1,
+            XGate(): 2,
         }
 
     def wire_symbol(
@@ -194,20 +194,20 @@ class CModNeg(Bloq):
         bb.free(ancilla)
         return {'ctrl': ctrl, 'x': x}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         cvs: Union[list[int], HasLength]
         if isinstance(self.dtype.bitsize, int):
             cvs = [0] * self.dtype.bitsize
         else:
             cvs = HasLength(self.dtype.bitsize)
         return {
-            (MultiControlX(cvs), 1),
-            (MultiControlX(cvs).adjoint(), 1),
-            (And(self.cv, 1), 1),
-            (And(self.cv, 1).adjoint(), 1),
-            (MultiTargetCNOT(self.dtype.bitsize), 1),
-            (AddK(self.dtype.bitsize, k=self.mod + 1, cvs=(1,), signed=False), 1),
-            (XGate(), 2),
+            MultiControlX(cvs): 1,
+            MultiControlX(cvs).adjoint(): 1,
+            And(self.cv, 1): 1,
+            And(self.cv, 1).adjoint(): 1,
+            MultiTargetCNOT(self.dtype.bitsize): 1,
+            AddK(self.dtype.bitsize, k=self.mod + 1, cvs=(1,), signed=False): 1,
+            XGate(): 2,
         }
 
     def wire_symbol(
@@ -285,12 +285,12 @@ class ModSub(Bloq):
         x = bb.add(BitwiseNot(self.dtype), x=x)
         return {'x': x, 'y': y}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return {
-            (BitwiseNot(self.dtype), 2),
-            (AddK(self.dtype.bitsize, self.mod + 1, signed=False), 1),
-            (AddK(self.dtype.bitsize, self.mod + 1, signed=False).adjoint(), 1),
-            (ModAdd(self.dtype.bitsize, self.mod), 1),
+            BitwiseNot(self.dtype): 2,
+            AddK(self.dtype.bitsize, self.mod + 1, signed=False): 1,
+            AddK(self.dtype.bitsize, self.mod + 1, signed=False).adjoint(): 1,
+            ModAdd(self.dtype.bitsize, self.mod): 1,
         }
 
     def wire_symbol(
@@ -365,12 +365,12 @@ class CModSub(Bloq):
         x = bb.add(BitwiseNot(self.dtype), x=x)
         return {'ctrl': ctrl, 'x': x, 'y': y}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return {
-            (BitwiseNot(self.dtype), 2),
-            (AddK(self.dtype.bitsize, self.mod + 1, signed=False), 1),
-            (AddK(self.dtype.bitsize, self.mod + 1, signed=False).adjoint(), 1),
-            (CModAdd(self.dtype, self.mod, self.cv), 1),
+            BitwiseNot(self.dtype): 2,
+            AddK(self.dtype.bitsize, self.mod + 1, signed=False): 1,
+            AddK(self.dtype.bitsize, self.mod + 1, signed=False).adjoint(): 1,
+            CModAdd(self.dtype, self.mod, self.cv): 1,
         }
 
     def wire_symbol(

--- a/qualtran/bloqs/multiplexers/unary_iteration_bloq.py
+++ b/qualtran/bloqs/multiplexers/unary_iteration_bloq.py
@@ -625,6 +625,6 @@ class UnaryIterationGate(GateWithRegisters):
 
         try:
             unary_iteration_loops(0, {}, total_bits(self.control_registers))
-            return {(bloq, count) for bloq, count in bloq_counts.items()}
+            return bloq_counts
         except NotImplementedError:
             return super().build_call_graph(ssa)

--- a/qualtran/bloqs/phase_estimation/kaiser_window_state.py
+++ b/qualtran/bloqs/phase_estimation/kaiser_window_state.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Dict, List, Set, TYPE_CHECKING
+from typing import Dict, List, TYPE_CHECKING
 
 import attrs
 import numpy as np
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     import quimb.tensor as qtn
 
     from qualtran import ConnectionT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @attrs.frozen
@@ -118,7 +118,7 @@ class KaiserWindowState(QPEWindowStateBase):
             )
         ]
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         from qualtran.bloqs.state_preparation.state_preparation_via_rotation import (
             StatePreparationViaRotations,
         )
@@ -127,7 +127,7 @@ class KaiserWindowState(QPEWindowStateBase):
             state_prep_coeff = HasLength(2**self.bitsize)
         else:
             state_prep_coeff = self.kaiser_state_coeff.tolist()
-        return {(StatePreparationViaRotations(state_prep_coeff, self.bitsize), 1)}
+        return {StatePreparationViaRotations(state_prep_coeff, self.bitsize): 1}
 
 
 @bloq_example

--- a/qualtran/bloqs/phase_estimation/qubitization_qpe.py
+++ b/qualtran/bloqs/phase_estimation/qubitization_qpe.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Iterator, Set, Tuple, TYPE_CHECKING
+from typing import Iterator, Tuple, TYPE_CHECKING
 
 import attrs
 import cirq
@@ -33,7 +33,7 @@ from qualtran.bloqs.qubitization.qubitization_walk_operator import QubitizationW
 from qualtran.symbolics import is_symbolic, SymbolicInt
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @attrs.frozen
@@ -131,15 +131,15 @@ class QubitizationQPE(GateWithRegisters):
             yield reflect_controlled.on_registers(control=qpre_reg[i], **reflect_regs)
         yield self.qft_inv.on(*qpre_reg)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Assumes self.unitary is not fast forwardable.
         M = 2**self.m_bits
         return {
-            (self.ctrl_state_prep, 1),
-            (self.walk.controlled(), 1),
-            (self.walk.reflect.controlled(ctrl_spec=CtrlSpec(cvs=0)), 2 * (self.m_bits - 1)),
-            (self.walk, M - 2),
-            (self.qft_inv, 1),
+            self.ctrl_state_prep: 1,
+            self.walk.controlled(): 1,
+            self.walk.reflect.controlled(ctrl_spec=CtrlSpec(cvs=0)): 2 * (self.m_bits - 1),
+            self.walk: M - 2,
+            self.qft_inv: 1,
         }
 
 

--- a/qualtran/bloqs/phase_estimation/text_book_qpe.py
+++ b/qualtran/bloqs/phase_estimation/text_book_qpe.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Iterator, Set, Tuple, TYPE_CHECKING
+from typing import Iterator, Tuple, TYPE_CHECKING
 
 import attrs
 import cirq
@@ -23,7 +23,7 @@ from qualtran.bloqs.qft.qft_text_book import QFTTextBook
 from qualtran.symbolics import is_symbolic, SymbolicInt
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @attrs.frozen
@@ -180,12 +180,12 @@ class TextbookQPE(GateWithRegisters):
             yield cirq.pow(unitary_op.controlled_by(qbit), 2**i)
         yield self.qft_inv.on(*phase_qubits)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         # Assumes self.unitary is not fast forwardable.
         return {
-            (self.ctrl_state_prep, 1),
-            (self.unitary.controlled(), (2**self.m_bits) - 1),
-            (self.qft_inv, 1),
+            self.ctrl_state_prep: 1,
+            self.unitary.controlled(): (2**self.m_bits) - 1,
+            self.qft_inv: 1,
         }
 
 

--- a/qualtran/bloqs/qft/approximate_qft.py
+++ b/qualtran/bloqs/qft/approximate_qft.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 from collections import defaultdict
 from functools import cached_property
-from typing import Dict, Iterator, Set, TYPE_CHECKING
+from typing import Iterator, TYPE_CHECKING
 
 import attrs
 import cirq
@@ -28,7 +28,11 @@ from qualtran.bloqs.rotations import AddIntoPhaseGrad
 from qualtran.symbolics import ceil, is_symbolic, log2, SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import (
+        BloqCountDictT,
+        MutableBloqCountDictT,
+        SympySymbolAllocator,
+    )
 
 
 @attrs.frozen
@@ -130,8 +134,8 @@ class ApproximateQFT(GateWithRegisters):
             for i in range(self.bitsize // 2):
                 yield cirq.SWAP(q[i], q[-i - 1])
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        phase_dict: Dict[AddIntoPhaseGrad, SymbolicInt] = defaultdict(int)
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        phase_dict: 'MutableBloqCountDictT' = defaultdict(int)
         if is_symbolic(self.bitsize, self.phase_bitsize):
             phase_dict[
                 AddIntoPhaseGrad(
@@ -142,10 +146,10 @@ class ApproximateQFT(GateWithRegisters):
             for i in range(1, int(self.bitsize)):
                 b = min(i, self.phase_bitsize - 1)
                 phase_dict[AddIntoPhaseGrad(b, b + 1, right_shift=1, controlled_by=1)] += 1
-        ret = {(Hadamard(), self.bitsize), *phase_dict.items()}
+        phase_dict[Hadamard()] = self.bitsize
         if self.with_reverse:
-            ret |= {(TwoBitSwap(), self.bitsize // 2)}
-        return ret
+            phase_dict[TwoBitSwap()] = self.bitsize // 2
+        return phase_dict
 
 
 @bloq_example

--- a/qualtran/bloqs/qft/two_bit_ffft.py
+++ b/qualtran/bloqs/qft/two_bit_ffft.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Dict, List, Set, TYPE_CHECKING
+from typing import Dict, List, TYPE_CHECKING
 
 import numpy as np
 from attrs import frozen
@@ -41,7 +41,7 @@ from qualtran.symbolics.types import SymbolicFloat
 if TYPE_CHECKING:
     import quimb.tensor as qtn
 
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 def _fkn_matrix(k: int, n: int) -> NDArray[np.complex128]:
@@ -105,13 +105,13 @@ class TwoBitFFFT(Bloq):
             qtn.Tensor(data=matrix.reshape((2,) * 4), inds=out_inds + in_inds, tags=[str(self)])
         ]
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return {
-            (Rz(2 * np.pi * self.k / self.n, eps=self.eps), 1),
-            (SGate(), 3),
-            (Hadamard(), 6),
-            (TGate(), 2),
-            (CNOT(), 3),
+            Rz(2 * np.pi * self.k / self.n, eps=self.eps): 1,
+            SGate(): 3,
+            Hadamard(): 6,
+            TGate(): 2,
+            CNOT(): 3,
         }
 
     def build_composite_bloq(

--- a/qualtran/bloqs/qsp/generalized_qsp.py
+++ b/qualtran/bloqs/qsp/generalized_qsp.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 from collections import Counter
 from functools import cached_property
-from typing import Iterable, Iterator, Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import Iterable, Iterator, Sequence, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 from attrs import field, frozen
@@ -47,7 +47,7 @@ from qualtran.symbolics import (
 if TYPE_CHECKING:
     import cirq
 
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 def qsp_complementary_polynomial(
@@ -369,7 +369,7 @@ class GeneralizedQSP(GateWithRegisters):
     def is_symbolic(self) -> bool:
         return is_symbolic(self.P, self.Q, self.negative_power)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         counts = Counter[Bloq]()
 
         degree = slen(self.P) - 1
@@ -380,7 +380,7 @@ class GeneralizedQSP(GateWithRegisters):
         counts[self.U.adjoint()] += smax(0, self.negative_power - degree)
         counts[self.U.adjoint().controlled()] += smin(degree, self.negative_power)
 
-        return set((bloq, count) for bloq, count in counts.items() if not is_zero(count))
+        return {bloq: count for bloq, count in counts.items() if not is_zero(count)}
 
 
 @bloq_example

--- a/qualtran/bloqs/reflections/reflection_using_prepare.py
+++ b/qualtran/bloqs/reflections/reflection_using_prepare.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Iterator, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import Iterator, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import cirq
@@ -33,7 +33,11 @@ from qualtran.symbolics import HasLength, is_symbolic, SymbolicInt
 if TYPE_CHECKING:
     from qualtran.bloqs.block_encoding.lcu_block_encoding import BlackBoxPrepare
     from qualtran.bloqs.state_preparation.prepare_base import PrepareOracle
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import (
+        BloqCountDictT,
+        MutableBloqCountDictT,
+        SympySymbolAllocator,
+    )
 
 
 @attrs.frozen(cache_hash=True)
@@ -162,21 +166,21 @@ class ReflectionUsingPrepare(GateWithRegisters, SpecializedSingleQubitControlled
         wire_symbols += ['R_L'] * total_bits(self.selection_registers)
         return cirq.CircuitDiagramInfo(wire_symbols=wire_symbols)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         n_phase_control = sum(reg.total_bits() for reg in self.selection_registers)
         cvs = HasLength(n_phase_control) if is_symbolic(n_phase_control) else [0] * n_phase_control
-        costs: Set['BloqCountT'] = {
-            (self.prepare_gate, 1),
-            (self.prepare_gate.adjoint(), 1),
-            (MultiControlZ(cvs), 1),
+        costs: 'MutableBloqCountDictT' = {
+            self.prepare_gate: 1,
+            self.prepare_gate.adjoint(): 1,
+            MultiControlZ(cvs): 1,
         }
         if self.control_val is None:
-            costs.add((XGate(), 2))
+            costs[XGate()] = 2
         if self.global_phase != 1:
             phase_op: Bloq = GlobalPhase.from_coefficient(self.global_phase, eps=self.eps)
             if self.control_val is not None:
                 phase_op = phase_op.controlled(ctrl_spec=CtrlSpec(cvs=self.control_val))
-            costs.add((phase_op, 1))
+            costs[phase_op] = 1
         return costs
 
     def adjoint(self) -> 'ReflectionUsingPrepare':

--- a/qualtran/bloqs/rotations/hamming_weight_phasing.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Set, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING
 
 import attrs
 import numpy as np
@@ -26,7 +26,7 @@ from qualtran.symbolics import SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, SoquetT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @attrs.frozen
@@ -96,14 +96,13 @@ class HammingWeightPhasing(GateWithRegisters):
     def pretty_name(self) -> str:
         return f'HWP_{self.bitsize}(Z^{self.exponent})'
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return {
-            (HammingWeightCompute(self.bitsize), 1),
-            (HammingWeightCompute(self.bitsize).adjoint(), 1),
-            (
-                ZPowGate(exponent=self.exponent, eps=self.eps / self.bitsize.bit_length()),
-                self.bitsize.bit_length(),
-            ),
+            HammingWeightCompute(self.bitsize): 1,
+            HammingWeightCompute(self.bitsize).adjoint(): 1,
+            ZPowGate(
+                exponent=self.exponent, eps=self.eps / self.bitsize.bit_length()
+            ): self.bitsize.bit_length(),
         }
 
 

--- a/qualtran/bloqs/rotations/phase_gradient.py
+++ b/qualtran/bloqs/rotations/phase_gradient.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Dict, Iterator, List, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import Dict, Iterator, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import cirq
@@ -42,7 +42,7 @@ from qualtran.symbolics.types import is_symbolic
 if TYPE_CHECKING:
     import quimb.tensor as qtn
 
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
     from qualtran.symbolics import SymbolicFloat, SymbolicInt
 
@@ -128,20 +128,19 @@ class PhaseGradientUnitary(GateWithRegisters):
             return self
         return attrs.evolve(self, exponent=self.exponent * power)
 
-    def build_call_graph(self, ssa: SympySymbolAllocator) -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> 'BloqCountDictT':
         gate = CZPowGate if self.is_controlled else ZPowGate
         if is_symbolic(self.bitsize):
             return {
-                (
-                    gate(exponent=self.exponent / 2 ** (self.bitsize), eps=self.eps / self.bitsize),
-                    self.bitsize,
-                )
+                gate(
+                    exponent=self.exponent / 2 ** (self.bitsize), eps=self.eps / self.bitsize
+                ): self.bitsize
             }
 
-        ret: Set['BloqCountT'] = set()
-        for i in range(self.bitsize):
-            ret.add((gate(exponent=self.exponent / 2**i, eps=self.eps / self.bitsize), 1))
-        return ret
+        return {
+            gate(exponent=self.exponent / 2**i, eps=self.eps / self.bitsize): 1
+            for i in range(self.bitsize)
+        }
 
 
 @bloq_example
@@ -324,12 +323,12 @@ class AddIntoPhaseGrad(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[
         phase_grad_out = (phase_grad + self.sign * self.scaled_val(x)) % (2**self.phase_bitsize)
         return {'x': x, 'phase_grad': phase_grad_out}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         num_toffoli = self.phase_bitsize - 2
         if self.controlled_by is not None:
-            return {(Toffoli(), 2 * num_toffoli)}
+            return {Toffoli(): 2 * num_toffoli}
 
-        return {(Toffoli(), num_toffoli)}
+        return {Toffoli(): num_toffoli}
 
     def adjoint(self) -> 'AddIntoPhaseGrad':
         return attrs.evolve(self, sign=-self.sign)
@@ -514,7 +513,7 @@ class AddScaledValIntoPhaseReg(GateWithRegisters, cirq.ArithmeticGate):  # type:
         phase_grad_out = (phase_grad + self.scaled_val(x)) % 2**self.phase_bitsize
         return {'x': x, 'phase_grad': phase_grad_out}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         num_additions = (self.gamma_dtype.bitsize + 2) // 2
         if not isinstance(self.gamma, sympy.Basic):
             num_additions_naive = 0
@@ -525,7 +524,7 @@ class AddScaledValIntoPhaseReg(GateWithRegisters, cirq.ArithmeticGate):  # type:
                 if -(self.phase_bitsize + self.x_dtype.num_int) < shift < self.x_dtype.num_frac:
                     num_additions_naive += 1
             num_additions = min(num_additions_naive, num_additions)
-        return {(AddIntoPhaseGrad(self.x_dtype.bitsize, self.phase_bitsize), num_additions)}
+        return {AddIntoPhaseGrad(self.x_dtype.bitsize, self.phase_bitsize): num_additions}
 
 
 @bloq_example

--- a/qualtran/bloqs/rotations/programmable_ancilla_rotation.py
+++ b/qualtran/bloqs/rotations/programmable_ancilla_rotation.py
@@ -21,7 +21,7 @@ from attrs import field, frozen
 from qualtran import Bloq, bloq_example, BloqBuilder, QBit, Register, Side, Signature, SoquetT
 from qualtran.bloqs.basic_gates import CNOT, Hadamard, XGate, ZPowGate
 from qualtran.bloqs.basic_gates._shims import Measure
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.symbolics import ceil, is_symbolic, log2, SymbolicFloat, SymbolicInt
 
 
@@ -131,7 +131,7 @@ class ZPowUsingProgrammedAncilla(Bloq):
         n_rounds = ceil(log2(1 / max_fail_probability))
         return cls(exponent=exponent, eps=eps, n_rounds=n_rounds)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> set['BloqCountT']:
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
         resources: Counter[Bloq] = Counter({CNOT(): self.n_rounds, XGate(): self.n_rounds})
 
         n_rz = self.n_rounds + (1 if self.apply_final_correction else 0)
@@ -149,7 +149,7 @@ class ZPowUsingProgrammedAncilla(Bloq):
 
         resources[Measure()] += self.n_rounds
 
-        return set(resources.items())
+        return resources
 
 
 @bloq_example

--- a/qualtran/bloqs/rotations/quantum_variable_rotation.py
+++ b/qualtran/bloqs/rotations/quantum_variable_rotation.py
@@ -56,7 +56,7 @@ References:
 
 import abc
 from functools import cached_property
-from typing import cast, Dict, Sequence, Set, TYPE_CHECKING
+from typing import cast, Dict, Sequence, TYPE_CHECKING
 
 import attrs
 import numpy as np
@@ -90,7 +90,7 @@ from qualtran.symbolics import (
 
 if TYPE_CHECKING:
     from qualtran import SoquetT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 class QvrInterface(GateWithRegisters, metaclass=abc.ABCMeta):
@@ -199,11 +199,11 @@ class QvrZPow(QvrInterface):
             out[-(i + offset)] = bb.add(ZPowGate(exponent=exp, eps=eps), q=out[-(i + offset)])
         return {self.cost_reg.name: bb.join(out, self.cost_reg.dtype)}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         zpow = ZPowGate(
             exponent=self.gamma / (2**self.num_frac_rotations), eps=self.eps / self.num_rotations
         )
-        return {(zpow, self.num_rotations)}
+        return {zpow: self.num_rotations}
 
 
 @bloq_example
@@ -481,14 +481,9 @@ class QvrPhaseGradient(QvrInterface):
         )
         return {self.cost_reg.name: out, 'phase_grad': phase_grad}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return {
-            (
-                AddScaledValIntoPhaseReg(
-                    self.cost_dtype, self.b_grad, self.gamma, self.gamma_dtype
-                ),
-                1,
-            )
+            AddScaledValIntoPhaseReg(self.cost_dtype, self.b_grad, self.gamma, self.gamma_dtype): 1
         }
 
 

--- a/qualtran/bloqs/rotations/rz_via_phase_gradient.py
+++ b/qualtran/bloqs/rotations/rz_via_phase_gradient.py
@@ -26,7 +26,7 @@ from qualtran import (
 )
 from qualtran.bloqs.arithmetic.controlled_add_or_subtract import ControlledAddOrSubtract
 from qualtran.bloqs.bookkeeping import Cast
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -99,8 +99,8 @@ class RzViaPhaseGradient(Bloq):
 
         return {'q': q, 'angle': angle, 'phase_grad': phase_grad}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> set['BloqCountT']:
-        return {(ControlledAddOrSubtract(self._angle_int_dtype, self._phasegrad_int_dtype), 1)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {ControlledAddOrSubtract(self._angle_int_dtype, self._phasegrad_int_dtype): 1}
 
 
 @bloq_example

--- a/qualtran/bloqs/rotations/zpow_via_phase_gradient.py
+++ b/qualtran/bloqs/rotations/zpow_via_phase_gradient.py
@@ -30,7 +30,7 @@ from qualtran import (
 )
 from qualtran.bloqs.arithmetic import XorK
 from qualtran.bloqs.rotations.phase_gradient import AddIntoPhaseGrad
-from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.resource_counting.generalizers import ignore_alloc_free
 from qualtran.symbolics import ceil, is_symbolic, log2, pi, SymbolicFloat, SymbolicInt
 
@@ -123,10 +123,10 @@ class ZPowConstViaPhaseGradient(Bloq):
 
         return {'q': q, 'phase_grad': phase_grad}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> set['BloqCountT']:
+    def build_call_graph(self, ssa: SympySymbolAllocator) -> BloqCountDictT:
         return {
-            (self._load_bloq.controlled(), 2),
-            (AddIntoPhaseGrad(self.phase_grad_bitsize, self.phase_grad_bitsize), 1),
+            self._load_bloq.controlled(): 2,
+            AddIntoPhaseGrad(self.phase_grad_bitsize, self.phase_grad_bitsize): 1,
         }
 
     def __str__(self) -> str:

--- a/qualtran/bloqs/state_preparation/prepare_uniform_superposition.py
+++ b/qualtran/bloqs/state_preparation/prepare_uniform_superposition.py
@@ -157,12 +157,12 @@ class PrepareUniformSuperposition(GateWithRegisters):
         _, l, logL = self.k_l_logL()
         theta = acos(1 - (2 ** floor(log2(l))) / l)
         return {
-            (Hadamard(), 3 * logL),
-            (LessThanConstant(logL, l), 1),
-            (LessThanConstant(logL, l).adjoint(), 1),
-            (Rz(theta), 2),
-            (MultiAnd(HasLength(logL)), 1),
-            (MultiAnd(HasLength(logL)).adjoint(), 1),
+            Hadamard(): 3 * logL,
+            LessThanConstant(logL, l): 1,
+            LessThanConstant(logL, l).adjoint(): 1,
+            Rz(theta): 2,
+            MultiAnd(HasLength(logL)): 1,
+            MultiAnd(HasLength(logL)).adjoint(): 1,
         }
 
 

--- a/qualtran/bloqs/state_preparation/sparse_state_preparation_via_rotations.py
+++ b/qualtran/bloqs/state_preparation/sparse_state_preparation_via_rotations.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Sequence, Set, TYPE_CHECKING, Union
+from typing import Sequence, TYPE_CHECKING, Union
 
 import numpy as np
 import sympy
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     import scipy
 
     from qualtran import BloqBuilder, SoquetT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 @frozen
@@ -193,8 +193,8 @@ class SparseStatePreparationViaRotations(Bloq):
 
         return {'target_state': target_state, 'phase_gradient': phase_gradient}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(self._dense_stateprep_bloq, 1), (self._basis_permutation_bloq, 1)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {self._dense_stateprep_bloq: 1, self._basis_permutation_bloq: 1}
 
 
 @bloq_example

--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
@@ -20,7 +20,7 @@ database) with a number of T gates scaling as 4L + O(log(1/eps)) where eps is th
 largest absolute error that one can tolerate in the prepared amplitudes.
 """
 from functools import cached_property
-from typing import Sequence, Set, Tuple, TYPE_CHECKING, Union
+from typing import Sequence, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import numpy as np
@@ -48,7 +48,7 @@ from qualtran.symbolics import bit_length, is_symbolic, Shaped, slen, SymbolicFl
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, Soquet, SoquetT
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 def _data_or_shape_to_tuple(data_or_shape: Union[NDArray, Shaped]) -> Tuple:
@@ -271,13 +271,13 @@ class StatePreparationAliasSampling(PrepareOracle):
             'keep': keep,
         }
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return {
-            (PrepareUniformSuperposition(self.n_coeff), 1),
-            (self.qrom_bloq, 1),
-            (LessThanEqual(self.mu, self.mu), 1),
-            (CSwap(self.selection_bitsize), 1),
-            (Hadamard(), self.mu),
+            PrepareUniformSuperposition(self.n_coeff): 1,
+            self.qrom_bloq: 1,
+            LessThanEqual(self.mu, self.mu): 1,
+            CSwap(self.selection_bitsize): 1,
+            Hadamard(): self.mu,
         }
 
 

--- a/qualtran/bloqs/state_preparation/state_preparation_via_rotation.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_via_rotation.py
@@ -74,7 +74,7 @@ References:
 """
 
 from collections import Counter
-from typing import cast, Dict, Iterable, List, Set, Tuple, TYPE_CHECKING, Union
+from typing import cast, Dict, Iterable, List, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import numpy as np
@@ -99,7 +99,7 @@ from qualtran.bloqs.rotations.phase_gradient import AddIntoPhaseGrad
 from qualtran.symbolics import bit_length, HasLength, is_symbolic, Shaped, slen, SymbolicInt
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 def _to_tuple_or_has_length(
@@ -229,7 +229,7 @@ class StatePreparationViaRotations(GateWithRegisters):
             soqs = self._prepare_phases(bb, **soqs)
         return soqs
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         ret: 'Counter[Bloq]' = Counter()
         ret[Rx(angle=-np.pi / 2)] += self.state_bitsize
         ret[Rx(angle=np.pi / 2)] += self.state_bitsize
@@ -237,7 +237,7 @@ class StatePreparationViaRotations(GateWithRegisters):
         ret[self.prga_prepare_phases] += 1
         for bloq in self.prga_prepare_amplitude:
             ret[bloq] += 1
-        return set(ret.items())
+        return ret
 
     def _prepare_amplitudes(self, bb: BloqBuilder, **soqs: SoquetT) -> Dict[str, SoquetT]:
         r"""Parameters into soqs:
@@ -456,12 +456,12 @@ class PRGAViaPhaseGradient(Bloq):
         bb.free(cast(Soquet, soqs.pop("target0_")))
         return soqs
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         ret: 'Counter[Bloq]' = Counter()
         ret[self.qrom_bloq] += 1
         ret[self.qrom_bloq.adjoint()] += 1
         ret[self.add_into_phase_grad] += 1
-        return set(ret.items())
+        return ret
 
     def __repr__(self):
         return (

--- a/qualtran/bloqs/swap_network/cswap_approx.py
+++ b/qualtran/bloqs/swap_network/cswap_approx.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Iterator, Set, TYPE_CHECKING
+from typing import Dict, Iterator, TYPE_CHECKING
 
 import cirq
 from attrs import frozen
@@ -32,7 +32,7 @@ from qualtran.resource_counting.generalizers import (
 from qualtran.symbolics import SymbolicInt
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -105,16 +105,12 @@ class CSwapApprox(GateWithRegisters):
             ("@(approx)",) + ("×(x)",) * self.bitsize + ("×(y)",) * self.bitsize
         )
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         n = self.bitsize
         # 4 * n: G gates, each wth 1 T and 4 single qubit cliffords
         # 4 * n: CNOTs
         # 2 * n - 1: CNOTs from 1 MultiTargetCNOT
-        return {
-            (TGate(), 4 * n),
-            (ArbitraryClifford(n=1), 16 * n),
-            (ArbitraryClifford(n=2), 6 * n - 1),
-        }
+        return {TGate(): 4 * n, ArbitraryClifford(n=1): 16 * n, ArbitraryClifford(n=2): 6 * n - 1}
 
 
 @bloq_example

--- a/qualtran/bloqs/swap_network/swap_with_zero.py
+++ b/qualtran/bloqs/swap_network/swap_with_zero.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import cast, Dict, Iterable, Iterator, Set, Tuple, TYPE_CHECKING, Union
+from typing import cast, Dict, Iterable, Iterator, Tuple, TYPE_CHECKING, Union
 
 import attrs
 import cirq
@@ -38,7 +38,7 @@ from qualtran.resource_counting.generalizers import ignore_split_join
 from qualtran.symbolics import is_symbolic, prod, SymbolicInt
 
 if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
 
 
@@ -180,9 +180,9 @@ class SwapWithZero(GateWithRegisters):
         }
         return sel | {'targets': targets}
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         num_swaps = prod(x for x in self.n_target_registers) - 1
-        return {(self.cswap_n, num_swaps)}
+        return {self.cswap_n: num_swaps}
 
     def _circuit_diagram_info_(self, args) -> cirq.CircuitDiagramInfo:
         from qualtran.cirq_interop._bloq_to_cirq import _wire_symbol_to_cirq_diagram_info

--- a/qualtran/resource_counting/__init__.py
+++ b/qualtran/resource_counting/__init__.py
@@ -23,6 +23,7 @@ from ._call_graph import (
     BloqCountDictT,
     BloqCountT,
     big_O,
+    MutableBloqCountDictT,
     SympySymbolAllocator,
     get_bloq_callee_counts,
     get_bloq_call_graph,

--- a/qualtran/resource_counting/_call_graph.py
+++ b/qualtran/resource_counting/_call_graph.py
@@ -23,6 +23,7 @@ from typing import (
     Iterable,
     List,
     Mapping,
+    MutableMapping,
     Optional,
     Sequence,
     Set,
@@ -37,6 +38,7 @@ from qualtran import Bloq, CompositeBloq, DecomposeNotImplementedError, Decompos
 
 BloqCountT = Tuple[Bloq, Union[int, sympy.Expr]]
 BloqCountDictT = Mapping[Bloq, Union[int, sympy.Expr]]
+MutableBloqCountDictT = MutableMapping[Bloq, Union[int, sympy.Expr]]
 from ._generalization import _make_composite_generalizer, GeneralizerT
 
 
@@ -66,7 +68,7 @@ class SympySymbolAllocator:
         return s
 
 
-def build_cbloq_call_graph(cbloq: CompositeBloq) -> Set[BloqCountT]:
+def build_cbloq_call_graph(cbloq: CompositeBloq) -> BloqCountDictT:
     """Count all the subbloqs in a composite bloq.
 
     This is the function underpinning `CompositeBloq.build_call_graph`.
@@ -78,7 +80,7 @@ def build_cbloq_call_graph(cbloq: CompositeBloq) -> Set[BloqCountT]:
     for binst in cbloq.bloq_instances:
         counts[binst.bloq] += 1
 
-    return {(bloq, n) for bloq, n in counts.items()}
+    return counts
 
 
 def _generalize_callees(

--- a/qualtran/resource_counting/_call_graph_test.py
+++ b/qualtran/resource_counting/_call_graph_test.py
@@ -31,6 +31,7 @@ from qualtran.resource_counting import (
     BloqCountT,
     get_bloq_call_graph,
     get_bloq_callee_counts,
+    MutableBloqCountDictT,
     SympySymbolAllocator,
 )
 from qualtran.resource_counting.generalizers import generalize_rotation_angle
@@ -151,7 +152,7 @@ class OnlyCallGraphBloqShim(Bloq):
         return Signature([])
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
-        counts = defaultdict(int)
+        counts: 'MutableBloqCountDictT' = defaultdict(int)
         for bloq, count in self.callees:
             counts[bloq] += count
         return counts

--- a/qualtran/resource_counting/_call_graph_test.py
+++ b/qualtran/resource_counting/_call_graph_test.py
@@ -12,8 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from collections import defaultdict
 from functools import cached_property
-from typing import Dict, Iterable, Optional, Sequence, Set, Tuple
+from typing import Dict, Iterable, Optional, Sequence, Tuple
 
 import attrs
 import networkx as nx
@@ -26,6 +27,7 @@ from qualtran import Bloq, BloqBuilder, Signature, Soquet, SoquetT
 from qualtran.bloqs.basic_gates import TGate
 from qualtran.bloqs.bookkeeping import ArbitraryClifford, Join, Split
 from qualtran.resource_counting import (
+    BloqCountDictT,
     BloqCountT,
     get_bloq_call_graph,
     get_bloq_callee_counts,
@@ -43,8 +45,8 @@ class BigBloq(Bloq):
     def signature(self) -> 'Signature':
         return Signature.build(x=self.bitsize)
 
-    def build_call_graph(self, ssa: Optional['SympySymbolAllocator']) -> Set['BloqCountT']:
-        return {(SubBloq(unrelated_param=0.5), sympy.log(self.bitsize))}
+    def build_call_graph(self, ssa: Optional['SympySymbolAllocator']) -> 'BloqCountDictT':
+        return {SubBloq(unrelated_param=0.5): sympy.log(self.bitsize)}
 
 
 @frozen
@@ -71,8 +73,8 @@ class SubBloq(Bloq):
     def signature(self) -> 'Signature':
         return Signature.build(q=1)
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return {(TGate(), 3)}
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {TGate(): 3}
 
 
 def get_big_bloq_counts_graph_1(bloq: Bloq) -> Tuple[nx.DiGraph, Dict[Bloq, SymbolicInt]]:
@@ -148,8 +150,11 @@ class OnlyCallGraphBloqShim(Bloq):
     def signature(self) -> 'Signature':
         return Signature([])
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return set(self.callees)
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        counts = defaultdict(int)
+        for bloq, count in self.callees:
+            counts[bloq] += count
+        return counts
 
     def pretty_name(self):
         return self.name

--- a/qualtran/resource_counting/classify_bloqs_test.py
+++ b/qualtran/resource_counting/classify_bloqs_test.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Set, Tuple, TYPE_CHECKING
+from typing import Tuple
 
 import attrs
 import numpy as np
@@ -30,7 +30,13 @@ from qualtran.bloqs.rotations.hamming_weight_phasing import HammingWeightPhasing
 from qualtran.bloqs.state_preparation.prepare_uniform_superposition import (
     PrepareUniformSuperposition,
 )
-from qualtran.resource_counting import BloqCountT, get_cost_value, QECGatesCost
+from qualtran.resource_counting import (
+    BloqCountDictT,
+    BloqCountT,
+    get_cost_value,
+    QECGatesCost,
+    SympySymbolAllocator,
+)
 from qualtran.resource_counting.classify_bloqs import (
     _get_basic_bloq_classification,
     bloq_is_rotation,
@@ -38,9 +44,6 @@ from qualtran.resource_counting.classify_bloqs import (
     classify_bloq,
     classify_t_count_by_bloq_type,
 )
-
-if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountT, SympySymbolAllocator
 
 
 @attrs.frozen
@@ -53,8 +56,8 @@ class TestBundleOfBloqs(Bloq):
     def signature(self) -> 'Signature':
         return Signature.build()
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> Set['BloqCountT']:
-        return set(self.bloqs)
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return dict(self.bloqs)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- This changes the build_call_graph function within bloqs in qualtran to return a dictionary of cost counts rather than a set.
- This will allow the ordering of cost counts to be deterministic

Note that this requires some slight code changes for bloqs that have multiple set items since (Toffoli(), 1) and (Toffoli(), 2) would have two different items in a set, but share an index in the dictionary.

This also may alter counts (i.e. fix a bug) where set items clobber each other.  For instance, adding (Toffoli(), self.bits_a) and (Toffoli(), self.bits_b) will previously give the wrong count if bits_a == bits_b since the two items would be the same in the set.