### PR TITLE
add option to generate QREF from callgraphs

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -31,8 +31,8 @@ qsharp
 qsharp-widgets
 
 # qref bartiq interop
-qref==0.7.0
-bartiq==0.6.0
+qref==0.9.0
+bartiq==0.9.0
 
 # serialization
 protobuf

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -12,7 +12,7 @@ alabaster==1.0.0
     # via sphinx
 annotated-types==0.7.0
     # via pydantic
-anyio==4.7.0
+anyio==4.8.0
     # via
     #   httpx
     #   jupyter-server
@@ -24,19 +24,19 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-ase==3.23.0
+ase==3.24.0
     # via openfermion
 astor==0.8.1
     # via
     #   flynt
     #   tensorflow-docs
-astroid==3.3.6
+astroid==3.3.8
     # via pylint
 asttokens==3.0.0
     # via stack-data
 async-lru==2.0.4
     # via jupyterlab
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -r deps/runtime.txt
     #   cirq-core
@@ -54,7 +54,7 @@ babel==2.16.0
     #   sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
-bartiq==0.6.0
+bartiq==0.9.0
     # via -r deps/runtime.txt
 beautifulsoup4==4.12.3
     # via
@@ -62,15 +62,15 @@ beautifulsoup4==4.12.3
     #   pydata-sphinx-theme
 black==24.8.0
     # via -r deps/format.txt
-bleach==6.2.0
+bleach[css]==6.2.0
     # via nbconvert
 blinker==1.9.0
     # via flask
 build==1.2.2.post1
     # via pip-tools
-cachetools==5.5.0
+cachetools==5.5.1
     # via -r deps/runtime.txt
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   httpcore
     #   httpx
@@ -79,13 +79,13 @@ cffi==1.17.1
     # via
     #   argon2-cffi-bindings
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 cirq-core==1.4.0
     # via
     #   -r deps/runtime.txt
     #   openfermion
-click==8.1.7
+click==8.1.8
     # via
     #   black
     #   flask
@@ -97,15 +97,15 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.3.1
     # via matplotlib
-cotengra==0.6.2
+cotengra==0.7.0
     # via quimb
-coverage[toml]==7.6.9
+coverage[toml]==7.6.10
     # via pytest-cov
 cryptography==44.0.0
     # via secretstorage
 cycler==0.12.1
     # via matplotlib
-cytoolz==1.0.0
+cytoolz==1.0.1
     # via quimb
 dash==2.18.2
     # via -r deps/runtime.txt
@@ -115,7 +115,7 @@ dash-html-components==2.0.0
     # via dash
 dash-table==5.0.0
     # via dash
-debugpy==1.8.9
+debugpy==1.8.12
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -142,11 +142,11 @@ exceptiongroup==1.2.2
     #   pytest
 execnet==2.1.1
     # via pytest-xdist
-executing==2.1.0
+executing==2.2.0
     # via stack-data
 fastjsonschema==2.21.1
     # via nbformat
-filelock==3.16.1
+filelock==3.17.0
     # via
     #   -r deps/pylint.txt
     #   -r deps/pytest.txt
@@ -155,21 +155,21 @@ flask==3.0.3
     # via dash
 flynt==0.78
     # via -r deps/format.txt
-fonttools==4.55.2
+fonttools==4.55.4
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 fxpmath==0.4.9
     # via -r deps/runtime.txt
-galois==0.4.3
+galois==0.4.4
     # via -r deps/runtime.txt
 graphviz==0.20.3
     # via qref
 greenlet==3.1.1
     # via sqlalchemy
-grpcio==1.68.1
+grpcio==1.69.0
     # via grpcio-tools
-grpcio-tools==1.68.1
+grpcio-tools==1.69.0
     # via -r deps/packaging.txt
 h11==0.14.0
     # via httpcore
@@ -181,6 +181,8 @@ httpcore==1.0.7
     # via httpx
 httpx==0.28.1
     # via jupyterlab
+id==1.5.0
+    # via twine
 idna==3.10
     # via
     #   anyio
@@ -189,7 +191,7 @@ idna==3.10
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via
     #   dash
     #   jupyter-cache
@@ -202,7 +204,7 @@ ipykernel==6.29.5
     #   -r deps/pytest.txt
     #   jupyterlab
     #   myst-nb
-ipython==8.30.0
+ipython==8.31.0
     # via
     #   -r deps/runtime.txt
     #   ipykernel
@@ -227,9 +229,9 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jax==0.4.36
+jax==0.5.0
     # via openfermion
-jaxlib==0.4.36
+jaxlib==0.5.0
     # via
     #   jax
     #   openfermion
@@ -239,7 +241,7 @@ jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   flask
     #   jupyter-server
@@ -276,11 +278,11 @@ jupyter-core==5.7.2
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyter-events==0.10.0
+jupyter-events==0.11.0
     # via jupyter-server
 jupyter-lsp==2.2.5
     # via jupyterlab
-jupyter-server==2.14.2
+jupyter-server==2.15.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -289,7 +291,7 @@ jupyter-server==2.14.2
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.3.2
+jupyterlab==4.3.4
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
@@ -299,11 +301,11 @@ jupyterlab-server==2.27.3
     #   notebook
 jupyterlab-widgets==3.0.13
     # via ipywidgets
-keyring==25.5.0
+keyring==25.6.0
     # via twine
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via matplotlib
-llvmlite==0.43.0
+llvmlite==0.44.0
     # via numba
 markdown-it-py==3.0.0
     # via
@@ -315,7 +317,7 @@ markupsafe==3.0.2
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.3
+matplotlib==3.10.0
     # via
     #   -r deps/runtime.txt
     #   ase
@@ -330,19 +332,19 @@ mdit-py-plugins==0.4.2
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-mistune==3.0.2
+mistune==3.1.0
     # via nbconvert
