### PR TITLE
[2025-04] Dependencies, including relased version of pennylane

### DIFF
--- a/dev_tools/requirements/deps/runtime.txt
+++ b/dev_tools/requirements/deps/runtime.txt
@@ -38,10 +38,7 @@ bartiq==0.9.0
 pyzx
 
 # Pennylane interop
-# TODO: https://github.com/quantumlib/Qualtran/issues/1589
-#       Reset to the released version when qualtran functionality
-#       is included
-pennylane@git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane
 
 # serialization
 protobuf

--- a/dev_tools/requirements/envs/dev.env.txt
+++ b/dev_tools/requirements/envs/dev.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=envs/dev.env.txt deps/dev-tools.txt deps/runtime.txt
 #
-absl-py==2.1.0
+absl-py==2.2.2
     # via tensorflow-docs
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
@@ -12,11 +12,11 @@ alabaster==1.0.0
     # via sphinx
 annotated-types==0.7.0
     # via pydantic
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   httpx
     #   jupyter-server
-anywidget==0.9.15
+anywidget==0.9.18
     # via qsharp-widgets
 appdirs==1.4.4
     # via pennylane
@@ -26,7 +26,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-ase==3.24.0
+ase==3.25.0
     # via openfermion
 astor==0.8.1
     # via
@@ -38,9 +38,9 @@ asttokens==3.0.0
     # via stack-data
 astunparse==1.6.3
     # via diastatic-malt
-async-lru==2.0.4
+async-lru==2.0.5
     # via jupyterlab
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -r deps/runtime.txt
     #   cirq-core
@@ -49,7 +49,7 @@ attrs==25.1.0
     #   referencing
 autograd==1.7.0
     # via pennylane
-autoray==0.7.0
+autoray==0.7.1
     # via
     #   cotengra
     #   pennylane
@@ -63,7 +63,7 @@ backports-tarfile==1.2.0
     # via jaraco-context
 bartiq==0.9.0
     # via -r deps/runtime.txt
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   nbconvert
     #   pydata-sphinx-theme
@@ -104,11 +104,11 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.1
+contourpy==1.3.2
     # via matplotlib
-cotengra==0.7.1
+cotengra==0.7.2
     # via quimb
-coverage[toml]==7.6.12
+coverage[toml]==7.8.0
     # via pytest-cov
 cryptography==44.0.2
     # via secretstorage
@@ -116,15 +116,9 @@ cycler==0.12.1
     # via matplotlib
 cytoolz==1.0.1
     # via quimb
-dash==2.18.2
+dash==3.0.3
     # via -r deps/runtime.txt
-dash-core-components==2.0.0
-    # via dash
-dash-html-components==2.0.0
-    # via dash
-dash-table==5.0.0
-    # via dash
-debugpy==1.8.13
+debugpy==1.8.14
     # via ipykernel
 decorator==5.2.1
     # via ipython
@@ -134,7 +128,7 @@ deprecation==2.1.0
     # via openfermion
 diastatic-malt==2.15.2
     # via pennylane
-dill==0.3.9
+dill==0.4.0
     # via pylint
 distlib==0.3.9
     # via virtualenv
@@ -157,7 +151,7 @@ executing==2.2.0
     # via stack-data
 fastjsonschema==2.21.1
     # via nbformat
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   -r deps/pylint.txt
     #   -r deps/pytest.txt
@@ -166,23 +160,23 @@ flask==3.0.3
     # via dash
 flynt==0.78
     # via -r deps/format.txt
-fonttools==4.56.0
+fonttools==4.57.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 fxpmath==0.4.9
     # via -r deps/runtime.txt
-galois==0.4.4
+galois==0.4.5
     # via -r deps/runtime.txt
 gast==0.6.0
     # via diastatic-malt
 graphviz==0.20.3
     # via qref
-greenlet==3.1.1
+greenlet==3.2.1
     # via sqlalchemy
-grpcio==1.70.0
+grpcio==1.71.0
     # via grpcio-tools
-grpcio-tools==1.70.0
+grpcio-tools==1.71.0
     # via -r deps/packaging.txt
 h11==0.14.0
     # via httpcore
@@ -190,7 +184,7 @@ h5py==3.13.0
     # via
     #   openfermion
     #   pyscf
-httpcore==1.0.7
+httpcore==1.0.8
     # via httpx
 httpx==0.28.1
     # via jupyterlab
@@ -210,20 +204,20 @@ importlib-metadata==8.6.1
     #   jupyter-cache
     #   keyring
     #   myst-nb
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
 ipykernel==6.29.5
     # via
     #   -r deps/pytest.txt
     #   jupyterlab
     #   myst-nb
-ipython==8.34.0
+ipython==8.35.0
     # via
     #   -r deps/runtime.txt
     #   ipykernel
     #   ipywidgets
     #   myst-nb
-ipywidgets==8.1.5
+ipywidgets==8.1.6
     # via
     #   -r deps/docs.txt
     #   -r deps/runtime.txt
@@ -265,7 +259,7 @@ jinja2==3.1.6
     #   nbconvert
     #   sphinx
     #   tensorflow-docs
-json5==0.10.0
+json5==0.12.0
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -305,7 +299,7 @@ jupyter-server==2.15.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.3.5
+jupyterlab==4.4.0
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
@@ -313,7 +307,7 @@ jupyterlab-server==2.27.3
     # via
     #   jupyterlab
     #   notebook
-jupyterlab-widgets==3.0.13
+jupyterlab-widgets==3.0.14
     # via ipywidgets
 keyring==25.6.0
     # via twine
@@ -348,13 +342,13 @@ mdit-py-plugins==0.4.2
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-mistune==3.1.2
+mistune==3.1.3
     # via nbconvert
 ml-dtypes==0.5.1
     # via
     #   jax
     #   jaxlib
