### PR TITLE
Make `BloqBuilder.join` accept array-like of soquets

### DIFF
--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -1234,12 +1234,13 @@ class BloqBuilder:
 
         return self.add(Split(dtype=soq.reg.dtype), reg=soq)
 
-    def join(self, soqs: NDArray[Soquet], dtype: Optional[QDType] = None) -> Soquet:  # type: ignore[type-var]
+    def join(self, soqs: SoquetInT, dtype: Optional[QDType] = None) -> Soquet:
         from qualtran.bloqs.bookkeeping import Join
 
         try:
+            soqs = np.asarray(soqs)
             (n,) = soqs.shape
-        except AttributeError:
+        except (AttributeError, ValueError):
             raise ValueError("`join` expects a 1-d array of input soquets to join.") from None
 
         if not all(soq.reg.bitsize == 1 for soq in soqs):

--- a/qualtran/_infra/composite_bloq_test.py
+++ b/qualtran/_infra/composite_bloq_test.py
@@ -389,6 +389,12 @@ def test_util_convenience_methods():
     assert len(cbloq.connections) == 1 + 10 + 1
 
 
+def test_join_list():
+    bb = BloqBuilder()
+    qs = [bb.allocate() for _ in range(10)]
+    _ = bb.join(qs)
+
+
 def test_util_convenience_methods_errors():
     bb = BloqBuilder()
 


### PR DESCRIPTION
fixes #1470 