### PR TITLE
Bump version number to v0.7.0.dev0

### DIFF
--- a/qualtran/_version.py
+++ b/qualtran/_version.py
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "0.6.0"
+__version__ = "0.7.0.dev0"


### PR DESCRIPTION
In accordance with dev_tools/how-to-cut-a-release.md, so we can continue development on main and only the tagged commit will report version of 0.6.0