-more-itertools==10.6.0
+more-itertools==10.7.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -362,7 +356,7 @@ mpmath==1.3.0
     # via sympy
 mypy==1.15.0
     # via -r deps/mypy.txt
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via
     #   black
     #   mypy
@@ -372,7 +366,7 @@ myst-nb==1.2.0
     # via -r deps/docs.txt
 myst-parser==4.0.1
     # via myst-nb
-narwhals==1.30.0
+narwhals==1.35.0
     # via plotly
 nbclient==0.10.2
     # via
@@ -406,7 +400,7 @@ networkx==3.4.2
     #   pennylane
 nh3==0.2.21
     # via readme-renderer
-notebook==7.3.2
+notebook==7.4.0
     # via
     #   -r deps/dev-tools.txt
     #   -r deps/runtime.txt
@@ -414,7 +408,7 @@ notebook-shim==0.2.4
     # via
     #   jupyterlab
     #   notebook
-numba==0.61.0
+numba==0.61.2
     # via
     #   galois
     #   quimb
@@ -449,7 +443,7 @@ opt-einsum==3.4.0
     # via jax
 overrides==7.7.0
     # via jupyter-server
-packaging==24.2
+packaging==25.0
     # via
     #   black
     #   build
@@ -474,25 +468,25 @@ parso==0.8.4
     # via jedi
 pathspec==0.12.1
     # via black
-pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane==0.41.0
     # via
     #   -r deps/runtime.txt
     #   pennylane-lightning
-pennylane-lightning==0.40.0
+pennylane-lightning==0.41.0
     # via pennylane
 pexpect==4.9.0
     # via ipython
-pillow==11.1.0
+pillow==11.2.1
     # via matplotlib
 pip-tools==7.4.1
     # via -r deps/pip-tools.txt
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   black
     #   jupyter-core
     #   pylint
     #   virtualenv
-plotly==6.0.0
+plotly==6.0.1
     # via
     #   -r deps/runtime.txt
     #   dash
@@ -500,9 +494,9 @@ pluggy==1.5.0
     # via pytest
 prometheus-client==0.21.1
     # via jupyter-server
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via ipython
-protobuf==5.29.3
+protobuf==5.29.4
     # via
     #   -r deps/runtime.txt
     #   grpcio-tools
@@ -524,11 +518,11 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pydantic==2.10.6
+pydantic==2.11.3
     # via
     #   bartiq
     #   qref
-pydantic-core==2.27.2
+pydantic-core==2.33.1
     # via pydantic
 pydata-sphinx-theme==0.16.1
     # via -r deps/docs.txt
@@ -543,7 +537,7 @@ pygments==2.19.1
     #   readme-renderer
     #   rich
     #   sphinx
-pylint==3.3.5
+pylint==3.3.6
     # via -r deps/pylint.txt
 pyparsing==3.1.4
     # via
@@ -556,7 +550,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pyscf==2.8.0
+pyscf==2.9.0
     # via openfermion
 pytest==8.3.5
     # via
@@ -565,9 +559,9 @@ pytest==8.3.5
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.25.3
+pytest-asyncio==0.26.0
     # via -r deps/pytest.txt
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via -r deps/pytest.txt
 pytest-xdist==3.6.1
     # via -r deps/pytest.txt
@@ -579,7 +573,7 @@ python-dateutil==2.9.0.post0
     #   pandas
 python-json-logger==3.3.0
     # via jupyter-events
-pytz==2025.1
+pytz==2025.2
     # via pandas
 pyyaml==6.0.2
     # via
@@ -588,7 +582,7 @@ pyyaml==6.0.2
     #   myst-nb
     #   myst-parser
     #   tensorflow-docs
-pyzmq==26.2.1
+pyzmq==26.4.0
     # via
     #   ipykernel
     #   jupyter-client
@@ -599,9 +593,9 @@ qref==0.9.0
     # via
     #   -r deps/runtime.txt
     #   bartiq
-qsharp==1.14.0
+qsharp==1.15.0
     # via -r deps/runtime.txt
-qsharp-widgets==1.14.0
+qsharp-widgets==1.15.0
     # via -r deps/runtime.txt
 quimb==1.10.0
     # via -r deps/runtime.txt
@@ -636,9 +630,9 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rich==13.9.4
+rich==14.0.0
     # via twine
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   jsonschema
     #   referencing
@@ -672,7 +666,7 @@ snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
     # via cirq-core
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
 sphinx==8.1.3
     # via
@@ -693,7 +687,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.38
+sqlalchemy==2.0.40
     # via jupyter-cache
 stack-data==0.6.3
     # via ipython
@@ -710,7 +704,7 @@ tensorflow-docs==2023.5.24.56664
     # via
     #   -r deps/docs.txt
     #   -r deps/pylint.txt
-termcolor==2.5.0
+termcolor==3.0.1
     # via diastatic-malt
 terminado==0.18.1
     # via
@@ -766,11 +760,11 @@ traitlets==5.14.3
     #   nbformat
 twine==6.1.0
     # via -r deps/packaging.txt
-types-protobuf==5.29.1.20250208
+types-protobuf==5.29.1.20250403
     # via mypy-protobuf
 types-python-dateutil==2.9.0.20241206
     # via arrow
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   -r deps/runtime.txt
     #   anyio
@@ -794,15 +788,18 @@ typing-extensions==4.12.2
     #   referencing
     #   rich
     #   sqlalchemy
-tzdata==2025.1
+    #   typing-inspection
+typing-inspection==0.4.0
+    # via pydantic
+tzdata==2025.2
     # via pandas
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   requests
     #   twine
