### PR TITLE
Add Add.controlled() -> CAdd

### DIFF
--- a/qualtran/bloqs/arithmetic/addition_test.py
+++ b/qualtran/bloqs/arithmetic/addition_test.py
@@ -407,3 +407,18 @@ def test_outofplaceadder_classical_action(bitsize):
     cb = b.decompose_bloq()
     for x, y in itertools.product(range(2**bitsize), repeat=2):
         assert b.call_classically(a=x, b=y, c=x + y) == cb.call_classically(a=x, b=y, c=x + y)
+
+
+def test_controlled_add_from_add():
+    add = Add(QUInt(32))
+    cadd = add.controlled(CtrlSpec(cvs=0))
+
+    ctrl, a, b = cadd.call_classically(ctrl=1, a=5, b=10)
+    assert ctrl == 1
+    assert a == 5
+    assert b == 10
+
+    ctrl, a, b = cadd.call_classically(ctrl=0, a=5, b=10)
+    assert ctrl == 0
+    assert a == 5
+    assert b == 15

--- a/qualtran/bloqs/arithmetic/controlled_add_or_subtract_test.py
+++ b/qualtran/bloqs/arithmetic/controlled_add_or_subtract_test.py
@@ -92,7 +92,6 @@ class TestNaiveControlledAddOrSubtract(Bloq):
         return {'ctrl': ctrl, 'a': a, 'b': b}
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("dtype", [QUInt(3), QUInt(4)])
 def test_tensor(dtype):
     bloq = ControlledAddOrSubtract(dtype, dtype)


### PR DESCRIPTION
`Controlled(Add)` is no good since it will try to do `Controlled(And())` which is ill-specified. This was causing a test failure in the test I've un-marked as slow, since it's not slow. 