### PR TITLE
Update math funcs to use functions from math instead of numpy to support arbitrary length integers

### DIFF
--- a/qualtran/symbolics/math_funcs.py
+++ b/qualtran/symbolics/math_funcs.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import math
 from typing import cast, Iterable, overload, TypeVar
 
 import numpy as np
@@ -35,7 +36,7 @@ def log2(x: SymbolicFloat) -> SymbolicFloat:
     from sympy.codegen.cfunctions import log2
 
     if not is_symbolic(x):
-        return np.log2(x)
+        return math.log2(x)
     return log2(x)
 
 
@@ -51,7 +52,7 @@ def ln(x: SymbolicFloat) -> SymbolicFloat:
     from sympy.codegen.cfunctions import log
 
     if not is_symbolic(x):
-        return np.log(x)
+        return math.log(x)
     return log(x)
 
 
@@ -107,7 +108,7 @@ def ssqrt(x: sympy.Expr) -> sympy.Expr: ...
 def ssqrt(x: SymbolicFloat) -> SymbolicFloat:
     if is_symbolic(x):
         return sympy.sqrt(x)
-    return np.sqrt(x)
+    return math.sqrt(x)
 
 
 @overload

--- a/qualtran/symbolics/math_funcs_test.py
+++ b/qualtran/symbolics/math_funcs_test.py
@@ -16,15 +16,31 @@ from typing import cast
 import numpy as np
 import pytest
 import sympy
+from sympy.codegen.cfunctions import log
 from sympy.codegen.cfunctions import log2 as sympy_log2
 
-from qualtran.symbolics import bit_length, ceil, is_zero, log2, sarg, sexp, smax, smin
+from qualtran.symbolics import bit_length, ceil, is_zero, ln, log2, sarg, sexp, smax, smin, ssqrt
 
 
 def test_log2():
     assert log2(sympy.Symbol('x')) == sympy_log2(sympy.Symbol('x'))
     assert log2(sympy.Number(10)) == sympy_log2(sympy.Number(10))
     assert log2(10) == np.log2(10)
+    assert log2(2**10000) == 10000
+
+
+def test_ln():
+    assert ln(sympy.Symbol('x')) == log(sympy.Symbol('x'))
+    assert ln(sympy.Number(10)) == log(sympy.Number(10))
+    assert ln(10) == np.log(10)
+    assert np.isclose(ln(2**1000) / ln(2), 1000)
+
+
+def test_ssqrt():
+    assert ssqrt(sympy.Symbol('x')) == sympy.sqrt(sympy.Symbol('x'))
+    assert ssqrt(sympy.Number(10)) == sympy.sqrt(sympy.Number(10))
+    assert ssqrt(10) == np.sqrt(10)
+    assert ssqrt(2**1000) == 2**500
 
 
 def test_sexp():


### PR DESCRIPTION


Fixes https://github.com/quantumlib/Qualtran/issues/1558