-virtualenv==20.29.3
+virtualenv==20.30.0
     # via -r deps/packaging.txt
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -823,7 +820,7 @@ wheel==0.45.1
     #   -r deps/packaging.txt
     #   astunparse
     #   pip-tools
-widgetsnbextension==4.0.13
+widgetsnbextension==4.0.14
     # via ipywidgets
 zipp==3.21.0
     # via importlib-metadata

--- a/dev_tools/requirements/envs/docs.env.txt
+++ b/dev_tools/requirements/envs/docs.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/docs.env.txt deps/docs.txt deps/runtime.txt
 #
-absl-py==2.1.0
+absl-py==2.2.2
     # via
     #   -c envs/dev.env.txt
     #   tensorflow-docs
@@ -20,12 +20,12 @@ annotated-types==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   httpx
     #   jupyter-server
-anywidget==0.9.15
+anywidget==0.9.18
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -57,11 +57,11 @@ astunparse==1.6.3
     # via
     #   -c envs/dev.env.txt
     #   diastatic-malt
-async-lru==2.0.4
+async-lru==2.0.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -73,7 +73,7 @@ autograd==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   pennylane
-autoray==0.7.0
+autoray==0.7.1
     # via
     #   -c envs/dev.env.txt
     #   cotengra
@@ -89,7 +89,7 @@ bartiq==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -135,11 +135,11 @@ comm==0.2.2
     #   -c envs/dev.env.txt
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.1
+contourpy==1.3.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.7.1
+cotengra==0.7.2
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -151,23 +151,11 @@ cytoolz==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   quimb
-dash==2.18.2
+dash==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-dash-core-components==2.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-dash-html-components==2.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-dash-table==5.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-debugpy==1.8.13
+debugpy==1.8.14
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -210,7 +198,7 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.56.0
+fonttools==4.57.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -222,7 +210,7 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-galois==0.4.4
+galois==0.4.5
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -234,7 +222,7 @@ graphviz==0.20.3
     # via
     #   -c envs/dev.env.txt
     #   qref
-greenlet==3.1.1
+greenlet==3.2.1
     # via
     #   -c envs/dev.env.txt
     #   sqlalchemy
@@ -242,7 +230,7 @@ h11==0.14.0
     # via
     #   -c envs/dev.env.txt
     #   httpcore
-httpcore==1.0.7
+httpcore==1.0.8
     # via
     #   -c envs/dev.env.txt
     #   httpx
@@ -272,14 +260,14 @@ ipykernel==6.29.5
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   myst-nb
-ipython==8.34.0
+ipython==8.35.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   ipykernel
     #   ipywidgets
     #   myst-nb
-ipywidgets==8.1.5
+ipywidgets==8.1.6
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
@@ -309,7 +297,7 @@ jinja2==3.1.6
     #   nbconvert
     #   sphinx
     #   tensorflow-docs
-json5==0.10.0
+json5==0.12.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
@@ -367,7 +355,7 @@ jupyter-server-terminals==0.5.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-jupyterlab==4.3.5
+jupyterlab==4.4.0
     # via
     #   -c envs/dev.env.txt
     #   notebook
@@ -380,7 +368,7 @@ jupyterlab-server==2.27.3
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-jupyterlab-widgets==3.0.13
+jupyterlab-widgets==3.0.14
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -425,7 +413,7 @@ mdurl==0.1.2
     # via
     #   -c envs/dev.env.txt
     #   markdown-it-py
-mistune==3.1.2
+mistune==3.1.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -441,7 +429,7 @@ myst-parser==4.0.1
     # via
     #   -c envs/dev.env.txt
     #   myst-nb
-narwhals==1.30.0
+narwhals==1.35.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
@@ -479,7 +467,7 @@ networkx==3.4.2
     #   -r deps/runtime.txt
     #   cirq-core
     #   pennylane
-notebook==7.3.2
+notebook==7.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -488,7 +476,7 @@ notebook-shim==0.2.4
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-numba==0.61.0
+numba==0.61.2
     # via
     #   -c envs/dev.env.txt
     #   galois
@@ -514,7 +502,7 @@ overrides==7.7.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-packaging==24.2
+packaging==25.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -539,12 +527,12 @@ parso==0.8.4
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane==0.41.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pennylane-lightning
-pennylane-lightning==0.40.0
+pennylane-lightning==0.41.0
     # via
     #   -c envs/dev.env.txt
     #   pennylane
@@ -552,15 +540,15 @@ pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==11.1.0
+pillow==11.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
-plotly==6.0.0
+plotly==6.0.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -569,11 +557,11 @@ prometheus-client==0.21.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.29.3
+protobuf==5.29.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -600,12 +588,12 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
-pydantic==2.10.6
+pydantic==2.11.3
     # via
     #   -c envs/dev.env.txt
     #   bartiq
     #   qref
-pydantic-core==2.27.2
+pydantic-core==2.33.1
     # via
     #   -c envs/dev.env.txt
     #   pydantic
@@ -646,7 +634,7 @@ python-json-logger==3.3.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
-pytz==2025.1
+pytz==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -658,7 +646,7 @@ pyyaml==6.0.2
     #   myst-nb
     #   myst-parser
     #   tensorflow-docs
-pyzmq==26.2.1
+pyzmq==26.4.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -673,11 +661,11 @@ qref==0.9.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   bartiq
-qsharp==1.14.0
+qsharp==1.15.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.14.0
+qsharp-widgets==1.15.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -712,7 +700,7 @@ rfc3986-validator==0.1.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jupyter-events
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -754,7 +742,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
@@ -789,7 +777,7 @@ sphinxcontrib-serializinghtml==2.0.0
     # via
     #   -c envs/dev.env.txt
     #   sphinx
