### PR TITLE
fix call graph for `Equals`

### DIFF
--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -1008,12 +1008,7 @@ class Equals(Bloq):
             cvs = [0] * self.bitsize
         else:
             cvs = HasLength(self.bitsize)
-        return {
-            Xor(self.dtype): 2,
-            MultiControlX(cvs=cvs): 1,
-            MultiAnd(cvs=cvs).adjoint(): 1,
-            CNOT(): 1,
-        }
+        return {Xor(self.dtype): 2, MultiControlX(cvs=cvs): 1}
 
     def on_classical_vals(self, x: int, y: int, target: int) -> Dict[str, 'ClassicalValT']:
         return {'x': x, 'y': y, 'target': target ^ (x == y)}

--- a/qualtran/bloqs/arithmetic/comparison_test.py
+++ b/qualtran/bloqs/arithmetic/comparison_test.py
@@ -310,6 +310,12 @@ def test_classical_equals(dtype):
     )
 
 
+def test_equals_call_graph():
+    bloq = Equals(QUInt(4))
+
+    qlt_testing.assert_equivalent_bloq_counts(bloq, ignore_split_join)
+
+
 def test_equals_a_constant():
     bb = BloqBuilder()
     bitsize = 5


### PR DESCRIPTION
bloq introduced in #1411 had some extra bloqs in the call graph