### PR TITLE
Add explicit versions and timeouts to GHA workflows

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,13 +16,25 @@ on:
   schedule:
     - cron: "0 11 * * 1-5"  # Mon-Fri at 11:00 AM UTC
 
+  # Allow manual invocation – useful for debugging.
+  workflow_dispatch:
+
+concurrency:
+  # Cancel any previously-started but still active runs on the same branch.
+  cancel-in-progress: true
+  group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
-      - uses: ts-graphviz/setup-graphviz@v1
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: ts-graphviz/setup-graphviz@c001ccfb5aff62e28bda6a6c39b59a7e061be5b9 # v1
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Install dependencies

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,13 +17,22 @@ on:
     branches:
       - main
 
+concurrency:
+  # Cancel any previously-started but still active runs on the same branch.
+  cancel-in-progress: true
+  group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
-      - uses: ts-graphviz/setup-graphviz@v1
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: ts-graphviz/setup-graphviz@c001ccfb5aff62e28bda6a6c39b59a7e061be5b9 # v1
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -35,11 +44,12 @@ jobs:
           check/pytest -m 'not notebook and not slow'
 
   pytest-dev-tools:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
-      - uses: ts-graphviz/setup-graphviz@v1
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: ts-graphviz/setup-graphviz@c001ccfb5aff62e28bda6a6c39b59a7e061be5b9 # v1
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -51,11 +61,12 @@ jobs:
           check/pytest-dev-tools
 
   notebooks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
-      - uses: ts-graphviz/setup-graphviz@v1
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: ts-graphviz/setup-graphviz@c001ccfb5aff62e28bda6a6c39b59a7e061be5b9 # v1
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -69,12 +80,13 @@ jobs:
           NUMBA_NUM_THREADS: 4
 
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -86,12 +98,13 @@ jobs:
           check/format-incremental
 
   pylint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -103,12 +116,13 @@ jobs:
           check/pylint
 
   mypy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -120,11 +134,12 @@ jobs:
           check/mypy
 
   autogenerate-notebooks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
-      - uses: ts-graphviz/setup-graphviz@v1
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: ts-graphviz/setup-graphviz@c001ccfb5aff62e28bda6a6c39b59a7e061be5b9 # v1
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Install dependencies


### PR DESCRIPTION
This updates the GitHub Actions workflows to conform to some Google requirements and best practices:

- pin versions of GitHub Actions to commit SHAs
- pin versions of runners instead of using *-latest
- set default permissions for workflow
- set timeouts on jobs, to prevent running for 6 hrs (the default) in case of hangs or loops

This also fixes the following Scorecard security warnings:

- https://github.com/quantumlib/Qualtran/security/code-scanning/17
- https://github.com/quantumlib/Qualtran/security/code-scanning/18
- https://github.com/quantumlib/Qualtran/security/code-scanning/20
- https://github.com/quantumlib/Qualtran/security/code-scanning/21
- https://github.com/quantumlib/Qualtran/security/code-scanning/22
- https://github.com/quantumlib/Qualtran/security/code-scanning/23
- https://github.com/quantumlib/Qualtran/security/code-scanning/24
- https://github.com/quantumlib/Qualtran/security/code-scanning/25
- https://github.com/quantumlib/Qualtran/security/code-scanning/26
- https://github.com/quantumlib/Qualtran/security/code-scanning/27
- https://github.com/quantumlib/Qualtran/security/code-scanning/28
- https://github.com/quantumlib/Qualtran/security/code-scanning/29
- https://github.com/quantumlib/Qualtran/security/code-scanning/30
- https://github.com/quantumlib/Qualtran/security/code-scanning/31
- https://github.com/quantumlib/Qualtran/security/code-scanning/32
- https://github.com/quantumlib/Qualtran/security/code-scanning/33
- https://github.com/quantumlib/Qualtran/security/code-scanning/34
- https://github.com/quantumlib/Qualtran/security/code-scanning/35
- https://github.com/quantumlib/Qualtran/security/code-scanning/36
- https://github.com/quantumlib/Qualtran/security/code-scanning/37
- https://github.com/quantumlib/Qualtran/security/code-scanning/38
- https://github.com/quantumlib/Qualtran/security/code-scanning/39