### PR TITLE
Hone Bloq<->Cirq adapters

### DIFF
--- a/qualtran/_infra/gate_with_registers.py
+++ b/qualtran/_infra/gate_with_registers.py
@@ -319,7 +319,7 @@ class GateWithRegisters(Bloq, cirq.Gate, metaclass=abc.ABCMeta):
 
         return _wire_symbol_from_gate(self, self.signature, reg, idx)
 
-    # Part-2: Cirq-FT style interface can be used to implemented algorithms by Bloq authors.
+    # Part-2: Cirq-FT style interface can be used to implement algorithms by Bloq authors.
 
     def _num_qubits_(self) -> int:
         return total_bits(self.signature)

--- a/qualtran/bloqs/basic_gates/global_phase.py
+++ b/qualtran/bloqs/basic_gates/global_phase.py
@@ -31,7 +31,7 @@ from qualtran import (
     SoquetT,
 )
 from qualtran.bloqs.basic_gates.rotation import ZPowGate
-from qualtran.cirq_interop import CirqGateAsBloqBase
+from qualtran.cirq_interop import CirqGateAsBloqMixin
 from qualtran.symbolics import pi, sarg, sexp, SymbolicComplex, SymbolicFloat
 
 if TYPE_CHECKING:
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 
 
 @frozen
-class GlobalPhase(CirqGateAsBloqBase):
+class GlobalPhase(CirqGateAsBloqMixin):
     r"""Applies a global phase to the circuit as a whole.
 
     The unitary effect is to multiply the state vector by the complex scalar

--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -21,13 +21,13 @@ import sympy
 from attrs import frozen
 
 from qualtran import bloq_example, BloqDocSpec, CompositeBloq, DecomposeTypeError, Register
-from qualtran.cirq_interop import CirqGateAsBloqBase
+from qualtran.cirq_interop import CirqGateAsBloqMixin
 from qualtran.drawing import Text, TextBox, WireSymbol
 from qualtran.symbolics import SymbolicFloat
 
 
 @frozen
-class ZPowGate(CirqGateAsBloqBase):
+class ZPowGate(CirqGateAsBloqMixin):
     r"""A gate that rotates around the Z axis of the Bloch sphere.
 
     The unitary matrix of `ZPowGate(exponent=t, global_shift=s)` is:
@@ -107,7 +107,7 @@ _Z_POW_DOC = BloqDocSpec(bloq_cls=ZPowGate, examples=[_z_pow])
 
 
 @frozen
-class CZPowGate(CirqGateAsBloqBase):
+class CZPowGate(CirqGateAsBloqMixin):
     exponent: float = 1.0
     global_shift: float = 0.0
     eps: SymbolicFloat = 1e-11
@@ -131,7 +131,7 @@ class CZPowGate(CirqGateAsBloqBase):
 
 
 @frozen
-class XPowGate(CirqGateAsBloqBase):
+class XPowGate(CirqGateAsBloqMixin):
     r"""A gate that rotates around the X axis of the Bloch sphere.
 
     The unitary matrix of `XPowGate(exponent=t, global_shift=s)` is:
@@ -205,7 +205,7 @@ _X_POW_DOC = BloqDocSpec(bloq_cls=XPowGate, examples=[_x_pow])
 
 
 @frozen
-class YPowGate(CirqGateAsBloqBase):
+class YPowGate(CirqGateAsBloqMixin):
     r"""A gate that rotates around the Y axis of the Bloch sphere.
 
     The unitary matrix of `YPowGate(exponent=t)` is:
@@ -279,7 +279,7 @@ _Y_POW_DOC = BloqDocSpec(bloq_cls=YPowGate, examples=[_y_pow])
 
 
 @frozen
