### PR TITLE
References: formatting fixes

### DIFF
--- a/dev_tools/bibliography.ipynb
+++ b/dev_tools/bibliography.ipynb
@@ -129,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for url, clss in backrefs.items():\n",
+    "for url, clss in sorted(backrefs.items(), key=lambda x: -len(x[1])):\n",
     "    text = f'### [{titles[url]}]({url})\\n'\n",
     "    for cls in clss:\n",
     "        text += f' - {cls.__name__}\\n'\n",

--- a/qualtran/Autodoc.ipynb
+++ b/qualtran/Autodoc.ipynb
@@ -61,7 +61,7 @@
     "\n",
     "### References\n",
     "\n",
-    "We provide custom support for a \"References\" section where you should reference the source(s) of the construction. References are newline seperated. They must start with a markdown-style link of `[title](url)`. This can optionally be followed by a period and any additional information in standard markdown format. To balance structure vs. readability, reference links should be kept to a single line and need not respect the 100-character line limit.\n",
+    "We provide custom support for a \"References\" section where you should reference the source(s) of the construction. References are newline seperated. They must start with a markdown-style link of `[title](url)`. This can optionally be followed by a period and any additional information in standard markdown format. To balance structure vs. readability, reference links should be kept to a single line and need not respect the 100-character line limit. Canonically, the next line should include one or two author last names, the first year of publication, and specific figures or equations relevant to the bloq. Prefer arxiv links. Link to the abstract page; not directly to the pdf.\n",
     "\n",
     "```python\n",
     "class QROM(Bloq):\n",
@@ -166,7 +166,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/qualtran/bloqs/arithmetic/comparison.ipynb
+++ b/qualtran/bloqs/arithmetic/comparison.ipynb
@@ -485,7 +485,7 @@
     "https://github.com/quantumlib/Qualtran/issues/389\n",
     "\n",
     "#### References\n",
