### PR TITLE
Greedy topological sort with symbolic register sizes

### DIFF
--- a/qualtran/_infra/binst_graph_iterators.py
+++ b/qualtran/_infra/binst_graph_iterators.py
@@ -40,6 +40,8 @@ def _priority(node: 'BloqInstance') -> int:
         return -_ALLOCATION_PRIORITY
 
     signature = node.bloq.signature
+    if any(reg.dtype.is_symbolic() for reg in signature):
+        return 0
     return total_bits(signature.rights()) - total_bits(signature.lefts())
 
 

--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -40,7 +40,6 @@ import numpy as np
 import sympy
 from numpy.typing import NDArray
 
-from ..symbolics import SymbolicInt
 from .binst_graph_iterators import greedy_topological_sort
 from .bloq import Bloq, DecomposeNotImplementedError, DecomposeTypeError
 from .data_types import check_dtypes_consistent, QAny, QBit, QDType
@@ -50,6 +49,7 @@ from .registers import Register, Side, Signature
 if TYPE_CHECKING:
     import cirq
 
+    from qualtran import SymbolicInt
     from qualtran.bloqs.bookkeeping.auto_partition import Unused
     from qualtran.cirq_interop._cirq_to_bloq import CirqQuregInT, CirqQuregT
     from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
@@ -884,10 +884,10 @@ class BloqBuilder:
     def add_register(self, reg: Register, bitsize: None = None) -> Union[None, SoquetT]: ...
 
     @overload
-    def add_register(self, reg: str, bitsize: SymbolicInt) -> SoquetT: ...
+    def add_register(self, reg: str, bitsize: 'SymbolicInt') -> SoquetT: ...
 
     def add_register(
-        self, reg: Union[str, Register], bitsize: Optional[SymbolicInt] = None
+        self, reg: Union[str, Register], bitsize: Optional['SymbolicInt'] = None
     ) -> Union[None, SoquetT]:
         """Add a new register to the composite bloq being built.
 

--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -49,11 +49,11 @@ from .registers import Register, Side, Signature
 if TYPE_CHECKING:
     import cirq
 
-    from qualtran import SymbolicInt
     from qualtran.bloqs.bookkeeping.auto_partition import Unused
     from qualtran.cirq_interop._cirq_to_bloq import CirqQuregInT, CirqQuregT
     from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
+    from qualtran.symbolics import SymbolicInt
 
 # NDArrays must be bound to np.generic
 _SoquetType = TypeVar('_SoquetType', bound=np.generic)

--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -40,6 +40,7 @@ import numpy as np
 import sympy
 from numpy.typing import NDArray
 
+from ..symbolics import SymbolicInt
 from .binst_graph_iterators import greedy_topological_sort
 from .bloq import Bloq, DecomposeNotImplementedError, DecomposeTypeError
 from .data_types import check_dtypes_consistent, QAny, QBit, QDType
@@ -883,10 +884,10 @@ class BloqBuilder:
     def add_register(self, reg: Register, bitsize: None = None) -> Union[None, SoquetT]: ...
 
     @overload
-    def add_register(self, reg: str, bitsize: int) -> SoquetT: ...
+    def add_register(self, reg: str, bitsize: SymbolicInt) -> SoquetT: ...
 
     def add_register(
-        self, reg: Union[str, Register], bitsize: Optional[int] = None
+        self, reg: Union[str, Register], bitsize: Optional[SymbolicInt] = None
     ) -> Union[None, SoquetT]:
         """Add a new register to the composite bloq being built.
 


### PR DESCRIPTION
There was a bug with symbolic register sizes when iterating over the bloq instances, see the comment in the added test (which used to fail)