-ml-dtypes==0.5.0
+ml-dtypes==0.5.1
     # via
     #   jax
     #   jaxlib
-more-itertools==10.5.0
+more-itertools==10.6.0
     # via
     #   jaraco-classes
     #   jaraco-functools
 mpmath==1.3.0
     # via sympy
-mypy==1.13.0
+mypy==1.14.1
     # via -r deps/mypy.txt
 mypy-extensions==1.0.0
     # via
@@ -354,12 +356,12 @@ myst-nb==1.1.2
     # via -r deps/docs.txt
 myst-parser==4.0.0
     # via myst-nb
-nbclient==0.10.1
+nbclient==0.10.2
     # via
     #   jupyter-cache
     #   myst-nb
     #   nbconvert
-nbconvert==7.16.4
+nbconvert==7.16.5
     # via
     #   -r deps/docs.txt
     #   -r deps/runtime.txt
@@ -383,9 +385,9 @@ networkx==3.4.2
     #   -r deps/runtime.txt
     #   cirq-core
     #   openfermion
-nh3==0.2.19
+nh3==0.2.20
     # via readme-renderer
-notebook==7.3.1
+notebook==7.3.2
     # via
     #   -r deps/dev-tools.txt
     #   -r deps/runtime.txt
@@ -393,7 +395,7 @@ notebook-shim==0.2.4
     # via
     #   jupyterlab
     #   notebook
-numba==0.60.0
+numba==0.61.0
     # via
     #   galois
     #   quimb
@@ -449,12 +451,10 @@ pathspec==0.12.1
     # via black
 pexpect==4.9.0
     # via ipython
-pillow==11.0.0
+pillow==11.1.0
     # via matplotlib
 pip-tools==7.4.1
     # via -r deps/pip-tools.txt
-pkginfo==1.12.0
-    # via twine
 platformdirs==4.3.6
     # via
     #   black
@@ -469,15 +469,15 @@ pluggy==1.5.0
     # via pytest
 prometheus-client==0.21.1
     # via jupyter-server
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via ipython
-protobuf==5.29.1
+protobuf==5.29.3
     # via
     #   -r deps/runtime.txt
     #   grpcio-tools
     #   mypy-protobuf
     #   tensorflow-docs
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   ipykernel
     #   quimb
@@ -493,17 +493,17 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pydantic==2.10.3
+pydantic==2.10.5
     # via
     #   bartiq
     #   qref
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via pydantic
-pydata-sphinx-theme==0.16.0
+pydata-sphinx-theme==0.16.1
     # via -r deps/docs.txt
-pydot==3.0.3
+pydot==3.0.4
     # via -r deps/runtime.txt
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   accessible-pygments
     #   ipython
@@ -512,7 +512,7 @@ pygments==2.18.0
     #   readme-renderer
     #   rich
     #   sphinx
-pylint==3.3.2
+pylint==3.3.3
     # via -r deps/pylint.txt
 pyparsing==3.1.4
     # via
@@ -523,7 +523,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pyscf==2.7.0
+pyscf==2.8.0
     # via openfermion
 pytest==8.3.4
     # via
@@ -532,7 +532,7 @@ pytest==8.3.4
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.24.0
+pytest-asyncio==0.25.2
     # via -r deps/pytest.txt
 pytest-cov==6.0.0
     # via -r deps/pytest.txt
@@ -544,7 +544,7 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   matplotlib
     #   pandas
-python-json-logger==2.0.7
+python-json-logger==3.2.1
     # via jupyter-events
 pytz==2024.2
     # via pandas
@@ -560,19 +560,19 @@ pyzmq==26.2.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qref==0.7.0
+qref==0.9.0
     # via
     #   -r deps/runtime.txt
     #   bartiq
-qsharp==1.11.1
+qsharp==1.12.1
     # via -r deps/runtime.txt
-qsharp-widgets==1.11.1
+qsharp-widgets==1.12.1
     # via -r deps/runtime.txt
-quimb==1.9.0
+quimb==1.10.0
     # via -r deps/runtime.txt
 readme-renderer==44.0
     # via twine
-referencing==0.35.1
+referencing==0.36.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -580,6 +580,7 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   dash
+    #   id
     #   jupyterlab-server
     #   openfermion
     #   requests-toolbelt
@@ -605,7 +606,7 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-scipy==1.14.1
+scipy==1.15.1
     # via
     #   ase
     #   cirq-core
@@ -650,7 +651,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.36
+sqlalchemy==2.0.37
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -674,7 +675,7 @@ terminado==0.18.1
     #   jupyter-server
     #   jupyter-server-terminals
 tinycss2==1.4.0
-    # via nbconvert
+    # via bleach
 tomli==2.2.1
     # via
     #   black
@@ -718,7 +719,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-twine==6.0.1
+twine==6.1.0
     # via -r deps/packaging.txt
 types-protobuf==5.29.1.20241207
     # via mypy-protobuf
@@ -736,22 +737,24 @@ typing-extensions==4.12.2
     #   dash
     #   galois
     #   ipython
+    #   mistune
     #   mypy
     #   myst-nb
     #   pydantic
     #   pydantic-core
     #   pydata-sphinx-theme
+    #   referencing
     #   rich
     #   sqlalchemy
-tzdata==2024.2
+tzdata==2025.1
     # via pandas
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   requests
     #   twine
-virtualenv==20.28.0
+virtualenv==20.29.1
     # via -r deps/packaging.txt
 wcwidth==0.2.13
     # via prompt-toolkit

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -20,7 +20,7 @@ annotated-types==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-anyio==4.7.0
+anyio==4.8.0
     # via
     #   -c envs/dev.env.txt
     #   httpx
@@ -53,7 +53,7 @@ async-lru==2.0.4
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -72,7 +72,7 @@ babel==2.16.0
     #   jupyterlab-server
     #   pydata-sphinx-theme
     #   sphinx
