### PR TITLE
Fix Toffoli control system

### DIFF
--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -843,8 +843,8 @@ def _map_soqs(
             flat_soq_map[old_soqs] = new_soqs
             continue
 
-        assert isinstance(old_soqs, np.ndarray), old_soqs
-        assert isinstance(new_soqs, np.ndarray), new_soqs
+        old_soqs = np.asarray(old_soqs)
+        new_soqs = np.asarray(new_soqs)
         assert old_soqs.shape == new_soqs.shape, (old_soqs.shape, new_soqs.shape)
         for o, n in zip(old_soqs.reshape(-1), new_soqs.reshape(-1)):
             flat_soq_map[o] = n

--- a/qualtran/bloqs/basic_gates/toffoli.py
+++ b/qualtran/bloqs/basic_gates/toffoli.py
@@ -155,7 +155,7 @@ class Toffoli(Bloq):
                 cc_cnot, ctrl2=np.array([new_ctrl, ctrl0]), ctrl=ctrl1, target=in_soqs.pop('target')
             )
 
-            return [new_ctrl], [ctrl0, ctrl1, target]
+            return [new_ctrl], [(ctrl0, ctrl1), target]
 
         return cc_cnot, add_controlled
 

--- a/qualtran/bloqs/basic_gates/toffoli_test.py
+++ b/qualtran/bloqs/basic_gates/toffoli_test.py
@@ -16,13 +16,13 @@ import itertools
 import cirq
 import numpy as np
 
+import qualtran.testing as qlt_testing
 from qualtran import BloqBuilder, CtrlSpec
 from qualtran.bloqs.basic_gates import Toffoli, ZeroState
 from qualtran.bloqs.basic_gates.toffoli import _toffoli
 from qualtran.bloqs.mcmt import And
 from qualtran.drawing.musical_score import Circle, ModPlus
 from qualtran.resource_counting import GateCounts, get_cost_value, QECGatesCost
-from qualtran.testing import assert_wire_symbols_match_expected
 
 
 def test_toffoli(bloq_autotester):
@@ -51,7 +51,7 @@ _c(1): ───@───@───
           │   │
 _c(2): ───X───X───""",
     )
-    assert_wire_symbols_match_expected(
+    qlt_testing.assert_wire_symbols_match_expected(
         Toffoli(), [Circle(filled=True), Circle(filled=True), ModPlus()]
     )
 
@@ -115,3 +115,11 @@ def test_ctrl_toffoli_cost():
 
     _, sigma = cc_tof.call_graph()
     assert sigma == {Toffoli(): 1, And(): 2, And().adjoint(): 2}
+
+
+def test_toffoli_controlled():
+    # https://github.com/quantumlib/Qualtran/issues/1709
+    from qualtran import Controlled
+
+    bloq = Controlled(Toffoli().as_composite_bloq(), CtrlSpec())
+    qlt_testing.assert_valid_bloq_decomposition(bloq)


### PR DESCRIPTION
`Toffoli.get_ctrl_system` did not respect the signature of `Toffoli`. I don't know how/why this wasn't tested prior...

Fixes #1709 

I also made it so you don't need to explicitly cast these things to ndarrays in `get_ctrl_system`. We'll be nice and convert them during soquet mapping. 