### PR TITLE
`PlusEqualProduct` version of `GFMultiplication` for GF($2^m$)

### DIFF
--- a/qualtran/bloqs/gf_arithmetic/gf2_multiplication.ipynb
+++ b/qualtran/bloqs/gf_arithmetic/gf2_multiplication.ipynb
@@ -56,12 +56,13 @@
     "gates.\n",
     "\n",
     "#### Parameters\n",
-    " - `bitsize`: The degree $m$ of the galois field $GF(2^m)$. Also corresponds to the number of qubits in each of the two input registers $a$ and $b$ that should be multiplied. \n",
+    " - `bitsize`: The degree $m$ of the galois field $GF(2^m)$. Also corresponds to the number of qubits in each of the two input registers $a$ and $b$ that should be multiplied.\n",
+    " - `plus_equal_prod`: If True, implements the `PlusEqualProduct` version that applies the map $|x\\rangle |y\\rangle |z\\rangle \\rightarrow |x\\rangle |y\\rangle |x + z\\rangle$. \n",
     "\n",
     "#### Registers\n",
     " - `x`: Input THRU register of size $m$ that stores elements from $GF(2^m)$.\n",
     " - `y`: Input THRU register of size $m$ that stores elements from $GF(2^m)$.\n",
-    " - `result`: Output RIGHT register of size $m$ that stores the product $x * y$ in $GF(2^m)$.  \n",
+    " - `result`: Register of size $m$ that stores the product $x * y$ in $GF(2^m)$. If plus_equal_prod is True - result is a THRU register and stores $result + x * y$. If plus_equal_prod is False - result is a RIGHT register and stores $x * y$.  \n",
     "\n",
     "#### References\n",
     " - [On the Design and Optimization of a Quantum Polynomial-Time Attack on Elliptic Curve Cryptography](https://arxiv.org/abs/0710.1093). \n",