-bartiq==0.6.0
+bartiq==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -81,7 +81,7 @@ beautifulsoup4==4.12.3
     #   -c envs/dev.env.txt
     #   nbconvert
     #   pydata-sphinx-theme
-bleach==6.2.0
+bleach[css]==6.2.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -89,11 +89,11 @@ blinker==1.9.0
     # via
     #   -c envs/dev.env.txt
     #   flask
-cachetools==5.5.0
+cachetools==5.5.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c envs/dev.env.txt
     #   httpcore
@@ -103,7 +103,7 @@ cffi==1.17.1
     # via
     #   -c envs/dev.env.txt
     #   argon2-cffi-bindings
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -111,7 +111,7 @@ cirq-core==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-click==8.1.7
+click==8.1.8
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -125,7 +125,7 @@ contourpy==1.3.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.6.2
+cotengra==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -133,7 +133,7 @@ cycler==0.12.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cytoolz==1.0.0
+cytoolz==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -153,7 +153,7 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-debugpy==1.8.9
+debugpy==1.8.12
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -180,7 +180,7 @@ exceptiongroup==1.2.2
     #   -c envs/dev.env.txt
     #   anyio
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   stack-data
@@ -192,7 +192,7 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.55.2
+fonttools==4.55.4
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -204,7 +204,7 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-galois==0.4.3
+galois==0.4.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -239,7 +239,7 @@ imagesize==1.4.1
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -250,7 +250,7 @@ ipykernel==6.29.5
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   myst-nb
-ipython==8.30.0
+ipython==8.31.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -275,7 +275,7 @@ jedi==0.19.2
     # via
     #   -c envs/dev.env.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -324,7 +324,7 @@ jupyter-core==5.7.2
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyter-events==0.10.0
+jupyter-events==0.11.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
@@ -332,7 +332,7 @@ jupyter-lsp==2.2.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-jupyter-server==2.14.2
+jupyter-server==2.15.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-lsp
@@ -344,7 +344,7 @@ jupyter-server-terminals==0.5.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-jupyterlab==4.3.2
+jupyterlab==4.3.4
     # via
     #   -c envs/dev.env.txt
     #   notebook
@@ -361,11 +361,11 @@ jupyterlab-widgets==3.0.13
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-llvmlite==0.43.0
+llvmlite==0.44.0
     # via
     #   -c envs/dev.env.txt
     #   numba
@@ -380,7 +380,7 @@ markupsafe==3.0.2
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.3
+matplotlib==3.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -398,7 +398,7 @@ mdurl==0.1.2
     # via
     #   -c envs/dev.env.txt
     #   markdown-it-py
-mistune==3.0.2
+mistune==3.1.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -414,13 +414,13 @@ myst-parser==4.0.0
     # via
     #   -c envs/dev.env.txt
     #   myst-nb
-nbclient==0.10.1
+nbclient==0.10.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-cache
     #   myst-nb
     #   nbconvert
-nbconvert==7.16.4
+nbconvert==7.16.5
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
@@ -447,7 +447,7 @@ networkx==3.4.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-notebook==7.3.1
+notebook==7.3.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -456,7 +456,7 @@ notebook-shim==0.2.4
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-numba==0.60.0
+numba==0.61.0
     # via
     #   -c envs/dev.env.txt
     #   galois
@@ -505,7 +505,7 @@ pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==11.0.0
+pillow==11.1.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -522,16 +522,16 @@ prometheus-client==0.21.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.29.1
+protobuf==5.29.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   tensorflow-docs
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -553,24 +553,24 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
-pydantic==2.10.3
+pydantic==2.10.5
     # via
     #   -c envs/dev.env.txt
     #   bartiq
     #   qref
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-pydata-sphinx-theme==0.16.0
+pydata-sphinx-theme==0.16.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
-pydot==3.0.3
+pydot==3.0.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   accessible-pygments
@@ -591,7 +591,7 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   matplotlib
     #   pandas
-python-json-logger==2.0.7
+python-json-logger==3.2.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
@@ -613,24 +613,24 @@ pyzmq==26.2.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qref==0.7.0
+qref==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   bartiq
-qsharp==1.11.1
+qsharp==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.11.1
+qsharp-widgets==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-quimb==1.9.0
+quimb==1.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.35.1
+referencing==0.36.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -661,7 +661,7 @@ rpds-py==0.22.3
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.14.1
+scipy==1.15.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -723,7 +723,7 @@ sphinxcontrib-serializinghtml==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sqlalchemy==2.0.36
+sqlalchemy==2.0.37
     # via
     #   -c envs/dev.env.txt
     #   jupyter-cache
@@ -757,7 +757,7 @@ terminado==0.18.1
 tinycss2==1.4.0
     # via
     #   -c envs/dev.env.txt
-    #   nbconvert
+    #   bleach
 tomli==2.2.1
     # via
     #   -c envs/dev.env.txt
@@ -812,12 +812,14 @@ typing-extensions==4.12.2
     #   dash
     #   galois
     #   ipython
+    #   mistune
     #   myst-nb
     #   pydantic
     #   pydantic-core
     #   pydata-sphinx-theme
+    #   referencing
     #   sqlalchemy
-tzdata==2024.2
+tzdata==2025.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -825,7 +827,7 @@ uri-template==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -8,7 +8,7 @@ annotated-types==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-anyio==4.7.0
+anyio==4.8.0
     # via
     #   -c envs/dev.env.txt
     #   httpx
@@ -41,7 +41,7 @@ async-lru==2.0.4
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -57,7 +57,7 @@ babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
-bartiq==0.6.0
+bartiq==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -69,7 +69,7 @@ black==24.8.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/format.txt
-bleach==6.2.0
+bleach[css]==6.2.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -77,11 +77,11 @@ blinker==1.9.0
     # via
     #   -c envs/dev.env.txt
     #   flask
-cachetools==5.5.0
+cachetools==5.5.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c envs/dev.env.txt
     #   httpcore
