### PR TITLE
Bugfix in `QROAMCleanAdjointWrapper` to correctly pass `num_controls` to `QROAMCleanAdjoint`

### DIFF
--- a/qualtran/bloqs/data_loading/qroam_clean.py
+++ b/qualtran/bloqs/data_loading/qroam_clean.py
@@ -71,6 +71,8 @@ def get_optimal_log_block_size_clean_ancilla(
         k = log2(qroam_block_size)
     if is_symbolic(k):
         return k
+    if k < 0:
+        return 0
     k_int = np.array([np.floor(k), np.ceil(k)])
     return int(k_int[np.argmin(qroam_cost(2**k_int, data_size, bitsize, adjoint))])
 
@@ -233,6 +235,7 @@ class QROAMCleanAdjointWrapper(Bloq):
         if self.qroam_clean.has_data():
             return QROAMCleanAdjoint.build_from_data(
                 *self.qroam_clean.batched_data_permuted,
+                target_bitsizes=self.qroam_clean.target_bitsizes,
                 target_shapes=(self.qroam_clean.block_sizes,)
                 * len(self.qroam_clean.batched_data_permuted),
                 log_block_sizes=self.log_block_sizes,

--- a/qualtran/bloqs/data_loading/qroam_clean.py
+++ b/qualtran/bloqs/data_loading/qroam_clean.py
@@ -236,6 +236,7 @@ class QROAMCleanAdjointWrapper(Bloq):
                 target_shapes=(self.qroam_clean.block_sizes,)
                 * len(self.qroam_clean.batched_data_permuted),
                 log_block_sizes=self.log_block_sizes,
+                num_controls=self.qroam_clean.num_controls,
             )
         else:
             return QROAMCleanAdjoint.build_from_bitsize(
@@ -244,6 +245,7 @@ class QROAMCleanAdjointWrapper(Bloq):
                 target_shapes=(self.qroam_clean.block_sizes,)
                 * len(self.qroam_clean.target_bitsizes),
                 log_block_sizes=self.log_block_sizes,
+                num_controls=self.qroam_clean.num_controls,
             )
 
     def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:

--- a/qualtran/bloqs/data_loading/qrom.py
+++ b/qualtran/bloqs/data_loading/qrom.py
@@ -22,7 +22,7 @@ import numpy as np
 import sympy
 from numpy.typing import ArrayLike, NDArray
 
-from qualtran import bloq_example, BloqDocSpec, QUInt, Register
+from qualtran import bloq_example, BloqDocSpec, DecomposeTypeError, QUInt, Register
 from qualtran._infra.gate_with_registers import merge_qubits
 from qualtran.bloqs.arithmetic import XorK
 from qualtran.bloqs.basic_gates import CNOT
@@ -152,6 +152,13 @@ class QROM(QROMBase, UnaryIterationGate):  # type: ignore[misc]
             yield self._load_nth_data(zero_indx, ctrl_qubits=(and_target,), **target_regs)
             yield cirq.inverse(multi_controlled_and)
             context.qubit_manager.qfree(list(junk.flatten()) + [and_target])
+
+    def decompose_from_registers(
+        self, *, context: cirq.DecompositionContext, **quregs: NDArray[cirq.Qid]
+    ) -> cirq.OP_TREE:
+        if self.has_data():
+            return super().decompose_from_registers(context=context, **quregs)
+        raise DecomposeTypeError(f"Cannot decompose symbolic {self} with no data.")
 
     def _break_early(self, selection_index_prefix: Tuple[int, ...], l: int, r: int):
         if not self.has_data():

--- a/qualtran/bloqs/data_loading/select_swap_qrom_test.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom_test.py
@@ -232,3 +232,14 @@ def test_tensor_contraction(use_dirty_ancilla: bool):
     )
     qrom = QROM.build_from_data(data)
     np.testing.assert_allclose(qrom.tensor_contract(), qroam.tensor_contract(), atol=1e-8)
+
+
+def test_select_swap_block_sizes():
+    data = [*range(1600)]
+    qroam_opt = SelectSwapQROM.build_from_data(data)
+    qroam_subopt = SelectSwapQROM.build_from_data(data, log_block_sizes=(8,))
+    assert qroam_opt.block_sizes == (16,)
+    assert qroam_opt.t_complexity().t < qroam_subopt.t_complexity().t
+
+    qroam = SelectSwapQROM.build_from_data(data, use_dirty_ancilla=False)
+    assert qroam.block_sizes == (8,)


### PR DESCRIPTION
See updated test, which would fail earlier but passes now. 

Also made other drive by improvements like:

1. Fix the logic of `get_optimal_log_block_size_clean_ancilla` so it returns an integer >=0.
2. Pass ` target_bitsizes` to `QROAMCleanAdjoint` from` QROAMCleanAdjointWrapper` so that target bitsize remains the same post delegation when constructing the bloq for data. 
3. Update `find_optimal_log_block_size` implementation for `SelectSwapQROM` to find the optimal bitsize taking into account a factor of 2 for dirty ancillas. Added a test to verify the new block size leads to smaller counts. 
4. Raise a `DecomposeTypeError` for `QROM` decomposition when `self.has_data()` is false. This makes qubit counting protocols deal with symbolic qroms better. 