### PR TITLE
Minor fixes to GF arithmetic bloqs

### DIFF
--- a/qualtran/bloqs/gf_arithmetic/gf2_inverse.py
+++ b/qualtran/bloqs/gf_arithmetic/gf2_inverse.py
@@ -208,7 +208,7 @@ class GF2Inverse(Bloq):
             junk.extend([beta, beta_squared])
             beta = beta * beta_squared
         junk.append(beta)
-        return {'x': x, 'result': x ** (-1), 'junk': np.array(junk)}
+        return {'x': x, 'result': x ** (-1) if x else self.qgf.gf_type(0), 'junk': np.array(junk)}
 
 
 @bloq_example(generalizer=[ignore_split_join, ignore_alloc_free])

--- a/qualtran/bloqs/gf_arithmetic/gf2_inverse_test.py
+++ b/qualtran/bloqs/gf_arithmetic/gf2_inverse_test.py
@@ -49,7 +49,7 @@ def test_gf2_inverse_classical_sim_quick():
     m = 1
     bloq = GF2Inverse(m)
     GFM = GF(2**m)
-    assert_consistent_classical_action(bloq, x=GFM.elements[1:])
+    assert_consistent_classical_action(bloq, x=GFM.elements)
 
 
 @pytest.mark.slow
@@ -57,7 +57,7 @@ def test_gf2_inverse_classical_sim_quick():
 def test_gf2_inverse_classical_sim(m):
     bloq = GF2Inverse(m)
     GFM = GF(2**m)
-    assert_consistent_classical_action(bloq, x=GFM.elements[1:])
+    assert_consistent_classical_action(bloq, x=GFM.elements)
 
 
 @pytest.mark.parametrize('m', [*range(1, 12)])

--- a/qualtran/bloqs/gf_arithmetic/gf2_multiplication_test.py
+++ b/qualtran/bloqs/gf_arithmetic/gf2_multiplication_test.py
@@ -73,7 +73,7 @@ def test_synthesize_lr_circuit_slow(m):
 
 def test_gf2_plus_equal_prod_classical_sim_quick():
     m = 2
-    bloq = GF2Multiplication(m, plus_equal_prod=True)
+    bloq = GF2Multiplication(QGF(2, m), plus_equal_prod=True)
     GFM = GF(2**m)
     assert_consistent_classical_action(bloq, x=GFM.elements, y=GFM.elements, result=GFM.elements)
 
@@ -318,7 +318,8 @@ def test_gf2mulmod_classical_action_slow():
 def test_gf2mulmod_classical_action_adjoint(m_x):
     blq = GF2MulViaKaratsuba(m_x)
     adjoint = blq.adjoint()
-    for i, j in np.random.random_integers(0, len(blq.gf.elements) - 1, (10, 2)):
+    rs = np.random.default_rng(42)
+    for i, j in rs.integers(0, len(blq.gf.elements) - 1, (10, 2)):
         f = blq.gf.elements[i]
         g = blq.gf.elements[j]
         a, b, c = blq.call_classically(x=f, y=g)


### PR DESCRIPTION
Support computing inverse of `0` as `0` and update gf2 multiplication bloqs to be instantiated in the same way so they can be used as drop in replacement of each other. 