@@ -91,7 +91,7 @@ cffi==1.17.1
     # via
     #   -c envs/dev.env.txt
     #   argon2-cffi-bindings
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -99,7 +99,7 @@ cirq-core==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-click==8.1.7
+click==8.1.8
     # via
     #   -c envs/dev.env.txt
     #   black
@@ -113,7 +113,7 @@ contourpy==1.3.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.6.2
+cotengra==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -121,7 +121,7 @@ cycler==0.12.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cytoolz==1.0.0
+cytoolz==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -141,7 +141,7 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-debugpy==1.8.9
+debugpy==1.8.12
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -162,7 +162,7 @@ exceptiongroup==1.2.2
     #   -c envs/dev.env.txt
     #   anyio
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   stack-data
@@ -178,7 +178,7 @@ flynt==0.78
     # via
     #   -c envs/dev.env.txt
     #   -r deps/format.txt
-fonttools==4.55.2
+fonttools==4.55.4
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -190,7 +190,7 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-galois==0.4.3
+galois==0.4.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -217,7 +217,7 @@ idna==3.10
     #   httpx
     #   jsonschema
     #   requests
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -225,7 +225,7 @@ ipykernel==6.29.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-ipython==8.30.0
+ipython==8.31.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -252,7 +252,7 @@ jedi==0.19.2
     # via
     #   -c envs/dev.env.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -294,7 +294,7 @@ jupyter-core==5.7.2
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyter-events==0.10.0
+jupyter-events==0.11.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
@@ -302,7 +302,7 @@ jupyter-lsp==2.2.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-jupyter-server==2.14.2
+jupyter-server==2.15.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-lsp
@@ -314,7 +314,7 @@ jupyter-server-terminals==0.5.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-jupyterlab==4.3.2
+jupyterlab==4.3.4
     # via
     #   -c envs/dev.env.txt
     #   notebook
@@ -331,11 +331,11 @@ jupyterlab-widgets==3.0.13
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-llvmlite==0.43.0
+llvmlite==0.44.0
     # via
     #   -c envs/dev.env.txt
     #   numba
@@ -345,7 +345,7 @@ markupsafe==3.0.2
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.3
+matplotlib==3.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -355,7 +355,7 @@ matplotlib-inline==0.1.7
     #   -c envs/dev.env.txt
     #   ipykernel
     #   ipython
-mistune==3.0.2
+mistune==3.1.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -367,11 +367,11 @@ mypy-extensions==1.0.0
     # via
     #   -c envs/dev.env.txt
     #   black
-nbclient==0.10.1
+nbclient==0.10.2
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-nbconvert==7.16.4
+nbconvert==7.16.5
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -393,7 +393,7 @@ networkx==3.4.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-notebook==7.3.1
+notebook==7.3.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -402,7 +402,7 @@ notebook-shim==0.2.4
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-numba==0.60.0
+numba==0.61.0
     # via
     #   -c envs/dev.env.txt
     #   galois
@@ -455,7 +455,7 @@ pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==11.0.0
+pillow==11.1.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -473,15 +473,15 @@ prometheus-client==0.21.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.29.1
+protobuf==5.29.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -503,20 +503,20 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
-pydantic==2.10.3
+pydantic==2.10.5
     # via
     #   -c envs/dev.env.txt
     #   bartiq
     #   qref
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-pydot==3.0.3
+pydot==3.0.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   ipython
@@ -534,7 +534,7 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   matplotlib
     #   pandas
-python-json-logger==2.0.7
+python-json-logger==3.2.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
@@ -552,24 +552,24 @@ pyzmq==26.2.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qref==0.7.0
+qref==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   bartiq
-qsharp==1.11.1
+qsharp==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.11.1
+qsharp-widgets==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-quimb==1.9.0
+quimb==1.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.35.1
+referencing==0.36.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -599,7 +599,7 @@ rpds-py==0.22.3
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.14.1
+scipy==1.15.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -648,7 +648,7 @@ terminado==0.18.1
 tinycss2==1.4.0
     # via
     #   -c envs/dev.env.txt
-    #   nbconvert
+    #   bleach
 tomli==2.2.1
     # via
     #   -c envs/dev.env.txt
@@ -705,9 +705,11 @@ typing-extensions==4.12.2
     #   dash
     #   galois
     #   ipython
+    #   mistune
     #   pydantic
     #   pydantic-core
-tzdata==2024.2
+    #   referencing
+tzdata==2025.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -715,7 +717,7 @@ uri-template==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/pip-tools.env.txt
+++ b/dev_tools/requirements/envs/pip-tools.env.txt
@@ -8,7 +8,7 @@ build==1.2.2.post1
     # via
     #   -c envs/dev.env.txt
     #   pip-tools
-click==8.1.7
+click==8.1.8
     # via
     #   -c envs/dev.env.txt
     #   pip-tools

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -16,7 +16,7 @@ annotated-types==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-anyio==4.7.0
+anyio==4.8.0
     # via
     #   -c envs/dev.env.txt
     #   httpx
@@ -37,7 +37,7 @@ arrow==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   isoduration
-ase==3.23.0
+ase==3.24.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
@@ -45,7 +45,7 @@ astor==0.8.1
     # via
     #   -c envs/dev.env.txt
     #   tensorflow-docs
-astroid==3.3.6
+astroid==3.3.8
     # via
     #   -c envs/dev.env.txt
     #   pylint
@@ -57,7 +57,7 @@ async-lru==2.0.4
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -74,7 +74,7 @@ babel==2.16.0
     #   -c envs/dev.env.txt
     #   jupyterlab-server
     #   sphinx
-bartiq==0.6.0
+bartiq==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -82,7 +82,7 @@ beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-bleach==6.2.0
+bleach[css]==6.2.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -90,11 +90,11 @@ blinker==1.9.0
     # via
     #   -c envs/dev.env.txt
     #   flask