-sqlalchemy==2.0.38
+sqlalchemy==2.0.40
     # via
     #   -c envs/dev.env.txt
     #   jupyter-cache
@@ -811,7 +799,7 @@ tensorflow-docs==2023.5.24.56664
     # via
     #   -c envs/dev.env.txt
     #   -r deps/docs.txt
-termcolor==2.5.0
+termcolor==3.0.1
     # via
     #   -c envs/dev.env.txt
     #   diastatic-malt
@@ -872,7 +860,7 @@ types-python-dateutil==2.9.0.20241206
     # via
     #   -c envs/dev.env.txt
     #   arrow
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -893,7 +881,12 @@ typing-extensions==4.12.2
     #   pyzx
     #   referencing
     #   sqlalchemy
-tzdata==2025.1
+    #   typing-inspection
+typing-inspection==0.4.0
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
+tzdata==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -901,7 +894,7 @@ uri-template==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -931,7 +924,7 @@ wheel==0.45.1
     # via
     #   -c envs/dev.env.txt
     #   astunparse
-widgetsnbextension==4.0.13
+widgetsnbextension==4.0.14
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets

--- a/dev_tools/requirements/envs/format.env.txt
+++ b/dev_tools/requirements/envs/format.env.txt
@@ -8,12 +8,12 @@ annotated-types==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   httpx
     #   jupyter-server
-anywidget==0.9.15
+anywidget==0.9.18
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -45,11 +45,11 @@ astunparse==1.6.3
     # via
     #   -c envs/dev.env.txt
     #   diastatic-malt
-async-lru==2.0.4
+async-lru==2.0.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -60,7 +60,7 @@ autograd==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   pennylane
-autoray==0.7.0
+autoray==0.7.1
     # via
     #   -c envs/dev.env.txt
     #   cotengra
@@ -74,7 +74,7 @@ bartiq==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -123,11 +123,11 @@ comm==0.2.2
     #   -c envs/dev.env.txt
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.1
+contourpy==1.3.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.7.1
+cotengra==0.7.2
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -139,23 +139,11 @@ cytoolz==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   quimb
-dash==2.18.2
+dash==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-dash-core-components==2.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-dash-html-components==2.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-dash-table==5.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-debugpy==1.8.13
+debugpy==1.8.14
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -196,7 +184,7 @@ flynt==0.78
     # via
     #   -c envs/dev.env.txt
     #   -r deps/format.txt
-fonttools==4.56.0
+fonttools==4.57.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -208,7 +196,7 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-galois==0.4.4
+galois==0.4.5
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -224,7 +212,7 @@ h11==0.14.0
     # via
     #   -c envs/dev.env.txt
     #   httpcore
-httpcore==1.0.7
+httpcore==1.0.8
     # via
     #   -c envs/dev.env.txt
     #   httpx
@@ -247,13 +235,13 @@ ipykernel==6.29.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-ipython==8.34.0
+ipython==8.35.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   ipykernel
     #   ipywidgets
-ipywidgets==8.1.5
+ipywidgets==8.1.6
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -283,7 +271,7 @@ jinja2==3.1.6
     #   jupyterlab
     #   jupyterlab-server
     #   nbconvert
-json5==0.10.0
+json5==0.12.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
@@ -337,7 +325,7 @@ jupyter-server-terminals==0.5.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-jupyterlab==4.3.5
+jupyterlab==4.4.0
     # via
     #   -c envs/dev.env.txt
     #   notebook
@@ -350,7 +338,7 @@ jupyterlab-server==2.27.3
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-jupyterlab-widgets==3.0.13
+jupyterlab-widgets==3.0.14
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -382,7 +370,7 @@ matplotlib-inline==0.1.7
     #   -c envs/dev.env.txt
     #   ipykernel
     #   ipython
-mistune==3.1.2
+mistune==3.1.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -390,11 +378,11 @@ mpmath==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   sympy
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via
     #   -c envs/dev.env.txt
     #   black
-narwhals==1.30.0
+narwhals==1.35.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
@@ -425,7 +413,7 @@ networkx==3.4.2
     #   -r deps/runtime.txt
     #   cirq-core
     #   pennylane
-notebook==7.3.2
+notebook==7.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -434,7 +422,7 @@ notebook-shim==0.2.4
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-numba==0.61.0
+numba==0.61.2
     # via
     #   -c envs/dev.env.txt
     #   galois
@@ -460,7 +448,7 @@ overrides==7.7.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-packaging==24.2
+packaging==25.0
     # via
     #   -c envs/dev.env.txt
     #   black
@@ -489,12 +477,12 @@ pathspec==0.12.1
     # via
     #   -c envs/dev.env.txt
     #   black
-pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane==0.41.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pennylane-lightning
-pennylane-lightning==0.40.0
+pennylane-lightning==0.41.0
     # via
     #   -c envs/dev.env.txt
     #   pennylane
@@ -502,16 +490,16 @@ pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==11.1.0
+pillow==11.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   -c envs/dev.env.txt
     #   black
     #   jupyter-core
-plotly==6.0.0
+plotly==6.0.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -520,11 +508,11 @@ prometheus-client==0.21.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.29.3
+protobuf==5.29.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -550,12 +538,12 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
-pydantic==2.10.6
+pydantic==2.11.3
     # via
     #   -c envs/dev.env.txt
     #   bartiq
     #   qref
-pydantic-core==2.27.2
+pydantic-core==2.33.1
     # via
     #   -c envs/dev.env.txt
     #   pydantic
