### PR TITLE
[qwa] Export docs for bloqs without examples

### DIFF
--- a/dev_tools/ui-export.ipynb
+++ b/dev_tools/ui-export.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/dev_tools/ui-export.ipynb
+++ b/dev_tools/ui-export.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,12 +45,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "import attrs\n",
     "import hashlib\n",
+    "import json\n",
     "\n",
     "from qualtran import CompositeBloq\n",
     "from qualtran.bloqs.rotations.programmable_rotation_gate_array import ProgrammableRotationGateArray\n",
@@ -71,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,13 +133,6 @@
     "  for child_bloq, _ in call_graph.succ[bloq].items():\n",
     "    write_example(child_bloq)\n",
     "\n",
-    "  Path(f'ui_export/{bloq.__class__.__name__}').mkdir(parents=True, exist_ok=True)\n",
-    "\n",
-    "  doc_name = f'ui_export/{bloq.__class__.__name__}/docs.txt'\n",
-    "  if not os.path.isfile(doc_name):\n",
-    "    with open(doc_name, 'w') as doc_file:\n",
-    "      doc_file.write('\\n'.join(get_markdown_docstring(bloq.__class__)))\n",
-    "\n",
     "  file_name = f'ui_export/{bloq.__class__.__name__}/{bloq_filename(bloq)}'\n",
     "  if not os.path.isfile(file_name):\n",
     "    bloq_dict = {\n",
@@ -160,6 +154,13 @@
     "for section in NB_BY_SECTION:\n",
     "  for notebook_spec in section[1]:\n",
     "    for bloq_spec in notebook_spec.bloq_specs:\n",
+    "      Path(f'ui_export/{bloq_spec.bloq_cls.__name__}').mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "      doc_name = f'ui_export/{bloq_spec.bloq_cls.__name__}/docs.txt'\n",
+    "      if not os.path.isfile(doc_name):\n",
+    "        with open(doc_name, 'w') as doc_file:\n",
+    "          doc_file.write('\\n'.join(get_markdown_docstring(bloq_spec.bloq_cls)))\n",
+    "\n",
     "      for example in bloq_spec.examples:\n",
     "        write_example(example.make())"
    ]


### PR DESCRIPTION
Previously, the JSON export for the web app did not export documentation for Bloqs with no examples. This fixes that, which is a prerequisite for b/372965588.