-cachetools==5.5.0
+cachetools==5.5.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c envs/dev.env.txt
     #   httpcore
@@ -104,7 +104,7 @@ cffi==1.17.1
     # via
     #   -c envs/dev.env.txt
     #   argon2-cffi-bindings
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -113,7 +113,7 @@ cirq-core==1.4.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   openfermion
-click==8.1.7
+click==8.1.8
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -126,7 +126,7 @@ contourpy==1.3.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.6.2
+cotengra==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -134,7 +134,7 @@ cycler==0.12.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cytoolz==1.0.0
+cytoolz==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -154,7 +154,7 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-debugpy==1.8.9
+debugpy==1.8.12
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -188,7 +188,7 @@ exceptiongroup==1.2.2
     #   anyio
     #   ipython
     #   pytest
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   stack-data
@@ -196,7 +196,7 @@ fastjsonschema==2.21.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-filelock==3.16.1
+filelock==3.17.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
@@ -204,7 +204,7 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.55.2
+fonttools==4.55.4
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -216,7 +216,7 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-galois==0.4.3
+galois==0.4.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -252,7 +252,7 @@ imagesize==1.4.1
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -264,7 +264,7 @@ ipykernel==6.29.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-ipython==8.30.0
+ipython==8.31.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -287,11 +287,11 @@ itsdangerous==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   flask
-jax==0.4.36
+jax==0.5.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-jaxlib==0.4.36
+jaxlib==0.5.0
     # via
     #   -c envs/dev.env.txt
     #   jax
@@ -300,7 +300,7 @@ jedi==0.19.2
     # via
     #   -c envs/dev.env.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -344,7 +344,7 @@ jupyter-core==5.7.2
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyter-events==0.10.0
+jupyter-events==0.11.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
@@ -352,7 +352,7 @@ jupyter-lsp==2.2.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-jupyter-server==2.14.2
+jupyter-server==2.15.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-lsp
@@ -364,7 +364,7 @@ jupyter-server-terminals==0.5.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-jupyterlab==4.3.2
+jupyterlab==4.3.4
     # via
     #   -c envs/dev.env.txt
     #   notebook
@@ -381,11 +381,11 @@ jupyterlab-widgets==3.0.13
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-llvmlite==0.43.0
+llvmlite==0.44.0
     # via
     #   -c envs/dev.env.txt
     #   numba
@@ -395,7 +395,7 @@ markupsafe==3.0.2
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.3
+matplotlib==3.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -410,11 +410,11 @@ mccabe==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pylint
-mistune==3.0.2
+mistune==3.1.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-ml-dtypes==0.5.0
+ml-dtypes==0.5.1
     # via
     #   -c envs/dev.env.txt
     #   jax
@@ -423,11 +423,11 @@ mpmath==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   sympy
-nbclient==0.10.1
+nbclient==0.10.2
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-nbconvert==7.16.4
+nbconvert==7.16.5
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -451,7 +451,7 @@ networkx==3.4.2
     #   -r deps/runtime.txt
     #   cirq-core
     #   openfermion
-notebook==7.3.1
+notebook==7.3.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -460,7 +460,7 @@ notebook-shim==0.2.4
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-numba==0.60.0
+numba==0.61.0
     # via
     #   -c envs/dev.env.txt
     #   galois
@@ -526,7 +526,7 @@ pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==11.0.0
+pillow==11.1.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -548,16 +548,16 @@ prometheus-client==0.21.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.29.1
+protobuf==5.29.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   tensorflow-docs
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -583,26 +583,26 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
-pydantic==2.10.3
+pydantic==2.10.5
     # via
     #   -c envs/dev.env.txt
     #   bartiq
     #   qref
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-pydot==3.0.3
+pydot==3.0.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   ipython
     #   nbconvert
     #   sphinx
-pylint==3.3.2
+pylint==3.3.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
@@ -612,7 +612,7 @@ pyparsing==3.1.4
     #   bartiq
     #   matplotlib
     #   pydot
-pyscf==2.7.0
+pyscf==2.8.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
@@ -627,7 +627,7 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   matplotlib
     #   pandas
-python-json-logger==2.0.7
+python-json-logger==3.2.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
@@ -646,24 +646,24 @@ pyzmq==26.2.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qref==0.7.0
+qref==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   bartiq
-qsharp==1.11.1
+qsharp==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.11.1
+qsharp-widgets==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-quimb==1.9.0
+quimb==1.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.35.1
+referencing==0.36.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -695,7 +695,7 @@ rpds-py==0.22.3
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.14.1
+scipy==1.15.1
     # via
     #   -c envs/dev.env.txt
     #   ase
@@ -786,7 +786,7 @@ terminado==0.18.1
 tinycss2==1.4.0
     # via
     #   -c envs/dev.env.txt
-    #   nbconvert
+    #   bleach
 tomli==2.2.1
     # via
     #   -c envs/dev.env.txt
@@ -848,9 +848,11 @@ typing-extensions==4.12.2
     #   dash
     #   galois
     #   ipython
+    #   mistune
     #   pydantic
     #   pydantic-core
-tzdata==2024.2
+    #   referencing
+tzdata==2025.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -858,7 +860,7 @@ uri-template==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -8,7 +8,7 @@ annotated-types==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-anyio==4.7.0
+anyio==4.8.0
     # via
     #   -c envs/dev.env.txt
     #   httpx
@@ -29,7 +29,7 @@ arrow==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   isoduration
-ase==3.23.0
+ase==3.24.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
@@ -41,7 +41,7 @@ async-lru==2.0.4
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -57,7 +57,7 @@ babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
-bartiq==0.6.0
+bartiq==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -65,7 +65,7 @@ beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-bleach==6.2.0
+bleach[css]==6.2.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -73,11 +73,11 @@ blinker==1.9.0
     # via
     #   -c envs/dev.env.txt
     #   flask