-class Rz(CirqGateAsBloqBase):
+class Rz(CirqGateAsBloqMixin):
     """Single-qubit Rz gate.
 
     Args:
@@ -320,7 +320,7 @@ class Rz(CirqGateAsBloqBase):
 
 
 @frozen
-class Rx(CirqGateAsBloqBase):
+class Rx(CirqGateAsBloqMixin):
     angle: Union[sympy.Expr, float]
     eps: SymbolicFloat = 1e-11
 
@@ -344,7 +344,7 @@ class Rx(CirqGateAsBloqBase):
 
 
 @frozen
-class Ry(CirqGateAsBloqBase):
+class Ry(CirqGateAsBloqMixin):
     angle: Union[sympy.Expr, float]
     eps: SymbolicFloat = 1e-11
 

--- a/qualtran/cirq_interop/__init__.py
+++ b/qualtran/cirq_interop/__init__.py
@@ -20,7 +20,7 @@ isort:skip_file
 from ._cirq_to_bloq import (
     CirqQuregT,
     CirqGateAsBloq,
-    CirqGateAsBloqBase,
+    CirqGateAsBloqMixin,
     cirq_optree_to_cbloq,
     cirq_gate_to_bloq,
     decompose_from_cirq_style_method,

--- a/qualtran/cirq_interop/_bloq_to_cirq.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq.py
@@ -14,13 +14,11 @@
 
 """Qualtran Bloqs to Cirq gates/circuits conversion."""
 
-from functools import cached_property
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import cirq
 import networkx as nx
 import numpy as np
-from numpy.typing import NDArray
 
 from qualtran import (
     Bloq,
@@ -40,7 +38,6 @@ from qualtran._infra.gate_with_registers import (
     _get_all_and_output_quregs_from_input,
     merge_qubits,
     split_qubits,
-    total_bits,
 )
 from qualtran.cirq_interop._cirq_to_bloq import _QReg, CirqQuregInT, CirqQuregT
 from qualtran.cirq_interop._interop_qubit_manager import InteropQubitManager
@@ -58,7 +55,9 @@ def _cirq_style_decompose_from_decompose_bloq(
     # Input qubits can get de-allocated by cbloq.to_cirq_circuit_and_quregs, thus mark them as managed.
     qm = InteropQubitManager(context.qubit_manager)
     qm.manage_qubits(merge_qubits(bloq.signature.lefts(), **in_quregs))
-    circuit, out_quregs = cbloq.to_cirq_circuit_and_quregs(qubit_manager=qm, **in_quregs)
+    circuit, out_quregs = _cbloq_to_cirq_circuit(
+        cbloq.signature, in_quregs, cbloq._binst_graph, qubit_manager=qm
+    )
     qubit_map = {q: q for q in circuit.all_qubits()}
     for reg in bloq.signature.rights():
         if reg.side == Side.RIGHT:
@@ -93,11 +92,6 @@ class BloqAsCirqGate(cirq.Gate):
         """The bloq we're wrapping."""
         return self._bloq
 
