### PR TITLE
Correct lint issues exposed with update to pylint-3

### DIFF
--- a/dev_tools/conf/.pylintrc
+++ b/dev_tools/conf/.pylintrc
@@ -8,7 +8,6 @@ reports=no
 py-version=3.9
 disable=
     abstract-class-instantiated,        # TODO: #1440 - enable and fix
-    deprecated-class,                   # TODO: #1440 - enable and fix
     possibly-used-before-assignment,    # TODO: #1440 - enable and fix
     used-before-assignment,             # TODO: #1440 - enable and fix
     C,

--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 """Classes for building and manipulating `CompositeBloq`."""
+from collections.abc import Hashable
 from functools import cached_property
 from typing import (
     Callable,
@@ -32,7 +33,6 @@ from typing import (
     TypeVar,
     Union,
 )
-from collections.abc import Hashable
 
 import attrs
 import networkx as nx

--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -19,7 +19,6 @@ from typing import (
     cast,
     Dict,
     FrozenSet,
-    Hashable,
     Iterable,
     Iterator,
     List,
@@ -33,6 +32,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from collections.abc import Hashable
 
 import attrs
 import networkx as nx

--- a/qualtran/symbolics/types.py
+++ b/qualtran/symbolics/types.py
@@ -11,7 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import overload, Sized, TypeVar, Union
+from typing import overload, TypeVar, Union
+from collections.abc import Sized
 
 import numpy as np
 import sympy

--- a/qualtran/symbolics/types.py
+++ b/qualtran/symbolics/types.py
@@ -11,8 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import overload, TypeVar, Union
 from collections.abc import Sized
+from typing import overload, TypeVar, Union
 
 import numpy as np
 import sympy


### PR DESCRIPTION
Fixes #1440 

Re-enables the following pylint issues which were disabled when bumping to pylint-3.

- [ ] abstract-class-instantiated
- [X] deprecated-class
- [ ] possibly-used-before-assignment
- [ ] used-before-assignment