@@ -589,7 +577,7 @@ python-json-logger==3.3.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
-pytz==2025.1
+pytz==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -597,7 +585,7 @@ pyyaml==6.0.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
-pyzmq==26.2.1
+pyzmq==26.4.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -612,11 +600,11 @@ qref==0.9.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   bartiq
-qsharp==1.14.0
+qsharp==1.15.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.14.0
+qsharp-widgets==1.15.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -650,7 +638,7 @@ rfc3986-validator==0.1.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jupyter-events
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -688,7 +676,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
@@ -702,7 +690,7 @@ sympy==1.12.1
     #   -r deps/runtime.txt
     #   bartiq
     #   cirq-core
-termcolor==2.5.0
+termcolor==3.0.1
     # via
     #   -c envs/dev.env.txt
     #   diastatic-malt
@@ -764,7 +752,7 @@ types-python-dateutil==2.9.0.20241206
     # via
     #   -c envs/dev.env.txt
     #   arrow
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -783,7 +771,12 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   pyzx
     #   referencing
-tzdata==2025.1
+    #   typing-inspection
+typing-inspection==0.4.0
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
+tzdata==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -791,7 +784,7 @@ uri-template==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -821,7 +814,7 @@ wheel==0.45.1
     # via
     #   -c envs/dev.env.txt
     #   astunparse
-widgetsnbextension==4.0.13
+widgetsnbextension==4.0.14
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets

--- a/dev_tools/requirements/envs/pip-tools.env.txt
+++ b/dev_tools/requirements/envs/pip-tools.env.txt
@@ -12,7 +12,7 @@ click==8.1.8
     # via
     #   -c envs/dev.env.txt
     #   pip-tools
-packaging==24.2
+packaging==25.0
     # via
     #   -c envs/dev.env.txt
     #   build

--- a/dev_tools/requirements/envs/pylint.env.txt
+++ b/dev_tools/requirements/envs/pylint.env.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=envs/dev.env.txt --output-file=envs/pylint.env.txt deps/pylint.txt deps/runtime.txt
 #
-absl-py==2.1.0
+absl-py==2.2.2
     # via
     #   -c envs/dev.env.txt
     #   tensorflow-docs
@@ -16,12 +16,12 @@ annotated-types==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   httpx
     #   jupyter-server
-anywidget==0.9.15
+anywidget==0.9.18
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -41,7 +41,7 @@ arrow==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   isoduration
-ase==3.24.0
+ase==3.25.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
@@ -61,11 +61,11 @@ astunparse==1.6.3
     # via
     #   -c envs/dev.env.txt
     #   diastatic-malt
-async-lru==2.0.4
+async-lru==2.0.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -76,7 +76,7 @@ autograd==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   pennylane
-autoray==0.7.0
+autoray==0.7.1
     # via
     #   -c envs/dev.env.txt
     #   cotengra
@@ -91,7 +91,7 @@ bartiq==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -136,11 +136,11 @@ comm==0.2.2
     #   -c envs/dev.env.txt
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.1
+contourpy==1.3.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.7.1
+cotengra==0.7.2
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -152,23 +152,11 @@ cytoolz==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   quimb
-dash==2.18.2
+dash==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-dash-core-components==2.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-dash-html-components==2.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-dash-table==5.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-debugpy==1.8.13
+debugpy==1.8.14
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -188,7 +176,7 @@ diastatic-malt==2.15.2
     # via
     #   -c envs/dev.env.txt
     #   pennylane
-dill==0.3.9
+dill==0.4.0
     # via
     #   -c envs/dev.env.txt
     #   pylint
@@ -214,7 +202,7 @@ fastjsonschema==2.21.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
@@ -222,7 +210,7 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.56.0
+fonttools==4.57.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -234,7 +222,7 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-galois==0.4.4
+galois==0.4.5
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -255,7 +243,7 @@ h5py==3.13.0
     #   -c envs/dev.env.txt
     #   openfermion
     #   pyscf
-httpcore==1.0.7
+httpcore==1.0.8
     # via
     #   -c envs/dev.env.txt
     #   httpx
@@ -278,7 +266,7 @@ importlib-metadata==8.6.1
     # via
     #   -c envs/dev.env.txt
     #   dash
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -286,13 +274,13 @@ ipykernel==6.29.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-ipython==8.34.0
+ipython==8.35.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   ipykernel
     #   ipywidgets
-ipywidgets==8.1.5
+ipywidgets==8.1.6
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -333,7 +321,7 @@ jinja2==3.1.6
     #   nbconvert
     #   sphinx
     #   tensorflow-docs
-json5==0.10.0
+json5==0.12.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
@@ -387,7 +375,7 @@ jupyter-server-terminals==0.5.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-jupyterlab==4.3.5
+jupyterlab==4.4.0
     # via
     #   -c envs/dev.env.txt
     #   notebook
@@ -400,7 +388,7 @@ jupyterlab-server==2.27.3
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-jupyterlab-widgets==3.0.13
+jupyterlab-widgets==3.0.14
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -437,7 +425,7 @@ mccabe==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pylint
-mistune==3.1.2
+mistune==3.1.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -450,7 +438,7 @@ mpmath==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   sympy
-narwhals==1.30.0
+narwhals==1.35.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
@@ -483,7 +471,7 @@ networkx==3.4.2
     #   cirq-core
     #   openfermion
     #   pennylane
-notebook==7.3.2
+notebook==7.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -492,7 +480,7 @@ notebook-shim==0.2.4
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-numba==0.61.0
+numba==0.61.2
     # via
     #   -c envs/dev.env.txt
     #   galois
@@ -533,7 +521,7 @@ overrides==7.7.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-packaging==24.2
+packaging==25.0
     # via
     #   -c envs/dev.env.txt
     #   deprecation
@@ -560,12 +548,12 @@ parso==0.8.4
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane==0.41.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pennylane-lightning
-pennylane-lightning==0.40.0
+pennylane-lightning==0.41.0
     # via
     #   -c envs/dev.env.txt
     #   pennylane
