### PR TITLE
Maked intermediate additions unsigned in ModAdd

### DIFF
--- a/qualtran/bloqs/mod_arithmetic/mod_addition.py
+++ b/qualtran/bloqs/mod_arithmetic/mod_addition.py
@@ -100,12 +100,8 @@ class ModAdd(Bloq):
         # constant subtraction circuit.
         x_split = bb.split(x)
         y_split = bb.split(y)
-        x = bb.join(
-            np.concatenate([[junk_bit], x_split]), dtype=QInt(bitsize=self.bitsize + 1)
-        )
-        y = bb.join(
-            np.concatenate([[sign], y_split]), dtype=QInt(bitsize=self.bitsize + 1)
-        )
+        x = bb.join(np.concatenate([[junk_bit], x_split]), dtype=QInt(bitsize=self.bitsize + 1))
+        y = bb.join(np.concatenate([[sign], y_split]), dtype=QInt(bitsize=self.bitsize + 1))
 
         # Perform in-place addition on quantum register y.
         x, y = bb.add(Add(QInt(bitsize=self.bitsize + 1)), a=x, b=y)

--- a/qualtran/bloqs/mod_arithmetic/mod_addition.py
+++ b/qualtran/bloqs/mod_arithmetic/mod_addition.py
@@ -125,6 +125,7 @@ class ModAdd(Bloq):
             AddK(bitsize=self.bitsize, k=self.mod, signed=True, cvs=(1,)), x=y, ctrls=sign_split
         )
         sign = bb.join(sign_split)
+        y = bb.add(Cast(QInt(bitsize=self.bitsize), QMontgomeryUInt(bitsize=self.bitsize)), reg=y)
 
         # Check if y < x; if yes flip the bit of the signed ancilla bit. Then bitflip the sign bit
         # again before freeing.

--- a/qualtran/bloqs/mod_arithmetic/mod_addition.py
+++ b/qualtran/bloqs/mod_arithmetic/mod_addition.py
@@ -25,6 +25,7 @@ from qualtran import (
     BloqDocSpec,
     GateWithRegisters,
     QBit,
+    QInt,
     QMontgomeryUInt,
     QUInt,
     Register,
@@ -100,14 +101,14 @@ class ModAdd(Bloq):
         x_split = bb.split(x)
         y_split = bb.split(y)
         x = bb.join(
-            np.concatenate([[junk_bit], x_split]), dtype=QMontgomeryUInt(bitsize=self.bitsize + 1)
+            np.concatenate([[junk_bit], x_split]), dtype=QInt(bitsize=self.bitsize + 1)
         )
         y = bb.join(
-            np.concatenate([[sign], y_split]), dtype=QMontgomeryUInt(bitsize=self.bitsize + 1)
+            np.concatenate([[sign], y_split]), dtype=QInt(bitsize=self.bitsize + 1)
         )
 
         # Perform in-place addition on quantum register y.
-        x, y = bb.add(Add(QMontgomeryUInt(bitsize=self.bitsize + 1)), a=x, b=y)
+        x, y = bb.add(Add(QInt(bitsize=self.bitsize + 1)), a=x, b=y)
 
         # Temporary solution to equalize the bitlength of the x and y registers for Add().
         x_split = bb.split(x)
@@ -121,7 +122,7 @@ class ModAdd(Bloq):
         # negative.
         y_split = bb.split(y)
         sign = y_split[0]
-        y = bb.join(y_split[1:], dtype=QMontgomeryUInt(bitsize=self.bitsize))
+        y = bb.join(y_split[1:], dtype=QInt(bitsize=self.bitsize))
 
         sign_split = bb.split(sign)
         sign_split, y = bb.add(


### PR DESCRIPTION
Replicate bug with ModAdd(bitsize=8, mod=17).adjoint().on_classical_vals(x=0,y=0). Basically, we do signed integer addition with registers that have unsigned dtypes. Change the intermediate register dtypes to QInt to perform modular reductions then restore to unsigned int dtypes.