-    @cached_property
-    def signature(self) -> Signature:
-        """`GateWithRegisters` registers."""
-        return self.bloq.signature
-
     @classmethod
     def bloq_on(
         cls, bloq: Bloq, cirq_quregs: Dict[str, 'CirqQuregT'], qubit_manager: cirq.QubitManager  # type: ignore[type-var]
@@ -120,15 +114,16 @@ class BloqAsCirqGate(cirq.Gate):
         all_quregs, out_quregs = _get_all_and_output_quregs_from_input(
             bloq.signature, qubit_manager, in_quregs=cirq_quregs
         )
-        return BloqAsCirqGate(bloq=bloq).on_registers(**all_quregs), out_quregs
+        cirq_op = BloqAsCirqGate(bloq=bloq).on(*merge_qubits(bloq.signature, **all_quregs))
+        return cirq_op, out_quregs
 
     def _num_qubits_(self) -> int:
-        return total_bits(self.signature)
+        return self.bloq.signature.n_qubits()
 
     def _decompose_with_context_(
         self, qubits: Sequence[cirq.Qid], context: Optional[cirq.DecompositionContext] = None
     ) -> cirq.OP_TREE:
-        quregs = split_qubits(self.signature, qubits)
+        quregs = split_qubits(self.bloq.signature, qubits)
         if context is None:
             context = cirq.DecompositionContext(cirq.ops.SimpleQubitManager())
         try:
@@ -143,21 +138,15 @@ class BloqAsCirqGate(cirq.Gate):
         return self._decompose_with_context_(qubits)
 
     def _unitary_(self):
-        if all(reg.side == Side.THRU for reg in self.signature):
+        if all(reg.side == Side.THRU for reg in self.bloq.signature):
             try:
-                _ = self.bloq.decompose_bloq()  # check for decomposability
-                return NotImplemented
-            except (DecomposeNotImplementedError, DecomposeTypeError):
                 tensor = self.bloq.tensor_contract()
                 if tensor.ndim != 2:
                     return NotImplemented
                 return tensor
+            except NotImplementedError:
+                return NotImplemented
         return NotImplemented
-
-    def on_registers(
-        self, **qubit_regs: Union[cirq.Qid, Sequence[cirq.Qid], NDArray[cirq.Qid]]  # type: ignore[type-var]
-    ) -> cirq.Operation:
-        return self.on(*merge_qubits(self.signature, **qubit_regs))
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
         """Draw cirq diagrams.

--- a/qualtran/cirq_interop/_bloq_to_cirq_test.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq_test.py
@@ -19,7 +19,7 @@ import pytest
 from attrs import frozen
 
 from qualtran import Bloq, BloqBuilder, ConnectionT, Signature, Soquet, SoquetT
-from qualtran._infra.gate_with_registers import get_named_qubits
+from qualtran._infra.gate_with_registers import get_named_qubits, merge_qubits
 from qualtran.bloqs.basic_gates import Toffoli, XGate, YGate
 from qualtran.bloqs.factoring import ModExp
 from qualtran.bloqs.mcmt.and_bloq import And, MultiAnd
@@ -226,8 +226,8 @@ def test_bloq_as_cirq_gate_for_mod_exp():
     mod_exp = ModExp.make_for_shor(4, 3)
     gate = BloqAsCirqGate(mod_exp)
     # Use Cirq's infrastructure to construct an operation and corresponding decomposition.
-    quregs = get_named_qubits(gate.signature)
-    op = gate.on_registers(**quregs)
+    quregs = get_named_qubits(mod_exp.signature)
+    op = gate.on(*merge_qubits(mod_exp.signature, **quregs))
     # cirq.decompose_once(op) delegates to underlying Bloq's decomposition specified in
     # `bloq.decompose_bloq()` and wraps resulting composite bloq in a Cirq op-tree. Note
     # how `BloqAsCirqGate.decompose_with_registers()` automatically takes care of mapping
@@ -257,7 +257,7 @@ x1: ──────────x──────────1───*=3�
     decomposed_circuit, out_regs = cbloq.to_cirq_circuit_and_quregs(exponent=quregs['exponent'])
     # Whereas when directly applying a cirq gate on qubits to get an operations, we need to
     # specify both input and output registers.
-    circuit = cirq.Circuit(gate.on_registers(**out_regs), decomposed_circuit)
+    circuit = cirq.Circuit(gate.on(*merge_qubits(cbloq.signature, **out_regs)), decomposed_circuit)
     # Notice the newly allocated qubits _C(0) and _C(1) for output register x.
     cirq.testing.assert_has_diagram(
         circuit,


### PR DESCRIPTION
CirqGateAsBloq only has bloq API. BloqAsCirqGate only has cirq API.

I also took the liberty of removing a level of indirection that had BloqAsCirqGate bopping over to composite_bloq.py only to immediately come back to the interop module. 

Changed CirqGateAsBloqBase to CirqGateAsBloqMixin and wrote about its intended use case(s).