### PR TITLE
[QGFPoly] Add `QGFPoly`, a new data type to represent polynomials over galois fields

### DIFF
--- a/qualtran/__init__.py
+++ b/qualtran/__init__.py
@@ -61,6 +61,7 @@ from ._infra.data_types import (
     BQUInt,
     QMontgomeryUInt,
     QGF,
+    QGFPoly,
 )
 
 # Internal imports: none

--- a/qualtran/_infra/data_types.py
+++ b/qualtran/_infra/data_types.py
@@ -1078,7 +1078,7 @@ class QGFPoly(QDType):
     def to_gf_coefficients(self, f_x: galois.Poly) -> galois.Array:
         """Returns a big-endian array of coefficients of the polynomial f(x)."""
         f_x_coeffs = self.qgf.gf_type.Zeros(self.degree + 1)
-        f_x_coeffs[self.degree - f_x.degree:] = f_x.coeffs
+        f_x_coeffs[self.degree - f_x.degree :] = f_x.coeffs
         return f_x_coeffs
 
     def from_gf_coefficients(self, f_x: galois.Array) -> galois.Poly:


### PR DESCRIPTION
Part of a larger effort to add bloqs that perform arithmetic over polynomials with coefficients in a galois field.  