@@ -573,16 +561,16 @@ pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==11.1.0
+pillow==11.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
     #   pylint
-plotly==6.0.0
+plotly==6.0.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -595,11 +583,11 @@ prometheus-client==0.21.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.29.3
+protobuf==5.29.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -630,12 +618,12 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
-pydantic==2.10.6
+pydantic==2.11.3
     # via
     #   -c envs/dev.env.txt
     #   bartiq
     #   qref
-pydantic-core==2.27.2
+pydantic-core==2.33.1
     # via
     #   -c envs/dev.env.txt
     #   pydantic
@@ -649,7 +637,7 @@ pygments==2.19.1
     #   ipython
     #   nbconvert
     #   sphinx
-pylint==3.3.5
+pylint==3.3.6
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
@@ -663,7 +651,7 @@ pyperclip==1.9.0
     # via
     #   -c envs/dev.env.txt
     #   pyzx
-pyscf==2.8.0
+pyscf==2.9.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
@@ -682,7 +670,7 @@ python-json-logger==3.3.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
-pytz==2025.1
+pytz==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -691,7 +679,7 @@ pyyaml==6.0.2
     #   -c envs/dev.env.txt
     #   jupyter-events
     #   tensorflow-docs
-pyzmq==26.2.1
+pyzmq==26.4.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -706,11 +694,11 @@ qref==0.9.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   bartiq
-qsharp==1.14.0
+qsharp==1.15.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.14.0
+qsharp-widgets==1.15.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -746,7 +734,7 @@ rfc3986-validator==0.1.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jupyter-events
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -793,7 +781,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
@@ -840,7 +828,7 @@ tensorflow-docs==2023.5.24.56664
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pylint.txt
-termcolor==2.5.0
+termcolor==3.0.1
     # via
     #   -c envs/dev.env.txt
     #   diastatic-malt
@@ -904,7 +892,7 @@ types-python-dateutil==2.9.0.20241206
     # via
     #   -c envs/dev.env.txt
     #   arrow
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -923,7 +911,12 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   pyzx
     #   referencing
-tzdata==2025.1
+    #   typing-inspection
+typing-inspection==0.4.0
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
+tzdata==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -931,7 +924,7 @@ uri-template==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -961,7 +954,7 @@ wheel==0.45.1
     # via
     #   -c envs/dev.env.txt
     #   astunparse
-widgetsnbextension==4.0.13
+widgetsnbextension==4.0.14
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets

--- a/dev_tools/requirements/envs/pytest.env.txt
+++ b/dev_tools/requirements/envs/pytest.env.txt
@@ -8,12 +8,12 @@ annotated-types==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   httpx
     #   jupyter-server
-anywidget==0.9.15
+anywidget==0.9.18
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -33,7 +33,7 @@ arrow==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   isoduration
-ase==3.24.0
+ase==3.25.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
@@ -45,11 +45,11 @@ astunparse==1.6.3
     # via
     #   -c envs/dev.env.txt
     #   diastatic-malt
-async-lru==2.0.4
+async-lru==2.0.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -60,7 +60,7 @@ autograd==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   pennylane
-autoray==0.7.0
+autoray==0.7.1
     # via
     #   -c envs/dev.env.txt
     #   cotengra
@@ -74,7 +74,7 @@ bartiq==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -119,15 +119,15 @@ comm==0.2.2
     #   -c envs/dev.env.txt
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.1
+contourpy==1.3.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.7.1
+cotengra==0.7.2
     # via
     #   -c envs/dev.env.txt
     #   quimb
-coverage[toml]==7.6.12
+coverage[toml]==7.8.0
     # via
     #   -c envs/dev.env.txt
     #   pytest-cov
@@ -139,23 +139,11 @@ cytoolz==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   quimb
-dash==2.18.2
+dash==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-dash-core-components==2.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-dash-html-components==2.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-dash-table==5.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-debugpy==1.8.13
+debugpy==1.8.14
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -197,7 +185,7 @@ fastjsonschema==2.21.1
     # via
     #   -c envs/dev.env.txt
     #   nbformat
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -205,7 +193,7 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.56.0
+fonttools==4.57.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -217,7 +205,7 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-galois==0.4.4
+galois==0.4.5
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -238,7 +226,7 @@ h5py==3.13.0
     #   -c envs/dev.env.txt
     #   openfermion
     #   pyscf
-httpcore==1.0.7
+httpcore==1.0.8
     # via
     #   -c envs/dev.env.txt
     #   httpx
@@ -257,7 +245,7 @@ importlib-metadata==8.6.1
     # via
     #   -c envs/dev.env.txt
     #   dash
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
     #   -c envs/dev.env.txt
     #   pytest
@@ -266,13 +254,13 @@ ipykernel==6.29.5
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
     #   jupyterlab
-ipython==8.34.0
+ipython==8.35.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   ipykernel
     #   ipywidgets
-ipywidgets==8.1.5
+ipywidgets==8.1.6
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -307,7 +295,7 @@ jinja2==3.1.6
     #   jupyterlab
     #   jupyterlab-server
     #   nbconvert
-json5==0.10.0
+json5==0.12.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
@@ -361,7 +349,7 @@ jupyter-server-terminals==0.5.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-jupyterlab==4.3.5
+jupyterlab==4.4.0
     # via
     #   -c envs/dev.env.txt
     #   notebook
@@ -374,7 +362,7 @@ jupyterlab-server==2.27.3
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-jupyterlab-widgets==3.0.13
+jupyterlab-widgets==3.0.14
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -407,7 +395,7 @@ matplotlib-inline==0.1.7
     #   -c envs/dev.env.txt
     #   ipykernel
     #   ipython
