### PR TITLE
Modify KaliskiModInverse to support zero

### DIFF
--- a/qualtran/bloqs/mod_arithmetic/mod_division_test.py
+++ b/qualtran/bloqs/mod_arithmetic/mod_division_test.py
@@ -36,11 +36,24 @@ def test_kaliski_mod_inverse_classical_action(bitsize, mod):
             continue
         x_montgomery = dtype.uint_to_montgomery(x, mod)
         res = blq.call_classically(x=x_montgomery)
+        print(x, x_montgomery)
         assert res == cblq.call_classically(x=x_montgomery)
         assert len(res) == 2
         assert res[0] == dtype.montgomery_inverse(x_montgomery, mod)
         assert dtype.montgomery_product(int(res[0]), x_montgomery, mod) == R
-        assert blq.adjoint().call_classically(x=res[0], m=res[1]) == (x_montgomery,)
+        assert blq.adjoint().call_classically(x=res[0], junk=res[1]) == (x_montgomery,)
+
+
+@pytest.mark.parametrize('bitsize', [5, 6])
+@pytest.mark.parametrize('mod', [3, 5, 7, 11, 13, 15])
+def test_kaliski_mod_inverse_classical_action_zero(bitsize, mod):
+    blq = KaliskiModInverse(bitsize, mod)
+    cblq = blq.decompose_bloq()
+    # When x = 0 the terminal condition is achieved at the first iteration, this corresponds to
+    # m_0 = is_terminal_0 = 1 and all other bits = 0.
+    junk = 2 ** (4 * bitsize - 1) + 2 ** (2 * bitsize - 1)
+    assert blq.call_classically(x=0) == cblq.call_classically(x=0) == (0, junk)
+    assert blq.adjoint().call_classically(x=0, junk=junk) == (0,)
 
 
 @pytest.mark.parametrize('bitsize', [5, 6])


### PR DESCRIPTION
By construction KaliskiModInverse assumes its inputs are valid (i.e. gcd(x, mod) = 1). The case of zero is interesting however since for the bloq to be unitary it has to send zero to itself. the default circuit either does that or sends it to $p$ depending on whether the opreation $p - r$ is implemented as `ModNeg` $\mathcal{O}(2n)$ 
toffoli or as ~r -> AddK($p + 1$)  $\mathcal{O}(n)$ toffoli (which is what we do).

Changing the final step to use ModNeg solves the problem (but increases the toffoli costs by $n$). it also prevents us from freeing the $u$ and $s$  registers so we will have to keep them around for uncomputation. This means we keep $6n$ junk qubits.

Alternatively we can do this at no additional cost and by keeping only $4n$ junk qubits. The condition $x=0$ or more precisely $v=0$ is checked at the beginning of each iteration. so I just keep the result of that check for uncomputation. The case where $x=0$ corresponds to having the first check yield 1. Also the first check is 1 if and ony if $x=0$.