@@ -99,7 +100,7 @@
    },
    "outputs": [],
    "source": [
-    "gf16_multiplication = GF2Multiplication(4)"
+    "gf16_multiplication = GF2Multiplication(4, plus_equal_prod=True)"
    ]
   },
   {
@@ -114,7 +115,7 @@
     "import sympy\n",
     "\n",
     "m = sympy.Symbol('m')\n",
-    "gf2_multiplication_symbolic = GF2Multiplication(m)"
+    "gf2_multiplication_symbolic = GF2Multiplication(m, plus_equal_prod=False)"
    ]
   },
   {

--- a/qualtran/bloqs/gf_arithmetic/gf2_multiplication.py
+++ b/qualtran/bloqs/gf_arithmetic/gf2_multiplication.py
@@ -51,7 +51,7 @@ class SynthesizeLRCircuit(Bloq):
     """Synthesize linear reversible circuit using CNOT gates.
 
     Args:
-        matrix: An n x m matrix describing the linear transformation.
+        matrix: An n x n matrix describing the linear transformation.
 
     References:
         [Efficient Synthesis of Linear Reversible Circuits](https://arxiv.org/abs/quant-ph/0302002)

--- a/qualtran/bloqs/gf_arithmetic/gf2_multiplication_test.py
+++ b/qualtran/bloqs/gf_arithmetic/gf2_multiplication_test.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import numpy as np
 import pytest
 from galois import GF
 
@@ -40,9 +41,10 @@ def test_synthesize_lr_circuit():
     bloq_adj = bloq.adjoint()
     QGFM, GFM = QGF(2, m), GF(2**m)
     for i in GFM.elements:
-        bloq_out = bloq.call_classically(q=QGFM.to_bits(i))[0]
+        bloq_out = bloq.call_classically(q=np.array(QGFM.to_bits(i)))[0]
         bloq_adj_out = bloq_adj.call_classically(q=bloq_out)[0]
-        assert i == QGFM.from_bits(bloq_adj_out)
+        assert isinstance(bloq_adj_out, np.ndarray)
+        assert i == QGFM.from_bits([*bloq_adj_out])
 
 
 @pytest.mark.slow
@@ -53,9 +55,10 @@ def test_synthesize_lr_circuit_slow(m):
     bloq_adj = bloq.adjoint()
     QGFM, GFM = QGF(2, m), GF(2**m)
     for i in GFM.elements:
-        bloq_out = bloq.call_classically(q=QGFM.to_bits(i))[0]
+        bloq_out = bloq.call_classically(q=np.array(QGFM.to_bits(i)))[0]
         bloq_adj_out = bloq_adj.call_classically(q=bloq_out)[0]
-        assert i == QGFM.from_bits(bloq_adj_out)
+        assert isinstance(bloq_adj_out, np.ndarray)
+        assert i == QGFM.from_bits([*bloq_adj_out])
 
 
 def test_gf2_plus_equal_prod_classical_sim_quick():

--- a/qualtran/bloqs/gf_arithmetic/gf2_multiplication_test.py
+++ b/qualtran/bloqs/gf_arithmetic/gf2_multiplication_test.py
@@ -15,10 +15,12 @@
 import pytest
 from galois import GF
 
+from qualtran import QGF
 from qualtran.bloqs.gf_arithmetic.gf2_multiplication import (
     _gf2_multiplication_symbolic,
     _gf16_multiplication,
     GF2Multiplication,
+    SynthesizeLRCircuit,
 )
 from qualtran.testing import assert_consistent_classical_action
 
@@ -31,9 +33,49 @@ def test_gf2_multiplication_symbolic(bloq_autotester):
     bloq_autotester(_gf2_multiplication_symbolic)
 
 
+def test_synthesize_lr_circuit():
+    m = 2
+    matrix = GF2Multiplication(m).reduction_matrix_q
+    bloq = SynthesizeLRCircuit(matrix)
+    bloq_adj = bloq.adjoint()
+    QGFM, GFM = QGF(2, m), GF(2**m)
+    for i in GFM.elements:
+        bloq_out = bloq.call_classically(q=QGFM.to_bits(i))[0]
+        bloq_adj_out = bloq_adj.call_classically(q=bloq_out)[0]
+        assert i == QGFM.from_bits(bloq_adj_out)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('m', [3, 4, 5])
+def test_synthesize_lr_circuit_slow(m):
+    matrix = GF2Multiplication(m).reduction_matrix_q
+    bloq = SynthesizeLRCircuit(matrix)
+    bloq_adj = bloq.adjoint()
+    QGFM, GFM = QGF(2, m), GF(2**m)
+    for i in GFM.elements:
+        bloq_out = bloq.call_classically(q=QGFM.to_bits(i))[0]
+        bloq_adj_out = bloq_adj.call_classically(q=bloq_out)[0]
+        assert i == QGFM.from_bits(bloq_adj_out)
+
+
+def test_gf2_plus_equal_prod_classical_sim_quick():
+    m = 2
+    bloq = GF2Multiplication(m, plus_equal_prod=True)
+    GFM = GF(2**m)
+    assert_consistent_classical_action(bloq, x=GFM.elements, y=GFM.elements, result=GFM.elements)
+
+
+@pytest.mark.slow
+def test_gf2_plus_equal_prod_classical_sim():
+    m = 3
+    bloq = GF2Multiplication(m, plus_equal_prod=True)
+    GFM = GF(2**m)
+    assert_consistent_classical_action(bloq, x=GFM.elements, y=GFM.elements, result=GFM.elements)
+
+
 def test_gf2_multiplication_classical_sim_quick():
     m = 2
-    bloq = GF2Multiplication(m)
+    bloq = GF2Multiplication(m, plus_equal_prod=False)
     GFM = GF(2**m)
     assert_consistent_classical_action(bloq, x=GFM.elements, y=GFM.elements)
 
@@ -41,6 +83,6 @@ def test_gf2_multiplication_classical_sim_quick():
 @pytest.mark.slow
 @pytest.mark.parametrize('m', [3, 4, 5])
 def test_gf2_multiplication_classical_sim(m):
-    bloq = GF2Multiplication(m)
+    bloq = GF2Multiplication(m, plus_equal_prod=False)
     GFM = GF(2**m)
     assert_consistent_classical_action(bloq, x=GFM.elements, y=GFM.elements)


### PR DESCRIPTION
Updates the existing `GFMultiplication` bloq to support an in-place `PlusEqualProduct` version of the bloq where the multiplied integer gets added to the result register. The decomposition is _very_ similar except we need an inverse of the linear reversible circuit at the beginning, so I decided to add this as a special case controlled by a flag instead of adding a new Bloq. 

Part of a larger effort to support galois field arithmetic in qualtran. xref https://github.com/quantumlib/Qualtran/issues/1419