-mistune==3.1.2
+mistune==3.1.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -420,7 +408,7 @@ mpmath==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   sympy
-narwhals==1.30.0
+narwhals==1.35.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
@@ -452,7 +440,7 @@ networkx==3.4.2
     #   cirq-core
     #   openfermion
     #   pennylane
-notebook==7.3.2
+notebook==7.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -461,7 +449,7 @@ notebook-shim==0.2.4
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-numba==0.61.0
+numba==0.61.2
     # via
     #   -c envs/dev.env.txt
     #   galois
@@ -502,7 +490,7 @@ overrides==7.7.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-packaging==24.2
+packaging==25.0
     # via
     #   -c envs/dev.env.txt
     #   deprecation
@@ -528,12 +516,12 @@ parso==0.8.4
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane==0.41.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pennylane-lightning
-pennylane-lightning==0.40.0
+pennylane-lightning==0.41.0
     # via
     #   -c envs/dev.env.txt
     #   pennylane
@@ -541,15 +529,15 @@ pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==11.1.0
+pillow==11.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
-plotly==6.0.0
+plotly==6.0.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -562,11 +550,11 @@ prometheus-client==0.21.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.29.3
+protobuf==5.29.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -596,12 +584,12 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
-pydantic==2.10.6
+pydantic==2.11.3
     # via
     #   -c envs/dev.env.txt
     #   bartiq
     #   qref
-pydantic-core==2.27.2
+pydantic-core==2.33.1
     # via
     #   -c envs/dev.env.txt
     #   pydantic
@@ -624,7 +612,7 @@ pyperclip==1.9.0
     # via
     #   -c envs/dev.env.txt
     #   pyzx
-pyscf==2.8.0
+pyscf==2.9.0
     # via
     #   -c envs/dev.env.txt
     #   openfermion
@@ -635,11 +623,11 @@ pytest==8.3.5
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-xdist
-pytest-asyncio==0.25.3
+pytest-asyncio==0.26.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/pytest.txt
@@ -658,7 +646,7 @@ python-json-logger==3.3.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
-pytz==2025.1
+pytz==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -666,7 +654,7 @@ pyyaml==6.0.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
-pyzmq==26.2.1
+pyzmq==26.4.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -681,11 +669,11 @@ qref==0.9.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   bartiq
-qsharp==1.14.0
+qsharp==1.15.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.14.0
+qsharp-widgets==1.15.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -720,7 +708,7 @@ rfc3986-validator==0.1.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jupyter-events
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -763,7 +751,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
@@ -778,7 +766,7 @@ sympy==1.12.1
     #   bartiq
     #   cirq-core
     #   openfermion
-termcolor==2.5.0
+termcolor==3.0.1
     # via
     #   -c envs/dev.env.txt
     #   diastatic-malt
@@ -840,7 +828,7 @@ types-python-dateutil==2.9.0.20241206
     # via
     #   -c envs/dev.env.txt
     #   arrow
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -858,7 +846,12 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   pyzx
     #   referencing
-tzdata==2025.1
+    #   typing-inspection
+typing-inspection==0.4.0
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
+tzdata==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -866,7 +859,7 @@ uri-template==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -896,7 +889,7 @@ wheel==0.45.1
     # via
     #   -c envs/dev.env.txt
     #   astunparse
-widgetsnbextension==4.0.13
+widgetsnbextension==4.0.14
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets

--- a/dev_tools/requirements/envs/runtime.env.txt
+++ b/dev_tools/requirements/envs/runtime.env.txt
@@ -8,12 +8,12 @@ annotated-types==0.7.0
     # via
     #   -c envs/dev.env.txt
     #   pydantic
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   httpx
     #   jupyter-server
-anywidget==0.9.15
+anywidget==0.9.18
     # via
     #   -c envs/dev.env.txt
     #   qsharp-widgets
@@ -41,11 +41,11 @@ astunparse==1.6.3
     # via
     #   -c envs/dev.env.txt
     #   diastatic-malt
-async-lru==2.0.4
+async-lru==2.0.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -56,7 +56,7 @@ autograd==1.7.0
     # via
     #   -c envs/dev.env.txt
     #   pennylane
-autoray==0.7.0
+autoray==0.7.1
     # via
     #   -c envs/dev.env.txt
     #   cotengra
@@ -70,7 +70,7 @@ bartiq==0.9.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -114,11 +114,11 @@ comm==0.2.2
     #   -c envs/dev.env.txt
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.1
+contourpy==1.3.2
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-cotengra==0.7.1
+cotengra==0.7.2
     # via
     #   -c envs/dev.env.txt
     #   quimb
@@ -130,23 +130,11 @@ cytoolz==1.0.1
     # via
     #   -c envs/dev.env.txt
     #   quimb
-dash==2.18.2
+dash==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-dash-core-components==2.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-dash-html-components==2.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-dash-table==5.0.0
-    # via
-    #   -c envs/dev.env.txt
-    #   dash
-debugpy==1.8.13
+debugpy==1.8.14
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -183,7 +171,7 @@ flask==3.0.3
     # via
     #   -c envs/dev.env.txt
     #   dash
-fonttools==4.56.0
+fonttools==4.57.0
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
@@ -195,7 +183,7 @@ fxpmath==0.4.9
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-galois==0.4.4
+galois==0.4.5
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -211,7 +199,7 @@ h11==0.14.0
     # via
     #   -c envs/dev.env.txt
     #   httpcore
-httpcore==1.0.7
+httpcore==1.0.8
     # via
     #   -c envs/dev.env.txt
     #   httpx
@@ -234,13 +222,13 @@ ipykernel==6.29.5
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab
-ipython==8.34.0
+ipython==8.35.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   ipykernel
     #   ipywidgets
