### PR TITLE
Pretty MSDs

### DIFF
--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -159,8 +159,8 @@ class ZPowGate(CirqGateAsBloqBase):
 
     def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
         if reg is None:
-            return Text('')
-        return TextBox(f'Z^{self.exponent}')
+            return Text(f'Z^{self.exponent}')
+        return TextBox("Z")
 
     def __str__(self):
         return f'Z**{self.exponent}'

--- a/qualtran/symbolics/math_funcs.py
+++ b/qualtran/symbolics/math_funcs.py
@@ -94,7 +94,7 @@ def sabs(x: sympy.Expr) -> sympy.Expr: ...
 
 
 def sabs(x: SymbolicFloat) -> SymbolicFloat:
-    return cast(SymbolicFloat, abs(x))
+    return cast(SymbolicFloat, abs(sympy.pi if isinstance(x, sympy.Symbol) else x))
 
 
 @overload


### PR DESCRIPTION
PR achieves two things in very few lines of code:
- Enables pretty MSD labels with some changes to `qualtran/symbolics/math_funcs.py` 
- Returns MSDs back to a Text + TextBox format with some changes to `qualtran/bloqs/basic_gates/rotation.py`

The PR benefits from research carried out in #1658 , but is separate because it departs from an entirely different foundation.
- 1658 assumed the current behaviour in main is the desired behaviour.
- It was found in the process that this not the case.
- This PR therefore takes an entirely different approach, using previous syntax/formatting in a way that seemingly matches the current state of main.

The result resembles what follows:
![pretty](https://github.com/user-attachments/assets/2b00adac-72df-472a-92fa-765a3fc4ed1f)

**Concerning generalisability: A**

A question that might arise about the use of `sympy.pi` in `sabs()` in `qualtran/symbolics/math_funcs.py` is whether this is specific to the example above. 

This is worth checking, but I think the solution applies generally. The reason is that this particular `sabs()` operation is used in `qualtran/bloqs/rotations/quantum_variable_rotation.py` as follows:

```
@cached_property
def num_frac_rotations(self) -> SymbolicInt:
    ignoring_small_angle_rots = ceil(log2((pi(self.eps) * 2 * sabs(self.gamma)) / self.eps))
    return smin(self.cost_dtype.num_frac, ignoring_small_angle_rots)

@cached_property
def num_rotations(self) -> SymbolicInt:
    return self.cost_dtype.num_int + self.num_frac_rotations + int(self.cost_dtype.signed)
```

Based on my current insight into the codebase, for `smin(self.cost_dtype.num_frac, ignoring_small_angle_rots)` to be influenced by the choice of angle in `sabs()`, one would need a very, very, very small angle; something like pi/10000. Additionally, it does not seem possible to leave this particular operation unresolved, as the mathematical expression would not simplify at all, yielding the super long ugly labels that are currently being printed in MSDs.

**Concerning generalisability: B**

I see more classes in `qualtran/bloqs/basic_gates/rotation.py` that could benefit from changing the `wire_symbol` similarly to how it is done here for `ZPowGate`. However, only `ZPowGate` is imported in `qualtran/bloqs/rotations/quantum_variable_rotation.py`, which seems to be the entry point for MSDs. I therefore limited changes to `ZPowGate`.



@mhucka @mpharrigan @tanujkhattar