### PR TITLE
Add ctrl system for `LCUBlockEncoding`

### DIFF
--- a/qualtran/bloqs/block_encoding/lcu_block_encoding.py
+++ b/qualtran/bloqs/block_encoding/lcu_block_encoding.py
@@ -18,6 +18,7 @@ from typing import Dict, Optional, Tuple, Union
 import attrs
 
 from qualtran import (
+    AddControlledT,
     Bloq,
     bloq_example,
     BloqBuilder,
@@ -282,6 +283,17 @@ class LCUBlockEncoding(BlockEncoding):
             return Circle(filled=bool(self.control_val))
         else:
             return TextBox('B[H]')
+
+    def get_ctrl_system(self, ctrl_spec: 'CtrlSpec') -> tuple['Bloq', 'AddControlledT']:
+        from qualtran.bloqs.mcmt.specialized_ctrl import get_ctrl_system_1bit_cv_from_bloqs
+
+        return get_ctrl_system_1bit_cv_from_bloqs(
+            self,
+            ctrl_spec,
+            current_ctrl_bit=self.control_val,
+            bloq_with_ctrl=attrs.evolve(self, control_val=1),
+            ctrl_reg_name='ctrl',
+        )
 
     def adjoint(self) -> 'Bloq':
         from qualtran.bloqs.mcmt.specialized_ctrl import (

--- a/qualtran/bloqs/block_encoding/lcu_block_encoding.py
+++ b/qualtran/bloqs/block_encoding/lcu_block_encoding.py
@@ -285,14 +285,13 @@ class LCUBlockEncoding(BlockEncoding):
             return TextBox('B[H]')
 
     def get_ctrl_system(self, ctrl_spec: 'CtrlSpec') -> tuple['Bloq', 'AddControlledT']:
-        from qualtran.bloqs.mcmt.specialized_ctrl import get_ctrl_system_1bit_cv_from_bloqs
+        from qualtran.bloqs.mcmt.specialized_ctrl import get_ctrl_system_1bit_cv
 
-        return get_ctrl_system_1bit_cv_from_bloqs(
+        return get_ctrl_system_1bit_cv(
             self,
             ctrl_spec,
             current_ctrl_bit=self.control_val,
-            bloq_with_ctrl=attrs.evolve(self, control_val=1),
-            ctrl_reg_name='ctrl',
+            get_ctrl_bloq_and_ctrl_reg_name=lambda cv: (attrs.evolve(self, control_val=cv), 'ctrl'),
         )
 
     def adjoint(self) -> 'Bloq':

--- a/qualtran/bloqs/block_encoding/lcu_block_encoding_test.py
+++ b/qualtran/bloqs/block_encoding/lcu_block_encoding_test.py
@@ -12,8 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import attrs
 import pytest
 
+from qualtran import CtrlSpec
 from qualtran.bloqs.block_encoding.lcu_block_encoding import (
     _black_box_lcu_block,
     _black_box_select_block,
@@ -41,8 +43,11 @@ def test_black_box_select_block_encoding(bloq_autotester):
 
 
 def test_ctrl_lcu_be_cost():
-    bloq = _lcu_block().controlled()
-    assert get_cost_value(bloq, QECGatesCost()) == GateCounts(
+    bloq = _lcu_block()
+    assert bloq.controlled() == attrs.evolve(bloq, control_val=1)
+    assert bloq.controlled(CtrlSpec(cvs=0)) == attrs.evolve(bloq, control_val=0)
+
+    assert get_cost_value(bloq.controlled(), QECGatesCost()) == GateCounts(
         cswap=28, and_bloq=77, clifford=438, rotation=16, measurement=77
     )
 

--- a/qualtran/bloqs/block_encoding/lcu_block_encoding_test.py
+++ b/qualtran/bloqs/block_encoding/lcu_block_encoding_test.py
@@ -15,6 +15,7 @@
 import attrs
 import pytest
 
+import qualtran.testing as qlt_testing
 from qualtran import CtrlSpec
 from qualtran.bloqs.block_encoding.lcu_block_encoding import (
     _black_box_lcu_block,
@@ -23,7 +24,6 @@ from qualtran.bloqs.block_encoding.lcu_block_encoding import (
     _select_block,
 )
 from qualtran.resource_counting import GateCounts, get_cost_value, QECGatesCost
-from qualtran.testing import execute_notebook
 
 
 def test_lcu_block_encoding(bloq_autotester):
@@ -54,4 +54,4 @@ def test_ctrl_lcu_be_cost():
 
 @pytest.mark.notebook
 def test_notebook():
-    execute_notebook('lcu_block_encoding')
+    qlt_testing.execute_notebook('lcu_block_encoding')

--- a/qualtran/bloqs/block_encoding/lcu_block_encoding_test.py
+++ b/qualtran/bloqs/block_encoding/lcu_block_encoding_test.py
@@ -20,6 +20,7 @@ from qualtran.bloqs.block_encoding.lcu_block_encoding import (
     _lcu_block,
     _select_block,
 )
+from qualtran.resource_counting import GateCounts, get_cost_value, QECGatesCost
 from qualtran.testing import execute_notebook
 
 
@@ -37,6 +38,13 @@ def test_select_block_encoding(bloq_autotester):
 
 def test_black_box_select_block_encoding(bloq_autotester):
     bloq_autotester(_black_box_select_block)
+
+
+def test_ctrl_lcu_be_cost():
+    bloq = _lcu_block().controlled()
+    assert get_cost_value(bloq, QECGatesCost()) == GateCounts(
+        cswap=28, and_bloq=77, clifford=438, rotation=16, measurement=77
+    )
 
 
 @pytest.mark.notebook


### PR DESCRIPTION
Fixes #1592

This somehow got missed when updating the ctrl-systems for the LCU bloqs.