-cachetools==5.5.0
+cachetools==5.5.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c envs/dev.env.txt
     #   httpcore
@@ -87,7 +87,7 @@ cffi==1.17.1
     # via
     #   -c envs/dev.env.txt
     #   argon2-cffi-bindings
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -96,7 +96,7 @@ cirq-core==1.4.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   openfermion
-click==8.1.7
+click==8.1.8
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -109,11 +109,11 @@ contourpy==1.3.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.6.2
+cotengra==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   quimb
-coverage[toml]==7.6.9
+coverage[toml]==7.6.10
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -121,7 +121,7 @@ cycler==0.12.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cytoolz==1.0.0
+cytoolz==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -141,7 +141,7 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-debugpy==1.8.9
+debugpy==1.8.12
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -171,7 +171,7 @@ execnet==2.1.1
     # via
     #   -c envs/dev.env.txt
     #   pytest-xdist
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   stack-data
@@ -179,7 +179,7 @@ fastjsonschema==2.21.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-filelock==3.16.1
+filelock==3.17.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -187,7 +187,7 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.55.2
+fonttools==4.55.4
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -199,7 +199,7 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-galois==0.4.3
+galois==0.4.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -231,7 +231,7 @@ idna==3.10
     #   httpx
     #   jsonschema
     #   requests
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -244,7 +244,7 @@ ipykernel==6.29.5
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
     #   jupyterlab
-ipython==8.30.0
+ipython==8.31.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -263,11 +263,11 @@ itsdangerous==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   flask
-jax==0.4.36
+jax==0.5.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
-jaxlib==0.4.36
+jaxlib==0.5.0
     # via
     #   -c envs/dev.env.txt
     #   jax
@@ -276,7 +276,7 @@ jedi==0.19.2
     # via
     #   -c envs/dev.env.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -318,7 +318,7 @@ jupyter-core==5.7.2
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyter-events==0.10.0
+jupyter-events==0.11.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
@@ -326,7 +326,7 @@ jupyter-lsp==2.2.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-jupyter-server==2.14.2
+jupyter-server==2.15.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-lsp
@@ -338,7 +338,7 @@ jupyter-server-terminals==0.5.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-jupyterlab==4.3.2
+jupyterlab==4.3.4
     # via
     #   -c envs/dev.env.txt
     #   notebook
@@ -355,11 +355,11 @@ jupyterlab-widgets==3.0.13
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-llvmlite==0.43.0
+llvmlite==0.44.0
     # via
     #   -c envs/dev.env.txt
     #   numba
@@ -369,7 +369,7 @@ markupsafe==3.0.2
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.3
+matplotlib==3.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -380,11 +380,11 @@ matplotlib-inline==0.1.7
     #   -c envs/dev.env.txt
     #   ipykernel
     #   ipython
-mistune==3.0.2
+mistune==3.1.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-ml-dtypes==0.5.0
+ml-dtypes==0.5.1
     # via
     #   -c envs/dev.env.txt
     #   jax
@@ -393,11 +393,11 @@ mpmath==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   sympy
-nbclient==0.10.1
+nbclient==0.10.2
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-nbconvert==7.16.4
+nbconvert==7.16.5
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -420,7 +420,7 @@ networkx==3.4.2
     #   -r deps/runtime.txt
     #   cirq-core
     #   openfermion
-notebook==7.3.1
+notebook==7.3.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -429,7 +429,7 @@ notebook-shim==0.2.4
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-numba==0.60.0
+numba==0.61.0
     # via
     #   -c envs/dev.env.txt
     #   galois
@@ -494,7 +494,7 @@ pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==11.0.0
+pillow==11.1.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -515,15 +515,15 @@ prometheus-client==0.21.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.29.1
+protobuf==5.29.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -549,20 +549,20 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
-pydantic==2.10.3
+pydantic==2.10.5
     # via
     #   -c envs/dev.env.txt
     #   bartiq
     #   qref
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-pydot==3.0.3
+pydot==3.0.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   ipython
@@ -573,7 +573,7 @@ pyparsing==3.1.4
     #   bartiq
     #   matplotlib
     #   pydot
-pyscf==2.7.0
+pyscf==2.8.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
@@ -584,7 +584,7 @@ pytest==8.3.4
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.24.0
+pytest-asyncio==0.25.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -603,7 +603,7 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   matplotlib
     #   pandas
-python-json-logger==2.0.7
+python-json-logger==3.2.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
@@ -621,24 +621,24 @@ pyzmq==26.2.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qref==0.7.0
+qref==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   bartiq
-qsharp==1.11.1
+qsharp==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.11.1
+qsharp-widgets==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-quimb==1.9.0
+quimb==1.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.35.1
+referencing==0.36.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -669,7 +669,7 @@ rpds-py==0.22.3
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.14.1
+scipy==1.15.1
     # via
     #   -c envs/dev.env.txt
     #   ase
@@ -724,7 +724,7 @@ terminado==0.18.1
 tinycss2==1.4.0
     # via
     #   -c envs/dev.env.txt
-    #   nbconvert
+    #   bleach
 tomli==2.2.1
     # via
     #   -c envs/dev.env.txt
@@ -780,9 +780,11 @@ typing-extensions==4.12.2
     #   dash
     #   galois
     #   ipython
+    #   mistune
     #   pydantic
     #   pydantic-core
-tzdata==2024.2
+    #   referencing
+tzdata==2025.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -790,7 +792,7 @@ uri-template==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -8,7 +8,7 @@ annotated-types==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-anyio==4.7.0
+anyio==4.8.0
     # via
     #   -c envs/dev.env.txt
     #   httpx
@@ -37,7 +37,7 @@ async-lru==2.0.4
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -53,7 +53,7 @@ babel==2.16.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
-bartiq==0.6.0
+bartiq==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -61,7 +61,7 @@ beautifulsoup4==4.12.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-bleach==6.2.0
+bleach[css]==6.2.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -69,11 +69,11 @@ blinker==1.9.0
     # via
     #   -c envs/dev.env.txt
     #   flask
