### PR TITLE
Override KaliskiModInverse.adjoint

### DIFF
--- a/qualtran/bloqs/mod_arithmetic/mod_division.py
+++ b/qualtran/bloqs/mod_arithmetic/mod_division.py
@@ -17,7 +17,7 @@ from typing import cast, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 import sympy
-from attrs import frozen
+from attrs import evolve, frozen
 
 from qualtran import (
     Bloq,
@@ -631,6 +631,9 @@ class KaliskiModInverse(Bloq):
         bb.free(s)
         bb.free(f)
         return {'x': x, 'm': m}
+
+    def adjoint(self) -> 'KaliskiModInverse':
+        return evolve(self, uncompute=self.uncompute ^ True)
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return _KaliskiModInverseImpl(self.bitsize, self.mod).build_call_graph(ssa)

--- a/qualtran/bloqs/mod_arithmetic/mod_division.py
+++ b/qualtran/bloqs/mod_arithmetic/mod_division.py
@@ -633,7 +633,7 @@ class KaliskiModInverse(Bloq):
         return {'x': x, 'm': m}
 
     def adjoint(self) -> 'KaliskiModInverse':
-        return evolve(self, uncompute=self.uncompute ^ True)
+        return evolve(self, uncompute=not self.uncompute)
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return _KaliskiModInverseImpl(self.bitsize, self.mod).build_call_graph(ssa)

--- a/qualtran/bloqs/mod_arithmetic/mod_division_test.py
+++ b/qualtran/bloqs/mod_arithmetic/mod_division_test.py
@@ -40,6 +40,7 @@ def test_kaliski_mod_inverse_classical_action(bitsize, mod):
         assert len(res) == 2
         assert res[0] == dtype.montgomery_inverse(x_montgomery, mod)
         assert dtype.montgomery_product(int(res[0]), x_montgomery, mod) == R
+        assert blq.adjoint().call_classically(x=res[0], m=res[1]) == (x_montgomery,)
 
 
 @pytest.mark.parametrize('bitsize', [5, 6])


### PR DESCRIPTION
this was missed in https://github.com/quantumlib/Qualtran/pull/1464
