### PR TITLE
Support spare Prepare with log_block_size=0

### DIFF
--- a/qualtran/bloqs/chemistry/sparse/prepare_test.py
+++ b/qualtran/bloqs/chemistry/sparse/prepare_test.py
@@ -17,8 +17,8 @@ from typing import Optional
 import numpy as np
 import pytest
 
+import qualtran.testing as qlt_testing
 from qualtran import Bloq
-from qualtran.bloqs.basic_gates import TGate
 from qualtran.bloqs.chemistry.sparse.prepare import _prep_sparse, get_sparse_inputs_from_integrals
 
 
@@ -64,9 +64,7 @@ def reconstruct_eris(eris, indx, nb):
 
 def test_decompose_bloq_counts():
     prep = _prep_sparse()
-    cost_decomp = prep.decompose_bloq().call_graph()[1][TGate()]
-    cost_call = prep.call_graph()[1][TGate()]
-    assert cost_decomp == cost_call
+    qlt_testing.assert_equivalent_bloq_counts(prep)
 
 
 def build_random_test_integrals(nb: int, seed: Optional[int] = 7):

--- a/qualtran/bloqs/chemistry/sparse/sparse.ipynb
+++ b/qualtran/bloqs/chemistry/sparse/sparse.ipynb
@@ -163,7 +163,7 @@
     "num_spin_orb = 6\n",
     "tpq, eris = build_random_test_integrals(num_spin_orb // 2)\n",
     "prep_sparse = PrepareSparse.from_hamiltonian_coeffs(\n",
-    "    num_spin_orb, tpq, eris, num_bits_state_prep=4, log_block_size=1\n",
+    "    num_spin_orb, tpq, eris, num_bits_state_prep=4\n",
     ")"
    ]
   },

--- a/qualtran/bloqs/data_loading/qroam_clean.ipynb
+++ b/qualtran/bloqs/data_loading/qroam_clean.ipynb
@@ -178,13 +178,13 @@
     "upon the target bitsize of elements to be loaded.\n",
     "\n",
     "#### Registers\n",
-    " - `- control_registers`: If control is specified, a THRU register to denote the control qubits. Empty by default for uncontrolled version of the Bloq.\n",
-    " - `- selection_registers`: $N$ THRU registers, each with shape (), to load $N$ dimensional classical datasets.\n",
-    " - `- target_registers`: $M$ RIGHT registers to load $M$ different classical datasets. Each target register is of bitsize $b$ and shape described by a tuple of length $N$.\n",
-    " - `- junk_registers`: $K - 1$ RIGHT registers, each of bitsize $b$ used to load batches of size $K$ \n",
+    " - `control_registers`: If control is specified, a THRU register to denote the control qubits. Empty by default for uncontrolled version of the Bloq.\n",
+    " - `selection_registers`: $N$ THRU registers, each with shape (), to load $N$ dimensional classical datasets.\n",
+    " - `target_registers`: $M$ RIGHT registers to load $M$ different classical datasets. Each target register is of bitsize $b$ and shape described by a tuple of length $N$.\n",
+    " - `junk_registers`: $K - 1$ RIGHT registers, each of bitsize $b$ used to load batches of size $K$ \n",
     "\n",
     "#### References\n",
-    " - [Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization](https://arxiv.org/abs/1902.02134).     Berry et al. (2019). Appendix A. and B.\n"
+    " - [Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization](https://arxiv.org/abs/1902.02134). Berry et al. (2019). Appendix A. and B.\n"
    ]
   },
   {

--- a/qualtran/bloqs/data_loading/qroam_clean.py
+++ b/qualtran/bloqs/data_loading/qroam_clean.py
@@ -97,18 +97,17 @@ class QROAMCleanAdjoint(QROMBase, GateWithRegisters):  # type: ignore[misc]
     original lookup).
 
     Registers:
-        - control_registers: If control is specified, a THRU register to denote the control qubits.
+        control_registers: If control is specified, a THRU register to denote the control qubits.
             Empty by default for uncontrolled version of the Bloq.
-        - selection_registers: $N$ THRU registers, each with shape (), to load $N$ dimensional
+        selection_registers: $N$ THRU registers, each with shape (), to load $N$ dimensional
             classical datasets.
-        - target_registers: $M$ LEFT registers to load $M$ different classical datasets. Each target
+        target_registers: $M$ LEFT registers to load $M$ different classical datasets. Each target
             register is of bitsize $b$ and shape described by a tuple of length $N + S$. Here $S$ is
             a parameter that describes the shape of the output to be loaded for each selection index.
 
-
     References:
         [Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization](https://arxiv.org/abs/1902.02134).
-            Berry et al. (2019). Appendix C.
+        Berry et al. (2019). Appendix C.
     """
 
     log_block_sizes: Tuple[SymbolicInt, ...] = attrs.field(
@@ -332,17 +331,17 @@ class QROAMClean(SelectSwapQROM):
     upon the target bitsize of elements to be loaded.
 
     Registers:
-        - control_registers: If control is specified, a THRU register to denote the control qubits.
+        control_registers: If control is specified, a THRU register to denote the control qubits.
             Empty by default for uncontrolled version of the Bloq.
-        - selection_registers: $N$ THRU registers, each with shape (), to load $N$ dimensional
+        selection_registers: $N$ THRU registers, each with shape (), to load $N$ dimensional
             classical datasets.
-        - target_registers: $M$ RIGHT registers to load $M$ different classical datasets. Each target
+        target_registers: $M$ RIGHT registers to load $M$ different classical datasets. Each target
             register is of bitsize $b$ and shape described by a tuple of length $N$.
-        - junk_registers: $K - 1$ RIGHT registers, each of bitsize $b$ used to load batches of size $K$
+        junk_registers: $K - 1$ RIGHT registers, each of bitsize $b$ used to load batches of size $K$
 
     References:
         [Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization](https://arxiv.org/abs/1902.02134).
-            Berry et al. (2019). Appendix A. and B.
+        Berry et al. (2019). Appendix A. and B.
     """
 
     log_block_sizes: Tuple[SymbolicInt, ...] = attrs.field(

--- a/qualtran/bloqs/data_loading/select_swap_qrom_test.py
+++ b/qualtran/bloqs/data_loading/select_swap_qrom_test.py
@@ -39,7 +39,7 @@ from qualtran.testing import assert_valid_bloq_decomposition
         pytest.param(
             data,
             block_size,
-            id=f"{block_size}-data{didx}",
+            id=f"data{didx}-{block_size}",
             marks=pytest.mark.slow if block_size == 1 and didx == 1 else (),
         )
         for didx, data in enumerate([[[1, 2, 3, 4, 5]], [[1, 2, 3], [3, 2, 1]], [[1], [2], [3]]])


### PR DESCRIPTION
Fixes #1547 

`PrepareSparse` would fail to decompose with `log_block_size=0`, which is extra unfortunate since the automatic-block-size determination would choose this sometimes. It looks like SelectSwapQROM and QROAMClean support `log_block_size=0`, but I'd really love if @tanujkhattar or @fdmalone could give a second opinion. The bug fix itself is entirely within `PrepareSparse` -- better accounting of the qroam registers. 

Some drive-by doc formatting fixes as well