-cachetools==5.5.0
+cachetools==5.5.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c envs/dev.env.txt
     #   httpcore
@@ -83,7 +83,7 @@ cffi==1.17.1
     # via
     #   -c envs/dev.env.txt
     #   argon2-cffi-bindings
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -91,7 +91,7 @@ cirq-core==1.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-click==8.1.7
+click==8.1.8
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -104,7 +104,7 @@ contourpy==1.3.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.6.2
+cotengra==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -112,7 +112,7 @@ cycler==0.12.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cytoolz==1.0.0
+cytoolz==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -132,7 +132,7 @@ dash-table==5.0.0
     # via
     #   -c envs/dev.env.txt
     #   dash
-debugpy==1.8.9
+debugpy==1.8.12
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -153,7 +153,7 @@ exceptiongroup==1.2.2
     #   -c envs/dev.env.txt
     #   anyio
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c envs/dev.env.txt
     #   stack-data
@@ -165,7 +165,7 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.55.2
+fonttools==4.55.4
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -177,7 +177,7 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-galois==0.4.3
+galois==0.4.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -204,7 +204,7 @@ idna==3.10
     #   httpx
     #   jsonschema
     #   requests
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via
     #   -c envs/dev.env.txt
     #   dash
@@ -212,7 +212,7 @@ ipykernel==6.29.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-ipython==8.30.0
+ipython==8.31.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -235,7 +235,7 @@ jedi==0.19.2
     # via
     #   -c envs/dev.env.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c envs/dev.env.txt
     #   flask
@@ -277,7 +277,7 @@ jupyter-core==5.7.2
     #   nbclient
     #   nbconvert
     #   nbformat
-jupyter-events==0.10.0
+jupyter-events==0.11.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
@@ -285,7 +285,7 @@ jupyter-lsp==2.2.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-jupyter-server==2.14.2
+jupyter-server==2.15.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-lsp
@@ -297,7 +297,7 @@ jupyter-server-terminals==0.5.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-jupyterlab==4.3.2
+jupyterlab==4.3.4
     # via
     #   -c envs/dev.env.txt
     #   notebook
@@ -314,11 +314,11 @@ jupyterlab-widgets==3.0.13
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-llvmlite==0.43.0
+llvmlite==0.44.0
     # via
     #   -c envs/dev.env.txt
     #   numba
@@ -328,7 +328,7 @@ markupsafe==3.0.2
     #   jinja2
     #   nbconvert
     #   werkzeug
-matplotlib==3.9.3
+matplotlib==3.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -338,7 +338,7 @@ matplotlib-inline==0.1.7
     #   -c envs/dev.env.txt
     #   ipykernel
     #   ipython
-mistune==3.0.2
+mistune==3.1.0
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -346,11 +346,11 @@ mpmath==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   sympy
-nbclient==0.10.1
+nbclient==0.10.2
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
-nbconvert==7.16.4
+nbconvert==7.16.5
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -372,7 +372,7 @@ networkx==3.4.2
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   cirq-core
-notebook==7.3.1
+notebook==7.3.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -381,7 +381,7 @@ notebook-shim==0.2.4
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-numba==0.60.0
+numba==0.61.0
     # via
     #   -c envs/dev.env.txt
     #   galois
@@ -429,7 +429,7 @@ pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==11.0.0
+pillow==11.1.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -446,15 +446,15 @@ prometheus-client==0.21.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.29.1
+protobuf==5.29.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -476,20 +476,20 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
-pydantic==2.10.3
+pydantic==2.10.5
     # via
     #   -c envs/dev.env.txt
     #   bartiq
     #   qref
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-pydot==3.0.3
+pydot==3.0.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c envs/dev.env.txt
     #   ipython
@@ -507,7 +507,7 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   matplotlib
     #   pandas
-python-json-logger==2.0.7
+python-json-logger==3.2.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
@@ -525,24 +525,24 @@ pyzmq==26.2.0
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
-qref==0.7.0
+qref==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   bartiq
-qsharp==1.11.1
+qsharp==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.11.1
+qsharp-widgets==1.12.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-quimb==1.9.0
+quimb==1.10.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-referencing==0.35.1
+referencing==0.36.1
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -572,7 +572,7 @@ rpds-py==0.22.3
     #   -c envs/dev.env.txt
     #   jsonschema
     #   referencing
-scipy==1.14.1
+scipy==1.15.1
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
@@ -621,7 +621,7 @@ terminado==0.18.1
 tinycss2==1.4.0
     # via
     #   -c envs/dev.env.txt
-    #   nbconvert
+    #   bleach
 tomli==2.2.1
     # via
     #   -c envs/dev.env.txt
@@ -675,9 +675,11 @@ typing-extensions==4.12.2
     #   dash
     #   galois
     #   ipython
+    #   mistune
     #   pydantic
     #   pydantic-core
-tzdata==2024.2
+    #   referencing
+tzdata==2025.1
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -685,7 +687,7 @@ uri-template==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   -c envs/dev.env.txt
     #   requests

--- a/qualtran/qref_interop/_bloq_to_qref.py
+++ b/qualtran/qref_interop/_bloq_to_qref.py
@@ -362,7 +362,7 @@ def _extract_symbols_from_port_sizes(ports: list[PortV1]) -> list[str]:
     return [str(symbol) for symbol in symbols]
 
 
-def _wrap_in_repetition(routine: RoutineV1, count: int | str) -> RoutineV1:
+def _wrap_in_repetition(routine: RoutineV1, count: Union[int, str]) -> RoutineV1:
     """Returns a routine with a repetition containing a single child.
     The repetition used is a constant sequence with count specified by input parameter.
     """

