### PR TITLE
Fix bug in classical simulation of `Add` with mixed signed/unsigned integers

### DIFF
--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -60,7 +60,9 @@ if TYPE_CHECKING:
 class Add(Bloq):
     r"""An n-bit addition gate.
 
-    Implements $U|a\rangle|b\rangle \rightarrow |a\rangle|a+b\rangle$ using $n - 1$ Toffoli gates.
+    This computes `a + b` and stores the result in `b`. Specifically it
+    implements $U|a\rangle|b\rangle \rightarrow |a\rangle|a+b\rangle$
+    using $n - 1$ Toffoli gates.
 
     Args:
         a_dtype: Quantum datatype used to represent the integer a.
@@ -116,7 +118,7 @@ class Add(Bloq):
     def on_classical_vals(
         self, a: 'ClassicalValT', b: 'ClassicalValT'
     ) -> Dict[str, 'ClassicalValT']:
-        unsigned = isinstance(self.a_dtype, (QUInt, QMontgomeryUInt))
+        unsigned = isinstance(self.b_dtype, (QUInt, QMontgomeryUInt))
         b_bitsize = self.b_dtype.bitsize
         return {
             'a': a,

--- a/qualtran/bloqs/arithmetic/addition_test.py
+++ b/qualtran/bloqs/arithmetic/addition_test.py
@@ -285,6 +285,32 @@ def test_add_symb():
     assert get_cost_value(bloq, QubitCount()) == sympy.sympify('Max(3, 2*n)')
 
 
+def test_add_mixed_signed_result_reg():
+    bloq = Add(QUInt(4), QInt(4))
+    cbloq = bloq.decompose_bloq()
+
+    for a in range(2**4):
+        for b in range(-(2**3), 2**3):
+            a_res1, b_res1 = bloq.call_classically(a=a, b=b)
+            a_res2, b_res2 = cbloq.call_classically(a=a, b=b)
+            assert a_res1 == a
+            assert a_res1 == a_res2
+            assert b_res1 == b_res2
+
+
+def test_add_mixed_signed_op_reg():
+    bloq = Add(QInt(4), QUInt(4))
+    cbloq = bloq.decompose_bloq()
+
+    for a in range(-(2**3), 2**3):
+        for b in range(2**4):
+            a_res1, b_res1 = bloq.call_classically(a=a, b=b)
+            a_res2, b_res2 = cbloq.call_classically(a=a, b=b)
+            assert a_res1 == a
+            assert a_res1 == a_res2
+            assert b_res1 == b_res2
+
+
 def test_out_of_place_adder():
     basis_map = {}
     gate = OutOfPlaceAdder(bitsize=3)

--- a/qualtran/bloqs/arithmetic/controlled_add_or_subtract_test.py
+++ b/qualtran/bloqs/arithmetic/controlled_add_or_subtract_test.py
@@ -67,6 +67,21 @@ def test_controlled_add_or_subtract_classical_sim(bitsize: int):
                     assert b_out_unsigned == (b_unsigned - a_unsigned + 2**bitsize) % 2**bitsize
 
 
+def test_caddsub_mixed_dtype():
+    from qualtran.bloqs.arithmetic import Add
+
+    bloq = Add(QUInt(4), QInt(4))
+    a, b_res = bloq.call_classically(a=0, b=-1)
+    assert a == 0
+    assert b_res == -1
+
+    bloq = ControlledAddOrSubtract(QUInt(4), QInt(4))
+    ctrl, a, b_result = bloq.call_classically(a=0, b=-1, ctrl=1)
+    assert ctrl == 1
+    assert a == 0
+    assert b_result == -1
+
+
 @frozen
 class TestNaiveControlledAddOrSubtract(Bloq):
     """A naive implementation of controlled add or subtract using two controlled bloqs.


### PR DESCRIPTION
 - Bug: the signedness of the addition depends on the _result_ register
 - Tests: make sure the behavior matches the decomposition for signed/unsigned and unsigned/signed. also test ControlledAddOrSubtract which is where this was reported