### PR TITLE
Compatibility shims

### DIFF
--- a/qualtran/__init__.py
+++ b/qualtran/__init__.py
@@ -61,6 +61,8 @@ from ._infra.data_types import (
     BQUInt,
     QMontgomeryUInt,
     QGF,
+    # Deprecated
+    BoundedQUInt,
 )
 
 # Internal imports: none

--- a/qualtran/_infra/data_types.py
+++ b/qualtran/_infra/data_types.py
@@ -49,6 +49,7 @@ respectively.
 """
 
 import abc
+import warnings
 from enum import Enum
 from functools import cached_property
 from typing import Any, Iterable, List, Optional, Sequence, Union
@@ -525,6 +526,11 @@ class BQUInt(QDType):
 
     def __str__(self):
         return f'{self.__class__.__name__}({self.bitsize}, {self.iteration_length})'
+
+
+def BoundedQUInt(*args, **kwargs):
+    warnings.warn("Please use `qualtran.BQUInt`", DeprecationWarning)
+    return BQUInt(*args, **kwargs)
 
 
 @attrs.frozen

--- a/qualtran/bloqs/mcmt/__init__.py
+++ b/qualtran/bloqs/mcmt/__init__.py
@@ -15,5 +15,5 @@
 from qualtran.bloqs.mcmt.and_bloq import And, MultiAnd
 from qualtran.bloqs.mcmt.controlled_via_and import ControlledViaAnd
 from qualtran.bloqs.mcmt.ctrl_spec_and import CtrlSpecAnd
-from qualtran.bloqs.mcmt.multi_control_pauli import MultiControlX, MultiControlZ
+from qualtran.bloqs.mcmt.multi_control_pauli import MultiControlPauli, MultiControlX, MultiControlZ
 from qualtran.bloqs.mcmt.multi_target_cnot import MultiTargetCNOT

--- a/qualtran/bloqs/mcmt/multi_control_pauli.py
+++ b/qualtran/bloqs/mcmt/multi_control_pauli.py
@@ -62,7 +62,8 @@ class MultiControlPauli(GateWithRegisters):
     """
 
     cvs: Union[HasLength, Tuple[int, ...]] = field(converter=_to_tuple_or_has_length)
-    target_bloq: Bloq
+    target_bloq: Bloq = None
+    _target_gate: 'Optional[cirq.Gate]' = field(kw_only=True, default=None)
 
     def __attrs_post_init__(self):
         warnings.warn(
@@ -72,6 +73,13 @@ class MultiControlPauli(GateWithRegisters):
             "use `target_bloq.controlled(CtrlSpec(cvs=cvs))`.",
             DeprecationWarning,
         )
+        if self.target_bloq is None:
+            if self._target_gate is None:
+                raise ValueError("Expected either `target_bloq` or `target_gate`")
+
+            from qualtran.cirq_interop import cirq_gate_to_bloq
+
+            object.__setattr__(self, 'target_bloq', cirq_gate_to_bloq(self._target_gate))
 
     @cached_property
     def signature(self) -> 'Signature':

--- a/qualtran/bloqs/state_preparation/__init__.py
+++ b/qualtran/bloqs/state_preparation/__init__.py
@@ -12,13 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from qualtran.bloqs.state_preparation.prepare_uniform_superposition import (
-    PrepareUniformSuperposition,
-)
-from qualtran.bloqs.state_preparation.state_preparation_alias_sampling import (
+from .prepare_base import PrepareOracle
+from .prepare_uniform_superposition import PrepareUniformSuperposition
+from .state_preparation_alias_sampling import (
     SparseStatePreparationAliasSampling,
     StatePreparationAliasSampling,
 )
-from qualtran.bloqs.state_preparation.state_preparation_via_rotation import (
-    StatePreparationViaRotations,
-)
+from .state_preparation_via_rotation import StatePreparationViaRotations

--- a/qualtran/cirq_interop/__init__.py
+++ b/qualtran/cirq_interop/__init__.py
@@ -25,3 +25,6 @@ from ._cirq_to_bloq import (
 )
 
 from ._bloq_to_cirq import BloqAsCirqGate
+from .._infra.gate_with_registers import get_named_qubits, merge_qubits, total_bits
+
+assert [get_named_qubits, merge_qubits, total_bits]


### PR DESCRIPTION
Based on v0.6

Some low-effort support for things used extensively in pyLIQTR, which is currently pinned to v0.4.

(work in progress)