### PR TITLE
Fix symbolic call graphs for factoring phase estimates

### DIFF
--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -988,6 +988,9 @@ class Equals(Bloq):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', x: 'Soquet', y: 'Soquet', target: 'Soquet'
     ) -> Dict[str, 'SoquetT']:
+        if is_symbolic(self.dtype.bitsize):
+            raise DecomposeTypeError(f"Cannot decompose {self} with symbolic `bitsize`.")
+
         cvs: Union[list[int], HasLength]
         if isinstance(self.bitsize, int):
             cvs = [0] * self.bitsize
@@ -1151,6 +1154,8 @@ class CLinearDepthGreaterThan(Bloq):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', ctrl: 'Soquet', a: 'Soquet', b: 'Soquet', target: 'Soquet'
     ) -> Dict[str, 'SoquetT']:
+        if is_symbolic(self.dtype.bitsize):
+            raise DecomposeTypeError(f"Cannot decompose {self} with symbolic `bitsize`.")
 
         if isinstance(self.dtype, QInt):
             a = bb.add(SignExtend(self.dtype, QInt(self.dtype.bitsize + 1)), x=a)
@@ -1360,6 +1365,9 @@ class _HalfLinearDepthGreaterThan(Bloq):
         c: Optional['Soquet'] = None,
         target: Optional['Soquet'] = None,
     ) -> Dict[str, 'SoquetT']:
+        if is_symbolic(self.dtype.bitsize):
+            raise DecomposeTypeError(f"Cannot decompose {self} with symbolic `bitsize`.")
+
         if self.uncompute:
             # Uncompute
             assert c is not None

--- a/qualtran/bloqs/arithmetic/comparison.py
+++ b/qualtran/bloqs/arithmetic/comparison.py
@@ -988,7 +988,7 @@ class Equals(Bloq):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', x: 'Soquet', y: 'Soquet', target: 'Soquet'
     ) -> Dict[str, 'SoquetT']:
-        if is_symbolic(self.dtype.bitsize):
+        if is_symbolic(self.bitsize):
             raise DecomposeTypeError(f"Cannot decompose {self} with symbolic `bitsize`.")
 
         cvs: Union[list[int], HasLength]

--- a/qualtran/bloqs/arithmetic/controlled_addition.py
+++ b/qualtran/bloqs/arithmetic/controlled_addition.py
@@ -23,6 +23,7 @@ from qualtran import (
     bloq_example,
     BloqBuilder,
     BloqDocSpec,
+    DecomposeTypeError,
     QBit,
     QInt,
     QUInt,
@@ -37,6 +38,7 @@ from qualtran.bloqs.bookkeeping import Cast
 from qualtran.bloqs.mcmt.and_bloq import And
 from qualtran.resource_counting.generalizers import ignore_split_join
 from qualtran.simulation.classical_sim import add_ints
+from qualtran.symbolics.types import is_symbolic
 
 if TYPE_CHECKING:
     import quimb.tensor as qtn
@@ -134,6 +136,9 @@ class CAdd(Bloq):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', ctrl: 'Soquet', a: 'Soquet', b: 'Soquet'
     ) -> Dict[str, 'SoquetT']:
+        if is_symbolic(self.a_dtype.bitsize, self.b_dtype.bitsize):
+            raise DecomposeTypeError(f"Cannot decompose {self} with symbolic `bitsize`.")
+
         a_arr = bb.split(a)
         ctrl_q = bb.split(ctrl)[0]
         ancilla_arr = []

--- a/qualtran/bloqs/factoring/ecc/ec_add_r.py
+++ b/qualtran/bloqs/factoring/ecc/ec_add_r.py
@@ -36,7 +36,7 @@ from qualtran.bloqs.data_loading import QROAMClean
 from qualtran.drawing import Circle, Text, TextBox, WireSymbol
 from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.simulation.classical_sim import ClassicalValT
-from qualtran.symbolics import is_symbolic, Shaped
+from qualtran.symbolics import is_symbolic, Shaped, SymbolicInt
 
 from .ec_add import ECAdd
 from .ec_point import ECPoint
@@ -75,7 +75,7 @@ class ECAddR(Bloq):
 
     """
 
-    n: int
+    n: 'SymbolicInt'
     R: ECPoint
 
     @cached_property
@@ -144,10 +144,10 @@ class ECWindowAddR(Bloq):
         Litinski. 2013. Section 1, eq. (3) and (4).
     """
 
-    n: int
+    n: 'SymbolicInt'
     R: ECPoint
-    add_window_size: int
-    mul_window_size: int = 1
+    add_window_size: 'SymbolicInt'
+    mul_window_size: 'SymbolicInt' = 1
 
     @cached_property
     def signature(self) -> 'Signature':

