### PR TITLE
pretty msds v1

### DIFF
--- a/qualtran/bloqs/rotations/quantum_variable_rotation.py
+++ b/qualtran/bloqs/rotations/quantum_variable_rotation.py
@@ -191,6 +191,7 @@ class QvrZPow(QvrInterface):
         if self.cost_dtype.signed:
             out[0] = bb.add(ZPowGate(exponent=1, eps=eps), q=out[0])
         offset = 1 + self.cost_dtype.num_frac - self.num_frac_rotations
+        offset = offset if isinstance(offset, int) else 1
         for i in range(num_rotations):
             power_of_two = i - self.num_frac_rotations
             exp = (2**power_of_two) * self.gamma * 2


### PR DESCRIPTION
The changes in this PR enable pretty print of musical score diagrams. 

The changes in `qualtran\drawing\_show_funcs.py` aim to be enable pretty formatting in a way that is independent from internal logic (to allow for changes) but flexible (to easily adapt to any changes):
- MSD data is captured on the way to the diagram
- Inspected, re-shuffled, evaluated, and simplified using incremental RegEx and SymPy steps
- Re-inserted for final rendered.

If the internal logic changes and labels change (I estimate minimally to moderately), the approach can be adapted by modifying the foundational RegEx capture of symbols and/or the locals for simpify.

&

PR also include a small change to `qualtran\bloqs\rotations\quantum_variable_rotation.py`. Perhaps I missed something when I set things up since I am submitting this PR as part of unitaryHack and there is limited time to get familiar with the codebase. That said, the `offset` was causing errors.

Closes #853 

Maybe.

Ps. I tend to use more space and comments, but I tried my best to stick to the style in the target files. Happy to expand.