### PR TITLE
[v0.6 branch] Optional new pennylane functionality

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,6 +16,7 @@ on:
   pull_request:
     branches:
       - main
+      - v0.6
 
 concurrency:
   # Cancel any previously-started but still active runs on the same branch.

--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -38,10 +38,7 @@ bartiq==0.9.0
 pyzx
 
 # Pennylane interop
-# TODO: https://github.com/quantumlib/Qualtran/issues/1589
-#       Reset to the released version when qualtran functionality
-#       is included
-pennylane@git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane
 
 # serialization
 protobuf

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -474,7 +474,7 @@ parso==0.8.4
     # via jedi
 pathspec==0.12.1
     # via black
-pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane==0.40.0
     # via
     #   -r deps/runtime.txt
     #   pennylane-lightning

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -539,7 +539,7 @@ parso==0.8.4
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane==0.40.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -489,7 +489,7 @@ pathspec==0.12.1
     # via
     #   -c envs/dev.env.txt
     #   black
-pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane==0.40.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -560,7 +560,7 @@ parso==0.8.4
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane==0.40.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -528,7 +528,7 @@ parso==0.8.4
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane==0.40.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -463,7 +463,7 @@ parso==0.8.4
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane==0.40.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -484,7 +484,13 @@ class Bloq(metaclass=abc.ABCMeta):
                 instance truly should not be included in the PennyLane circuit (e.g. for reshaping
                 bloqs). A bloq with no PennyLane equivalent should raise an exception instead.
         """
-        from pennylane.io import FromBloq
+        try:
+            from pennylane.io import FromBloq
+        except ImportError:
+            raise NotImplementedError(
+                f"{self} does not have a native PennyLane operation. "
+                f"pennylane>=0.41 will wrap this bloq in the `pennylane.io.FromBloq` adapter."
+            )
 
         return FromBloq(bloq=self, wires=wires)
 

--- a/qualtran/_infra/bloq.py
+++ b/qualtran/_infra/bloq.py
@@ -486,11 +486,11 @@ class Bloq(metaclass=abc.ABCMeta):
         """
         try:
             from pennylane.io import FromBloq
-        except ImportError:
+        except ImportError as e:
             raise NotImplementedError(
                 f"{self} does not have a native PennyLane operation. "
                 f"pennylane>=0.41 will wrap this bloq in the `pennylane.io.FromBloq` adapter."
-            )
+            ) from e
 
         return FromBloq(bloq=self, wires=wires)
 

--- a/qualtran/_infra/bloq_test.py
+++ b/qualtran/_infra/bloq_test.py
@@ -37,6 +37,9 @@ def test_bloq():
 def test_as_pl_op():
     import pennylane as qml
 
+    if not hasattr(qml, 'FromBloq'):
+        pytest.xfail("Requires pennylane>=0.41")
+
     tb = TestTwoBitOp()
 
     assert tb.as_pl_op(wires=[0, 1]) == qml.FromBloq(TestTwoBitOp(), wires=[0, 1])

--- a/qualtran/bloqs/basic_gates/cnot_test.py
+++ b/qualtran/bloqs/basic_gates/cnot_test.py
@@ -42,6 +42,8 @@ def test_cnot_tensor():
 
 def test_cnot_vs_pl():
     bloq = CNOT()
+    if not hasattr(qml, 'FromBloq'):
+        pytest.xfail("requires pennylane>=0.41")
     matrix = qml.FromBloq(bloq, wires=[0, 1]).matrix()
     # fmt: off
     should_be = np.array([


### PR DESCRIPTION
Since we can't push a PyPI package that depends on a url-specified dev branch of pennylane, make a patch against the v0.6 branch to fail gracefully if you only have the existing pennylane release. 