-    " - Supplementary Materials: Improved Techniques for Preparing Eigenstates of Fermionic Hamiltonians https://static-content.springer.com/esm/art%3A10.1038%2Fs41534-018-0071-5/MediaObjects/41534_2018_71_MOESM1_ESM.pdf\n"
+    " - [Supplementary Materials: Improved Techniques for Preparing Eigenstates of Fermionic Hamiltonians](https://static-content.springer.com/esm/art%3A10.1038%2Fs41534-018-0071-5/MediaObjects/41534_2018_71_MOESM1_ESM.pdf).\n"
    ]
   },
   {
@@ -702,7 +702,7 @@
     "\n",
     "#### References\n",
     " - [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662). \n",
-    " - Supplementary Materials: Improved Techniques for Preparing Eigenstates of Fermionic Hamiltonians. https://static-content.springer.com/esm/art%3A10.1038%2Fs41534-018-0071-5/MediaObjects/41534_2018_71_MOESM1_ESM.pdf\n"
+    " - [Supplementary Materials: Improved Techniques for Preparing Eigenstates of Fermionic Hamiltonians](https://static-content.springer.com/esm/art%3A10.1038%2Fs41534-018-0071-5/MediaObjects/41534_2018_71_MOESM1_ESM.pdf).\n"
    ]
   },
   {

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -233,8 +233,7 @@ class BiQubitsMixer(GateWithRegisters):
     https://github.com/quantumlib/Qualtran/issues/389
 
     References:
-        Supplementary Materials: Improved Techniques for Preparing Eigenstates of Fermionic Hamiltonians
-        https://static-content.springer.com/esm/art%3A10.1038%2Fs41534-018-0071-5/MediaObjects/41534_2018_71_MOESM1_ESM.pdf
+        [Supplementary Materials: Improved Techniques for Preparing Eigenstates of Fermionic Hamiltonians](https://static-content.springer.com/esm/art%3A10.1038%2Fs41534-018-0071-5/MediaObjects/41534_2018_71_MOESM1_ESM.pdf).
     """
 
     is_adjoint: bool = False
@@ -432,8 +431,7 @@ class LessThanEqual(GateWithRegisters, cirq.ArithmeticGate):  # type: ignore[mis
     References:
         [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662).
 
-        Supplementary Materials: Improved Techniques for Preparing Eigenstates of Fermionic Hamiltonians.
-        https://static-content.springer.com/esm/art%3A10.1038%2Fs41534-018-0071-5/MediaObjects/41534_2018_71_MOESM1_ESM.pdf
+        [Supplementary Materials: Improved Techniques for Preparing Eigenstates of Fermionic Hamiltonians](https://static-content.springer.com/esm/art%3A10.1038%2Fs41534-018-0071-5/MediaObjects/41534_2018_71_MOESM1_ESM.pdf).
     """
 
     x_bitsize: 'SymbolicInt'

--- a/qualtran/bloqs/arithmetic/multiplication.ipynb
+++ b/qualtran/bloqs/arithmetic/multiplication.ipynb
@@ -474,7 +474,7 @@
     " - `result`: a r_bitsize sized output fixed-point register. \n",
     "\n",
     "#### References\n",
-    " - [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](     https://arxiv.org/pdf/2007.07391.pdf) pg 70.\n"
+    " - [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](https://arxiv.org/abs/2007.07391). pg 70.\n"
    ]
   },
   {

--- a/qualtran/bloqs/arithmetic/multiplication.py
+++ b/qualtran/bloqs/arithmetic/multiplication.py
@@ -315,9 +315,8 @@ class Product(Bloq):
         result: A 2*`max(a_bitsize, b_bitsize)` bit-sized output register to store the result a*b.
 
     References:
-        [Fault-Tolerant Quantum Simulations of Chemistry in First
-        Quantization](https://arxiv.org/abs/2105.12767) pg 81 gives a Toffoli
-        complexity for multiplying two numbers.
+        [Fault-Tolerant Quantum Simulations of Chemistry in First Quantization](https://arxiv.org/abs/2105.12767).
+        pg 81 gives a Toffoli complexity for multiplying two numbers.
     """
 
     a_bitsize: SymbolicInt
@@ -377,8 +376,8 @@ class ScaleIntByReal(Bloq):
         result: a r_bitsize sized output fixed-point register.
 
     References:
-        [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](
-            https://arxiv.org/pdf/2007.07391.pdf) pg 70.
+        [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](https://arxiv.org/abs/2007.07391).
+        pg 70.
     """
 
     r_bitsize: SymbolicInt

--- a/qualtran/bloqs/arithmetic/subtraction.ipynb
+++ b/qualtran/bloqs/arithmetic/subtraction.ipynb
@@ -53,7 +53,7 @@
     " - `b`: A b_dtype.bitsize-sized input/output register (register b above). \n",
     "\n",
     "#### References\n",
-    " - [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization, page 9](https://arxiv.org/pdf/2007.07391). \n"
+    " - [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](https://arxiv.org/abs/2007.07391). Page 9.\n"
    ]
   },
   {

--- a/qualtran/bloqs/arithmetic/subtraction.py
+++ b/qualtran/bloqs/arithmetic/subtraction.py
@@ -68,7 +68,8 @@ class Subtract(Bloq):
         b: A b_dtype.bitsize-sized input/output register (register b above).
 
     References:
-        [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization, page 9](https://arxiv.org/pdf/2007.07391)
+        [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](https://arxiv.org/abs/2007.07391).
+        Page 9.
     """
 
     a_dtype: Union[QInt, QUInt, QMontgomeryUInt] = field()

--- a/qualtran/bloqs/block_encoding/linear_combination.ipynb
+++ b/qualtran/bloqs/block_encoding/linear_combination.ipynb
@@ -64,7 +64,7 @@
     " - `resource`: The resource register (present only if bitsize > 0). \n",
     "\n",
     "#### References\n",
-    " - [Quantum algorithms: A survey of applications and end-to-end complexities]( https://arxiv.org/abs/2310.03011). Dalzell et al. (2023). Ch. 10.2.\n"
+    " - [Quantum algorithms: A survey of applications and end-to-end complexities](https://arxiv.org/abs/2310.03011). Dalzell et al. (2023). Ch. 10.2.\n"
    ]
   },
   {

--- a/qualtran/bloqs/block_encoding/linear_combination.py
+++ b/qualtran/bloqs/block_encoding/linear_combination.py
@@ -75,8 +75,8 @@ class LinearCombination(BlockEncoding):
         resource: The resource register (present only if bitsize > 0).
 
     References:
-        [Quantum algorithms: A survey of applications and end-to-end complexities](
-        https://arxiv.org/abs/2310.03011). Dalzell et al. (2023). Ch. 10.2.
+        [Quantum algorithms: A survey of applications and end-to-end complexities](https://arxiv.org/abs/2310.03011).
+        Dalzell et al. (2023). Ch. 10.2.
     """
 
     _block_encodings: Tuple[BlockEncoding, ...] = field(

--- a/qualtran/bloqs/block_encoding/product.ipynb
+++ b/qualtran/bloqs/block_encoding/product.ipynb
@@ -69,7 +69,7 @@
     " - `resource`: The resource register (present only if bitsize > 0). \n",
     "\n",
     "#### References\n",
-    " - [Quantum algorithms: A survey of applications and end-to-end complexities]( https://arxiv.org/abs/2310.03011). Dalzell et al. (2023). Ch. 10.2.\n"
+    " - [Quantum algorithms: A survey of applications and end-to-end complexities](https://arxiv.org/abs/2310.03011). Dalzell et al. (2023). Ch. 10.2.\n"
    ]
   },
   {

--- a/qualtran/bloqs/block_encoding/product.py
+++ b/qualtran/bloqs/block_encoding/product.py
@@ -81,8 +81,8 @@ class Product(BlockEncoding):
         resource: The resource register (present only if bitsize > 0).
 
     References:
-        [Quantum algorithms: A survey of applications and end-to-end complexities](
-        https://arxiv.org/abs/2310.03011). Dalzell et al. (2023). Ch. 10.2.
+        [Quantum algorithms: A survey of applications and end-to-end complexities](https://arxiv.org/abs/2310.03011).
+        Dalzell et al. (2023). Ch. 10.2.
     """
 
     block_encodings: Tuple[BlockEncoding, ...] = field(

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/prepare_t.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/prepare_t.py
@@ -110,10 +110,11 @@ class PrepareTFirstQuantizationWithProj(Bloq):
         s: a register encoding bits for each component of the momenta.
 
     References:
-        [Quantum computation of stopping power for inertial fusion target design](
-            https://arxiv.org/abs/2308.12352) page 11, C3 also page 31 App A. Sec 2 b.
-        [Fault-Tolerant Quantum Simulations of Chemistry in First Quantization](
-            https://arxiv.org/abs/2105.12767) page 19, section B
+        [Quantum computation of stopping power for inertial fusion target design](https://arxiv.org/abs/2308.12352).
+        page 11, C3 also page 31 App A. Sec 2 b.
+
+        [Fault-Tolerant Quantum Simulations of Chemistry in First Quantization](https://arxiv.org/abs/2105.12767).
+        page 19, section B
     """
 
     num_bits_p: int

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/projectile.ipynb
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/projectile.ipynb
@@ -128,7 +128,7 @@
     " - `flags`: A 4 qubit flag register indicating which component of the Hamiltonian to apply. \n",
     "\n",
     "#### References\n",
-    " - [Fault-Tolerant Quantum Simulations of Chemistry in First Quantization](     https://arxiv.org/abs/2105.12767)\n"
+    " - [Fault-Tolerant Quantum Simulations of Chemistry in First Quantization](https://arxiv.org/abs/2105.12767). \n"
    ]
   },
   {
@@ -260,7 +260,7 @@
     " - `proj`: The system register. Will store a single register (x, y and z) components of size num_bits_n. \n",
     "\n",
     "#### References\n",
-    " - [Fault-Tolerant Quantum Simulations of Chemistry in First Quantization](     https://arxiv.org/abs/2105.12767)\n"
+    " - [Fault-Tolerant Quantum Simulations of Chemistry in First Quantization](https://arxiv.org/abs/2105.12767). \n"
    ]
   },
   {

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_and_prepare.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/projectile/select_and_prepare.py
@@ -233,8 +233,7 @@ class PrepareFirstQuantizationWithProj(PrepareOracle):
         flags: A 4 qubit flag register indicating which component of the Hamiltonian to apply.
 
     References:
-        [Fault-Tolerant Quantum Simulations of Chemistry in First Quantization](
-            https://arxiv.org/abs/2105.12767)
+        [Fault-Tolerant Quantum Simulations of Chemistry in First Quantization](https://arxiv.org/abs/2105.12767).
     """
 
     num_bits_p: int
@@ -409,8 +408,7 @@ class SelectFirstQuantizationWithProj(SelectOracle):
             components of size num_bits_n.
 
     References:
-        [Fault-Tolerant Quantum Simulations of Chemistry in First Quantization](
-            https://arxiv.org/abs/2105.12767)
+        [Fault-Tolerant Quantum Simulations of Chemistry in First Quantization](https://arxiv.org/abs/2105.12767).
     """
 
     num_bits_p: int

--- a/qualtran/bloqs/chemistry/quad_fermion/givens_bloq.ipynb
+++ b/qualtran/bloqs/chemistry/quad_fermion/givens_bloq.ipynb
@@ -98,7 +98,7 @@
     " - `phase_gradient`: QFxp data type representing the phase gradient register \n",
     "\n",
     "#### References\n",
-    " - [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](     https://arxiv.org/abs/2007.07391). Section II-C: Oracles for phasing by cost function. Appendix A: Addition for controlled rotations\n"
+    " - [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](https://arxiv.org/abs/2007.07391). Section II-C: Oracles for phasing by cost function. Appendix A: Addition for controlled rotations.\n"
    ]
   },
   {

--- a/qualtran/bloqs/chemistry/quad_fermion/givens_bloq.py
+++ b/qualtran/bloqs/chemistry/quad_fermion/givens_bloq.py
@@ -86,10 +86,9 @@ class RealGivensRotationByPhaseGradient(Bloq):
         phase_gradient: QFxp data type representing the phase gradient register
 
     References:
-        [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](
-            https://arxiv.org/abs/2007.07391).
+        [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](https://arxiv.org/abs/2007.07391).
         Section II-C: Oracles for phasing by cost function. Appendix A: Addition for controlled
-        rotations
+        rotations.
     """
 
     phasegrad_bitsize: int

--- a/qualtran/bloqs/chemistry/trotter/grid_ham/inverse_sqrt.py
+++ b/qualtran/bloqs/chemistry/trotter/grid_ham/inverse_sqrt.py
@@ -200,8 +200,7 @@ class PolynmomialEvaluationInverseSquareRoot(Bloq):
         out: Output register to store polynomial approximation to inverse square root.
 
     References:
-        [Quantum computation of stopping power for inertial fusion target design](
-            https://arxiv.org/pdf/2308.12352.pdf)
+        [Quantum computation of stopping power for inertial fusion target design](https://arxiv.org/abs/2308.12352).
     """
 
     x_sq_bitsize: int

--- a/qualtran/bloqs/chemistry/trotter/grid_ham/trotter.ipynb
+++ b/qualtran/bloqs/chemistry/trotter/grid_ham/trotter.ipynb
@@ -49,7 +49,7 @@
     " - `out`: Output register to store polynomial approximation to inverse square root. \n",
     "\n",
     "#### References\n",
-    " - [Quantum computation of stopping power for inertial fusion target design](     https://arxiv.org/pdf/2308.12352.pdf)\n"
+    " - [Quantum computation of stopping power for inertial fusion target design](https://arxiv.org/abs/2308.12352). \n"
    ]
   },
   {

--- a/qualtran/bloqs/chemistry/trotter/hubbard/hopping.py
+++ b/qualtran/bloqs/chemistry/trotter/hubbard/hopping.py
@@ -174,8 +174,8 @@ class HoppingTileHWP(HoppingTile):
         system: The system register of size 2 `length`.
 
     References:
-        [Early fault-tolerant simulations of the Hubbard model](
-            https://arxiv.org/abs/2012.09238) see Eq. 21 and App E.
+        [Early fault-tolerant simulations of the Hubbard model](https://arxiv.org/abs/2012.09238).
+        Eq. 21 and App E.
     """
 
     def short_name(self) -> str:

--- a/qualtran/bloqs/chemistry/trotter/hubbard/hubbard.ipynb
+++ b/qualtran/bloqs/chemistry/trotter/hubbard/hubbard.ipynb
@@ -463,7 +463,7 @@
     " - `system`: The system register of size 2 `length`. \n",
     "\n",
     "#### References\n",
-    " - [Early fault-tolerant simulations of the Hubbard model](     https://arxiv.org/abs/2012.09238) see Eq. 21 and App E.\n"
+    " - [Early fault-tolerant simulations of the Hubbard model](https://arxiv.org/abs/2012.09238). Eq. 21 and App E.\n"
    ]
   },
   {
@@ -581,7 +581,7 @@
     " - `system`: The system register of size 2 `length`. \n",
     "\n",
     "#### References\n",
-    " - [Early fault-tolerant simulations of the Hubbard model](     https://arxiv.org/abs/2012.09238) Eq. page 13 paragraph 1, and page     14 paragraph 3 right column. The apply 2 batches of $L^2/2$ rotations.\n"
+    " - [Early fault-tolerant simulations of the Hubbard model](https://arxiv.org/abs/2012.09238). Eq. page 13 paragraph 1, and page 14 paragraph 3 right column. They apply 2 batches of $L^2/2$ rotations.\n"
    ]
   },
   {

--- a/qualtran/bloqs/chemistry/trotter/hubbard/interaction.py
+++ b/qualtran/bloqs/chemistry/trotter/hubbard/interaction.py
@@ -91,9 +91,9 @@ class InteractionHWP(Bloq):
         system: The system register of size 2 `length`.
 
     References:
-        [Early fault-tolerant simulations of the Hubbard model](
-            https://arxiv.org/abs/2012.09238) Eq. page 13 paragraph 1, and page
-            14 paragraph 3 right column. The apply 2 batches of $L^2/2$ rotations.
+        [Early fault-tolerant simulations of the Hubbard model](https://arxiv.org/abs/2012.09238).
+        Eq. page 13 paragraph 1, and page 14 paragraph 3 right column.
+        They apply 2 batches of $L^2/2$ rotations.
     """
 
     length: SymbolicInt

--- a/qualtran/bloqs/chemistry/trotter/trotterized_unitary.ipynb
+++ b/qualtran/bloqs/chemistry/trotter/trotterized_unitary.ipynb
@@ -85,8 +85,8 @@
     " - `system`: The system register to which to apply the unitary. \n",
     "\n",
     "#### References\n",
-    " - [Theory of Trotter Error with Commutator Scaling](     https://journals.aps.org/prx/abstract/10.1103/PhysRevX.11.011020) Eq. 12 page 7.\n",
-    " - [Trotter error with commutator scaling for the Fermi-Hubbard model](     https://arxiv.org/abs/2306.10603) see github repo for software to produce splittings.\n"
+    " - [Theory of Trotter Error with Commutator Scaling](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.11.011020). Eq. 12 page 7.\n",
+    " - [Trotter error with commutator scaling for the Fermi-Hubbard model](https://arxiv.org/abs/2306.10603). See github repo for software to produce splittings.\n"
    ]
   },
   {

--- a/qualtran/bloqs/chemistry/trotter/trotterized_unitary.py
+++ b/qualtran/bloqs/chemistry/trotter/trotterized_unitary.py
@@ -74,11 +74,11 @@ class TrotterizedUnitary(Bloq):
         system: The system register to which to apply the unitary.
 
     References:
-        [Theory of Trotter Error with Commutator Scaling](
-            https://journals.aps.org/prx/abstract/10.1103/PhysRevX.11.011020) Eq. 12 page 7.
+        [Theory of Trotter Error with Commutator Scaling](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.11.011020)
+        Eq. 12 page 7.
 
-        [Trotter error with commutator scaling for the Fermi-Hubbard model](
-            https://arxiv.org/abs/2306.10603) see github repo for software to produce splittings.
+        [Trotter error with commutator scaling for the Fermi-Hubbard model](https://arxiv.org/abs/2306.10603).
+        See github repo for software to produce splittings.
     """
 
     bloqs: Sequence[Bloq]

--- a/qualtran/bloqs/multiplexers/apply_lth_bloq.ipynb
+++ b/qualtran/bloqs/multiplexers/apply_lth_bloq.ipynb
@@ -56,7 +56,7 @@
     " - `[user_spec]`: The output registers of the bloqs in `ops`. \n",
     "\n",
     "#### References\n",
-    " - [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity]( https://arxiv.org/abs/1805.03662). Babbush et al. (2018). Section III.A. and Figure 7.\n"
+    " - [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662). Babbush et al. (2018). Section III.A. and Figure 7.\n"
    ]
   },
   {

--- a/qualtran/bloqs/multiplexers/apply_lth_bloq.py
+++ b/qualtran/bloqs/multiplexers/apply_lth_bloq.py
@@ -51,8 +51,8 @@ class ApplyLthBloq(UnaryIterationGate, SpecializedSingleQubitControlledExtension
         [user_spec]: The output registers of the bloqs in `ops`.
 
     References:
-        [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](
-        https://arxiv.org/abs/1805.03662). Babbush et al. (2018). Section III.A. and Figure 7.
+        [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662).
+        Babbush et al. (2018). Section III.A. and Figure 7.
     """
 
     # type ignore needed here for Bloq as NDArray parameter

--- a/qualtran/bloqs/phase_estimation/lp_resource_state.py
+++ b/qualtran/bloqs/phase_estimation/lp_resource_state.py
@@ -106,11 +106,10 @@ class LPResourceState(QPEWindowStateBase):
 
 
     References:
-        [Optimum phase-shift estimation and the quantum description of the phase
-        difference](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.54.4564)
+        [Optimum phase-shift estimation and the quantum description of the phase difference](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.54.4564).
 
-        [Encoding Electronic Spectra in Quantum Circuits with Linear T
-        Complexity](https://arxiv.org/abs/1805.03662) Section II-B
+        [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662).
+        Section II-B
     """
 
     bitsize: SymbolicInt

--- a/qualtran/bloqs/rotations/hamming_weight_phasing.ipynb
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing.ipynb
@@ -199,7 +199,7 @@
     " - `phase_grad`: Phase gradient THRU register of size `O(log2(1/eps))`, to be used to apply the phasing via addition. \n",
     "\n",
     "#### References\n",
-    " - 1. [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization] (https://arxiv.org/abs/2007.07391), Appendix A: Addition for controlled rotations\n"
+    " - [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](https://arxiv.org/abs/2007.07391). Appendix A: Addition for controlled rotations\n"
    ]
   },
   {

--- a/qualtran/bloqs/rotations/hamming_weight_phasing.py
+++ b/qualtran/bloqs/rotations/hamming_weight_phasing.py
@@ -154,8 +154,8 @@ class HammingWeightPhasingViaPhaseGradient(GateWithRegisters):
             apply the phasing via addition.
 
     References:
-        1. [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization]
-        (https://arxiv.org/abs/2007.07391), Appendix A: Addition for controlled rotations
+        [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](https://arxiv.org/abs/2007.07391).
+        Appendix A: Addition for controlled rotations
     """
 
     bitsize: int

--- a/qualtran/bloqs/rotations/phase_gradient.ipynb
+++ b/qualtran/bloqs/rotations/phase_gradient.ipynb
@@ -70,7 +70,7 @@
     "\n",
     "#### References\n",
     " - [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](https://arxiv.org/abs/2007.07391). Appendix A: Addition for controlled rotations\n",
-    " - [Halving the cost of quantum addition](https://quantum-journal.org/papers/q-2018-06-18-74/pdf/). \n"
+    " - [Halving the cost of quantum addition](https://arxiv.org/abs/1709.06648). Gidney (2017).\n"
    ]
   },
   {

--- a/qualtran/bloqs/rotations/phase_gradient.py
+++ b/qualtran/bloqs/rotations/phase_gradient.py
@@ -88,7 +88,8 @@ class PhaseGradientUnitary(GateWithRegisters):
         [Compilation of Fault-Tolerant Quantum Heuristics for Combinatorial Optimization](https://arxiv.org/abs/2007.07391)
         Appendix A: Addition for controlled rotations
 
-        [Halving the cost of quantum addition](https://quantum-journal.org/papers/q-2018-06-18-74/pdf/)
+        [Halving the cost of quantum addition](https://arxiv.org/abs/1709.06648).
+        Gidney (2017).
     """
 
     bitsize: 'SymbolicInt'

--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.ipynb
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.ipynb
@@ -241,7 +241,8 @@
     "Total space will be $(2 \\log(L) + \\log(d) + 2 \\mu + 1)$ work qubits + $log(L)$ ancillas for QROM.\n",
     "\n",
     "#### References\n",
-    " - [1] [Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization](https://arxiv.org/pdf/1902.02134#page=15.30) Berry et al. (2019). Section 5, Eqs. 43, 44. [2] [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662). Babbush et al. (2018). Section III.D. and Figure 11.\n"
+    " - [Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization](https://arxiv.org/abs/1902.02134). Berry et al. (2019). Section 5, Eqs. 43, 44.\n",
+    " - [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662). Babbush et al. (2018). Section III.D. and Figure 11.\n"
    ]
   },
   {

--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
@@ -348,9 +348,10 @@ class SparseStatePreparationAliasSampling(PrepareOracle):
     Total space will be $(2 \log(L) + \log(d) + 2 \mu + 1)$ work qubits + $log(L)$ ancillas for QROM.
 
     References:
-        [1] [Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization](https://arxiv.org/pdf/1902.02134#page=15.30)
+        [Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization](https://arxiv.org/abs/1902.02134).
         Berry et al. (2019). Section 5, Eqs. 43, 44.
-        [2] [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662).
+
+        [Encoding Electronic Spectra in Quantum Circuits with Linear T Complexity](https://arxiv.org/abs/1805.03662).
         Babbush et al. (2018). Section III.D. and Figure 11.
     """
 


### PR DESCRIPTION
Fix nits in references, spot check with `bibliography.ipynb`. 