--- a/qualtran/qref_interop/_bloq_to_qref.py
+++ b/qualtran/qref_interop/_bloq_to_qref.py
@@ -129,7 +129,7 @@ def _bloq_instance_name(instance: BloqInstance) -> str:
 
 
 def bloq_to_qref(
-    obj: Bloq | CompositeBloq | BloqInstance, from_callgraph: bool = False
+    obj: Union[Bloq, CompositeBloq, BloqInstance], from_callgraph: bool = False
 ) -> SchemaV1:
     """Converts Bloq to QREF SchemaV1 object.
 
@@ -391,13 +391,13 @@ def _call_graph_to_routine_map(call_graph: nx.DiGraph) -> dict[Bloq, RoutineV1]:
     return nodes_to_routine_map
 
 
-def bloq_to_routine_from_callgraph(bloq: Bloq | CompositeBloq) -> RoutineV1:
+def bloq_to_routine_from_callgraph(bloq: Union[Bloq, CompositeBloq]) -> RoutineV1:
     """Creates a QREF routine based on the information coming from a bloq's call graph."""
     call_graph = bloq.call_graph()[0]
     nodes_to_routine_map = _call_graph_to_routine_map(call_graph)
 
     for routine in nodes_to_routine_map.values():
-        routine.ports = []
+        routine.ports = []  # type: ignore
         routine.connections = []
 
     for edge in list(call_graph.edges)[::-1]:

--- a/qualtran/qref_interop/_bloq_to_qref_test.py
+++ b/qualtran/qref_interop/_bloq_to_qref_test.py
@@ -64,8 +64,7 @@ def _assert_corresponding_subroutine(bloq, count, routines):
                 return True
         except AssertionError:
             pass
-    else:
-        assert False
+    assert False
 
 
 def _compare_routine_resources_recursively(bloq, routine):

--- a/qualtran/qref_interop/_bloq_to_qref_test.py
+++ b/qualtran/qref_interop/_bloq_to_qref_test.py
@@ -35,7 +35,8 @@ from qualtran.bloqs.arithmetic.comparison import LessThanEqual
 from qualtran.bloqs.basic_gates import CNOT
 from qualtran.bloqs.block_encoding.lcu_block_encoding import _black_box_lcu_block, _lcu_block
 from qualtran.bloqs.chemistry.df.double_factorization import _df_block_encoding, _df_one_body
-from qualtran.bloqs.data_loading.qrom import QROM
+from qualtran.bloqs.data_loading.qrom import _qrom_symb, QROM
+from qualtran.bloqs.factoring.rsa.rsa_phase_estimate import _rsa_pe
 from qualtran.bloqs.state_preparation import StatePreparationAliasSampling
 from qualtran.qref_interop import bloq_to_qref
 
@@ -46,15 +47,62 @@ def get_bloq_examples():
     return [_add_oop_large, _black_box_lcu_block, _lcu_block, _df_one_body, _df_block_encoding]
 
 
+def _assert_corresponding_subroutine(bloq, count, routines):
+    bloq_name = bloq.__class__.__name__
+    for routine in routines:
+        try:
+            result = False
+            if bloq_name in routine.name:
+                if count != 1:
+                    if routine.repetition is None:
+                        continue
+                    assert str(routine.repetition.count) == str(count)
+                    result = _compare_routine_resources_recursively(bloq, routine.children[0])
+                else:
+                    result = _compare_routine_resources_recursively(bloq, routine)
+            if result:
+                return True
+        except AssertionError:
+            pass
+    else:
+        assert False
+
+
+def _compare_routine_resources_recursively(bloq, routine):
+    reference_routine = bloq_to_qref(bloq).program
+    assert reference_routine.name in routine.name
+    bloq_counts = bloq.bloq_counts()
+    assert len(bloq_counts) == len(routine.children)
+    assert reference_routine.resources == routine.resources
+    for child_bloq in bloq_counts:
+        count = bloq_counts[child_bloq]
+        _assert_corresponding_subroutine(child_bloq, count, routine.children)
+    return True
+
+
 @pytest.mark.parametrize("bloq_example", get_bloq_examples())
-def test_bloq_examples_can_be_converted_to_qualtran(bloq_example):
+def test_bloq_examples_can_be_converted_to_qref(bloq_example):
     bloq = bloq_example.make()
     qref_routine = bloq_to_qref(bloq)
     assert verify_topology(qref_routine)
 
 
 @pytest.mark.parametrize("bloq_example", get_bloq_examples())
-def test_bloq_examples_can_be_converted_to_qualtran_when_decomposed(bloq_example):
+def test_bloq_examples_from_callgraphs_give_correct_counts_for_numeric(bloq_example):
+    bloq = bloq_example.make()
+    qref_routine_form_callgraph = bloq_to_qref(bloq, from_callgraph=True)
+    _compare_routine_resources_recursively(bloq, qref_routine_form_callgraph.program)
+
+
+@pytest.mark.parametrize("bloq_example", [_qrom_symb, _rsa_pe])
+def test_bloq_examples_from_callgraphs_give_correct_counts_for_symbolic(bloq_example):
+    bloq = bloq_example.make()
+    qref_routine_form_callgraph = bloq_to_qref(bloq, from_callgraph=True)
+    _compare_routine_resources_recursively(bloq, qref_routine_form_callgraph.program)
+
+
+@pytest.mark.parametrize("bloq_example", get_bloq_examples())
+def test_bloq_examples_can_be_converted_to_qref_when_decomposed(bloq_example):
     bloq = bloq_example.make().decompose_bloq()
     qref_routine = bloq_to_qref(bloq)
     assert verify_topology(qref_routine)


### PR DESCRIPTION
This PR introduces an option to create QREF routines from callgraphs.

I have not updated the dependencies, as I decided it will be better to ask @mpharrigan for assistance :)
Since we're using strict bounds, `qref==0.9.0` and `bartiq==0.9.0` should be fine. If you want me to provide some looser bounds, I can find out what these should be.