### PR TITLE
Bump version number for v0.6 release

### DIFF
--- a/qualtran/_version.py
+++ b/qualtran/_version.py
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.6.0.dev0"
+__version__ = "0.6.0"


### PR DESCRIPTION
In accordance with the docs for cutting a release, bump the version spec on `main` so I can tag the correct commit. 