### PR TITLE
Fix nightly tests

### DIFF
--- a/qualtran/bloqs/gf_arithmetic/gf2_multiplication_test.py
+++ b/qualtran/bloqs/gf_arithmetic/gf2_multiplication_test.py
@@ -184,11 +184,14 @@ def test_multiply_by_xk_classical_action(n, k):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(['n', 'k'], [(n, k) for n in range(4, 6) for k in range(1, 2 * n + 1)])
+@pytest.mark.parametrize(['n', 'k'], [(n, k) for n in range(4, 6) for k in range(1, n + 2)])
 def test_multiply_by_xk_classical_action_slow(n, k):
     blq = MultiplyPolyByOnePlusXk(n, k)
     fg_polys = tuple(itertools.product(range(2), repeat=n))[1:]
     h_polys = [*itertools.product(range(2), repeat=blq.signature[-1].shape[0])]
+    h_polys = [
+        h_polys[i] for i in np.random.choice(len(h_polys), min(len(h_polys), 20), replace=False)
+    ]
 
     qlt_testing.assert_consistent_classical_action(blq, f=fg_polys, g=fg_polys, h=h_polys)
 


### PR DESCRIPTION
- **Fix bug in KaliskiStep3 and add tests for all steps (#1496)**
- **Fix symbolic call graphs for factoring phase estimates (#1497)**
- **Deprecate `MultiControlPauli` (#1492)**
- **Self adjoint for `MCX` and `MCZ` (#1502)**
- **notebooks for `ZPowConstViaPhaseGradient` and `RzViaPhaseGradient` (#1507)**
- **First pass at fixing chemistry costs to use QECGatesCost (#1505)**
- **Make `BloqBuilder.join` accept array-like of soquets (#1509)**
- **Allow computing cost from decomposition of cirq gates (#1510)**
- **More explicit documentation of endianness (#1500)**
- **Be a bit careful about complexity of the sparse Hamiltonian (#1512)**
- **2024-12 Bump Dependencies (#1506)**
- **Make `And` a leaf bloq (#1513)**
- **restrict classical action of certain arithmetic bloqs (#1518)**
- **Add list primitives from Quartic speedups paper (#1503)**
- **add option to generate QREF from callgraphs (#1522)**
- **Implement Kikuchi guiding state preparation (#1504)**
- **Setting min version of attrs (#1521)**
- **Fix `CSwap` bloq in mod division (#1528)**
- **Add bloq for constant polynomial multiplication modulu in GF(2) (#1516)**
- **Tensor from classical action (#1514)**
- **Fix memory overflow in sparse matrix stress test (#1529)**
- **Rename factoring -> cryptograph and create a Root Bloqs docs section (#1532)**
- **Name our ci workflow files better (#1535)**
- **Update gf2.MultiplyPolyByConstantMod to support QGF dtype (#1533)**
- **make QGF with irreducible_poly=None compatible with QGF with the correct poly (#1540)**
- **Relax restriction on classical inputs for modular addition to fix nightly CI (#1537)**
- **Add BloqExample.docstring (#1536)**
- **Add a modulus parameter to QMontgomeryUInt (#1543)**
- **Override ctrl system for Toffoli (#1552)**
- **Add bloq for Binary Polynomial Multiplication (#1554)**
- **Fix nightly tests**