-ipywidgets==8.1.5
+ipywidgets==8.1.6
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -266,7 +254,7 @@ jinja2==3.1.6
     #   jupyterlab
     #   jupyterlab-server
     #   nbconvert
-json5==0.10.0
+json5==0.12.0
     # via
     #   -c envs/dev.env.txt
     #   jupyterlab-server
@@ -320,7 +308,7 @@ jupyter-server-terminals==0.5.3
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-jupyterlab==4.3.5
+jupyterlab==4.4.0
     # via
     #   -c envs/dev.env.txt
     #   notebook
@@ -333,7 +321,7 @@ jupyterlab-server==2.27.3
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-jupyterlab-widgets==3.0.13
+jupyterlab-widgets==3.0.14
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets
@@ -365,7 +353,7 @@ matplotlib-inline==0.1.7
     #   -c envs/dev.env.txt
     #   ipykernel
     #   ipython
-mistune==3.1.2
+mistune==3.1.3
     # via
     #   -c envs/dev.env.txt
     #   nbconvert
@@ -373,7 +361,7 @@ mpmath==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   sympy
-narwhals==1.30.0
+narwhals==1.35.0
     # via
     #   -c envs/dev.env.txt
     #   plotly
@@ -404,7 +392,7 @@ networkx==3.4.2
     #   -r deps/runtime.txt
     #   cirq-core
     #   pennylane
-notebook==7.3.2
+notebook==7.4.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -413,7 +401,7 @@ notebook-shim==0.2.4
     #   -c envs/dev.env.txt
     #   jupyterlab
     #   notebook
-numba==0.61.0
+numba==0.61.2
     # via
     #   -c envs/dev.env.txt
     #   galois
@@ -439,7 +427,7 @@ overrides==7.7.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-packaging==24.2
+packaging==25.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -463,12 +451,12 @@ parso==0.8.4
     # via
     #   -c envs/dev.env.txt
     #   jedi
-pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@qualtran_pl
+pennylane==0.41.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   pennylane-lightning
-pennylane-lightning==0.40.0
+pennylane-lightning==0.41.0
     # via
     #   -c envs/dev.env.txt
     #   pennylane
@@ -476,15 +464,15 @@ pexpect==4.9.0
     # via
     #   -c envs/dev.env.txt
     #   ipython
-pillow==11.1.0
+pillow==11.2.1
     # via
     #   -c envs/dev.env.txt
     #   matplotlib
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   -c envs/dev.env.txt
     #   jupyter-core
-plotly==6.0.0
+plotly==6.0.1
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -493,11 +481,11 @@ prometheus-client==0.21.1
     # via
     #   -c envs/dev.env.txt
     #   jupyter-server
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c envs/dev.env.txt
     #   ipython
-protobuf==5.29.3
+protobuf==5.29.4
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -523,12 +511,12 @@ pycparser==2.22
     # via
     #   -c envs/dev.env.txt
     #   cffi
-pydantic==2.10.6
+pydantic==2.11.3
     # via
     #   -c envs/dev.env.txt
     #   bartiq
     #   qref
-pydantic-core==2.27.2
+pydantic-core==2.33.1
     # via
     #   -c envs/dev.env.txt
     #   pydantic
@@ -562,7 +550,7 @@ python-json-logger==3.3.0
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
-pytz==2025.1
+pytz==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -570,7 +558,7 @@ pyyaml==6.0.2
     # via
     #   -c envs/dev.env.txt
     #   jupyter-events
-pyzmq==26.2.1
+pyzmq==26.4.0
     # via
     #   -c envs/dev.env.txt
     #   ipykernel
@@ -585,11 +573,11 @@ qref==0.9.0
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
     #   bartiq
-qsharp==1.14.0
+qsharp==1.15.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
-qsharp-widgets==1.14.0
+qsharp-widgets==1.15.0
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -623,7 +611,7 @@ rfc3986-validator==0.1.1
     #   -c envs/dev.env.txt
     #   jsonschema
     #   jupyter-events
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
@@ -661,7 +649,7 @@ sortedcontainers==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   cirq-core
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c envs/dev.env.txt
     #   beautifulsoup4
@@ -675,7 +663,7 @@ sympy==1.12.1
     #   -r deps/runtime.txt
     #   bartiq
     #   cirq-core
-termcolor==2.5.0
+termcolor==3.0.1
     # via
     #   -c envs/dev.env.txt
     #   diastatic-malt
@@ -735,7 +723,7 @@ types-python-dateutil==2.9.0.20241206
     # via
     #   -c envs/dev.env.txt
     #   arrow
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   -c envs/dev.env.txt
     #   -r deps/runtime.txt
@@ -753,7 +741,12 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   pyzx
     #   referencing
-tzdata==2025.1
+    #   typing-inspection
+typing-inspection==0.4.0
+    # via
+    #   -c envs/dev.env.txt
+    #   pydantic
+tzdata==2025.2
     # via
     #   -c envs/dev.env.txt
     #   pandas
@@ -761,7 +754,7 @@ uri-template==1.3.0
     # via
     #   -c envs/dev.env.txt
     #   jsonschema
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   -c envs/dev.env.txt
     #   requests
@@ -791,7 +784,7 @@ wheel==0.45.1
     # via
     #   -c envs/dev.env.txt
     #   astunparse
-widgetsnbextension==4.0.13
+widgetsnbextension==4.0.14
     # via
     #   -c envs/dev.env.txt
     #   ipywidgets


### PR DESCRIPTION
 - regularly scheduled update of our pinned dependencies for the CI
 - depend on a released version of pennylane. fixes #1589. Note that the relevant interop code in qualtran is still guarded by a `try/except` to disable the functionality that's only available in pennylane>=0.41