### PR TITLE
Implement PRODUCT decomposition

### DIFF
--- a/qualtran/bloqs/arithmetic/multiplication.py
+++ b/qualtran/bloqs/arithmetic/multiplication.py
@@ -23,6 +23,7 @@ from qualtran import (
     Bloq,
     bloq_example,
     BloqDocSpec,
+    CompositeBloq,
     ConnectionT,
     DecomposeTypeError,
     GateWithRegisters,


### PR DESCRIPTION
I have performed a quick implementation of the `PRODUCT` function using the implementation suggested in https://arxiv.org/pdf/2007.07391 (page 69).

This addresses issue #485. 

Some notes:
- This achieves the desired complexity and relies upon the `AND` bloq. It is important to use the `AND` bloq because the `AND.adjoint` natively allows us to uncompute without additional Toffoli complexity (by using the strategies from [Gidney](https://arxiv.org/abs/1709.06648))
- It also includes a brute force test checking all implementations with input sizes ranging from 1-3 bits. 
- My code as of now is not fully commented + notated --- I would appreciate feedback on making it better!