--- a/qualtran/bloqs/factoring/ecc/ec_phase_estimate_r.py
+++ b/qualtran/bloqs/factoring/ecc/ec_phase_estimate_r.py
@@ -34,6 +34,7 @@ from qualtran import (
 )
 from qualtran.bloqs.basic_gates import PlusState
 from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
+from qualtran.symbolics.types import SymbolicInt
 
 from .._factoring_shims import MeasureQFT
 from .ec_add_r import ECAddR, ECWindowAddR
@@ -58,10 +59,10 @@ class ECPhaseEstimateR(Bloq):
         mul_window_size: The number of bits in the modular multiplication window.
     """
 
-    n: int
+    n: 'SymbolicInt'
     point: ECPoint
-    add_window_size: int = 1
-    mul_window_size: int = 1
+    add_window_size: 'SymbolicInt' = 1
+    mul_window_size: 'SymbolicInt' = 1
 
     @cached_property
     def signature(self) -> 'Signature':

--- a/qualtran/bloqs/factoring/ecc/find_ecc_private_key.py
+++ b/qualtran/bloqs/factoring/ecc/find_ecc_private_key.py
@@ -75,11 +75,11 @@ class FindECCPrivateKey(Bloq):
         Litinski. 2023. Figure 4 (a).
     """
 
-    n: int
+    n: 'SymbolicInt'
     base_point: ECPoint
     public_key: ECPoint
-    add_window_size: int = 1
-    mul_window_size: int = 1
+    add_window_size: 'SymbolicInt' = 1
+    mul_window_size: 'SymbolicInt' = 1
 
     @cached_property
     def signature(self) -> 'Signature':

--- a/qualtran/bloqs/mod_arithmetic/mod_division.py
+++ b/qualtran/bloqs/mod_arithmetic/mod_division.py
@@ -138,6 +138,9 @@ class _KaliskiIterationStep2(Bloq):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', u: Soquet, v: Soquet, b: Soquet, a: Soquet, m: Soquet, f: Soquet
     ) -> Dict[str, 'SoquetT']:
+        if is_symbolic(self.bitsize):
+            raise DecomposeTypeError(f"Cannot decompose {self} with symbolic `bitsize`.")
+
         u_arr = bb.split(u)
         v_arr = bb.split(v)
 
@@ -543,6 +546,9 @@ class _KaliskiModInverseImpl(Bloq):
         f: Soquet,
         terminal_condition: Soquet,
     ) -> Dict[str, 'SoquetT']:
+        if is_symbolic(self.bitsize):
+            raise DecomposeTypeError(f"Cannot decompose {self} with symbolic `bitsize`.")
+
         f = bb.add(XGate(), q=f)
         u = bb.add(XorK(QMontgomeryUInt(self.bitsize), self.mod), x=u)
         s = bb.add(XorK(QMontgomeryUInt(self.bitsize), 1), x=s)
@@ -665,6 +671,9 @@ class KaliskiModInverse(Bloq):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', x: Soquet, junk: Optional[Soquet] = None
     ) -> Dict[str, 'SoquetT']:
+        if is_symbolic(self.bitsize):
+            raise DecomposeTypeError(f"Cannot decompose {self} with symbolic `bitsize`.")
+
         u = bb.allocate(self.bitsize, QMontgomeryUInt(self.bitsize))
         r = bb.allocate(self.bitsize, QMontgomeryUInt(self.bitsize))
         s = bb.allocate(self.bitsize, QMontgomeryUInt(self.bitsize))

--- a/qualtran/bloqs/mod_arithmetic/mod_multiplication.py
+++ b/qualtran/bloqs/mod_arithmetic/mod_multiplication.py
@@ -29,6 +29,7 @@ from qualtran import (
     BloqBuilder,
     BloqDocSpec,
     DecomposeNotImplementedError,
+    DecomposeTypeError,
     QBit,
     QInt,
     QMontgomeryUInt,
@@ -91,6 +92,9 @@ class ModDbl(Bloq):
         return {'x': x}
 
     def build_composite_bloq(self, bb: 'BloqBuilder', x: Soquet) -> Dict[str, 'SoquetT']:
+        if is_symbolic(self.dtype.bitsize):
+            raise DecomposeTypeError(f'symbolic decomposition is not supported for {self}')
+
         # Allocate ancilla bits for sign and double.
         lower_bit = bb.allocate(n=1)
         sign = bb.allocate(n=1)


### PR DESCRIPTION
- Adds symbolic type checking for remaining ECC bloqs (https://github.com/quantumlib/Qualtran/issues/1476)
- Adds DecomposeTypeErrors for bloqs which can't be symbolically decomposed
- Both call graphs for factoring phase estimates work for symbolic arguments
- Adds decomposition for MeasureQFT bloq to allow for call graphs of the phase estimation bloqs