### PR TITLE
SoquetT becomes a protocol

### DIFF
--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -59,6 +59,20 @@ if TYPE_CHECKING:
 
 
 class SoquetT(Protocol):
+    """Either a Soquet or an array thereof.
+
+    To narrow objects of this type, use `BloqBuilder.is_single(soq)` and/or
+    `BloqBuilder.is_ndarray(soqs)`.
+
+    Example:
+        >>> soq_or_soqs: SoquetT
+        ... if BloqBuilder.is_ndarray(soq_or_soqs):
+        ...     first_soq = soq_or_soqs.reshape(-1).item(0)
+        ... else:
+        ...     # Note: `.item()` raises if not a single item.
+        ...     first_soq = soq_or_soqs.item()
+
+    """
     @property
     def shape(self) -> Tuple[int, ...]: ...
 

--- a/qualtran/_infra/composite_bloq.py
+++ b/qualtran/_infra/composite_bloq.py
@@ -26,10 +26,12 @@ from typing import (
     Mapping,
     Optional,
     overload,
+    Protocol,
     Sequence,
     Set,
     Tuple,
     TYPE_CHECKING,
+    TypeGuard,
     TypeVar,
     Union,
 )
@@ -55,13 +57,15 @@ if TYPE_CHECKING:
     from qualtran.simulation.classical_sim import ClassicalValT
     from qualtran.symbolics import SymbolicInt
 
-# NDArrays must be bound to np.generic
-_SoquetType = TypeVar('_SoquetType', bound=np.generic)
 
-SoquetT = Union[Soquet, NDArray[_SoquetType]]
-"""A `Soquet` or array of soquets."""
+class SoquetT(Protocol):
+    @property
+    def shape(self) -> Tuple[int, ...]: ...
 
-SoquetInT = Union[Soquet, NDArray[_SoquetType], Sequence[Soquet]]
+    def item(self, *args) -> Soquet: ...
+
+
+SoquetInT = Union[SoquetT, Sequence[SoquetT]]
 """A soquet or array-like of soquets.
 
 This type alias is used for input argument to parts of the library that are more
@@ -693,9 +697,10 @@ def _flatten_soquet_collection(vals: Iterable[SoquetT]) -> List[Soquet]:
     """
     soqvals = []
     for soq_or_arr in vals:
-        if isinstance(soq_or_arr, Soquet):
-            soqvals.append(soq_or_arr)
+        if BloqBuilder.is_single(soq_or_arr):
+            soqvals.append(soq_or_arr.item())
         else:
+            assert BloqBuilder.is_ndarray(soq_or_arr)
             soqvals.extend(soq_or_arr.reshape(-1))
     return soqvals
 
@@ -802,13 +807,10 @@ def _process_soquets(
         unchecked_names.remove(reg.name)  # so we can check for surplus arguments.
 
         for li in reg.all_idxs():
-            idxed_soq = in_soq[li]
-            assert isinstance(idxed_soq, Soquet), idxed_soq
+            idxed_soq = in_soq[li].item()
             func(idxed_soq, reg, li)
-            if not check_dtypes_consistent(idxed_soq.reg.dtype, reg.dtype):
-                extra_str = (
-                    f"{idxed_soq.reg.name}: {idxed_soq.reg.dtype} vs {reg.name}: {reg.dtype}"
-                )
+            if not check_dtypes_consistent(idxed_soq.dtype, reg.dtype):
+                extra_str = f"{idxed_soq.reg.name}: {idxed_soq.dtype} vs {reg.name}: {reg.dtype}"
                 raise BloqError(
                     f"{debug_str} register dtypes are not consistent {extra_str}."
                 ) from None
@@ -838,9 +840,9 @@ def _map_soqs(
     # First: flatten out any numpy arrays
     flat_soq_map: Dict[Soquet, Soquet] = {}
     for old_soqs, new_soqs in soq_map:
-        if isinstance(old_soqs, Soquet):
-            assert isinstance(new_soqs, Soquet), new_soqs
-            flat_soq_map[old_soqs] = new_soqs
+        if BloqBuilder.is_single(old_soqs):
+            assert BloqBuilder.is_single(new_soqs), new_soqs
+            flat_soq_map[old_soqs] = new_soqs.item()
             continue
 
         assert isinstance(old_soqs, np.ndarray), old_soqs
@@ -858,9 +860,9 @@ def _map_soqs(
     vmap = np.vectorize(_map_soq, otypes=[object])
 
     def _map_soqs(soqs: SoquetT) -> SoquetT:
-        if isinstance(soqs, Soquet):
-            return _map_soq(soqs)
-        return vmap(soqs)
+        if BloqBuilder.is_ndarray(soqs):
+            return vmap(soqs)
+        return _map_soq(soqs.item())
 
     return {name: _map_soqs(soqs) for name, soqs in soqs.items()}
 
@@ -1060,6 +1062,24 @@ class BloqBuilder:
         bb.add_register_allowed = add_registers_allowed
 
         return bb, initial_soqs
+
+    @staticmethod
+    def is_single(x: 'SoquetT') -> TypeGuard['Soquet']:
+        """Returns True if `x` is a single soquet (not an ndarray of them).
+
+        This doesn't use stringent runtime type checking; it uses the SoquetT protocol
+        for "duck typing".
+        """
+        return x.shape == ()
+
+    @staticmethod
+    def is_ndarray(x: 'SoquetT') -> TypeGuard['NDArray']:
+        """Returns True if `x` is an ndarray of soquets (not a single one).
+
+        This doesn't use stringent runtime type checking; it uses the SoquetT protocol
+        for "duck typing".
+        """
+        return x.shape != ()
 
     @staticmethod
     def map_soqs(
@@ -1265,8 +1285,7 @@ class BloqBuilder:
             cbloq = bloq.decompose_bloq()
 
         for k, v in in_soqs.items():
-            if not isinstance(v, Soquet):
-                in_soqs[k] = np.asarray(v)
+            in_soqs[k] = np.asarray(v)
 
         # Initial mapping of LeftDangle according to user-provided in_soqs.
         soq_map: List[Tuple[SoquetT, SoquetT]] = [
@@ -1306,12 +1325,13 @@ class BloqBuilder:
 
         def _infer_reg(name: str, soq: SoquetT) -> Register:
             """Go from Soquet -> register, but use a specific name for the register."""
-            if isinstance(soq, Soquet):
-                return Register(name=name, dtype=soq.reg.dtype, side=Side.RIGHT)
+            if BloqBuilder.is_single(soq):
+                return Register(name=name, dtype=soq.dtype, side=Side.RIGHT)
+            assert BloqBuilder.is_ndarray(soq)
 
             # Get info from 0th soquet in an ndarray.
             return Register(
-                name=name, dtype=soq.reshape(-1)[0].reg.dtype, shape=soq.shape, side=Side.RIGHT
+                name=name, dtype=soq.reshape(-1).item(0).dtype, shape=soq.shape, side=Side.RIGHT
             )
 
         right_reg_names = [reg.name for reg in self._regs if reg.side & Side.RIGHT]
@@ -1358,10 +1378,10 @@ class BloqBuilder:
     def free(self, soq: Soquet, dirty: bool = False) -> None:
         from qualtran.bloqs.bookkeeping import Free
 
-        if not isinstance(soq, Soquet):
+        if not BloqBuilder.is_single(soq):
             raise ValueError("`free` expects a single Soquet to free.")
 
-        qdtype = soq.reg.dtype
+        qdtype = soq.dtype
         if not isinstance(qdtype, QDType):
             raise ValueError("`free` can only free quantum registers.")
 
@@ -1371,10 +1391,10 @@ class BloqBuilder:
         """Add a Split bloq to split up a register."""
         from qualtran.bloqs.bookkeeping import Split
 
-        if not isinstance(soq, Soquet):
+        if not BloqBuilder.is_single(soq):
             raise ValueError("`split` expects a single Soquet to split.")
 
-        qdtype = soq.reg.dtype
+        qdtype = soq.dtype
         if not isinstance(qdtype, QDType):
             raise ValueError("`split` can only split quantum registers.")
 

--- a/qualtran/_infra/composite_bloq_test.py
+++ b/qualtran/_infra/composite_bloq_test.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, List, Tuple
+from typing import assert_type, cast, Dict, List, Tuple
 
 import attrs
 import networkx as nx
@@ -144,7 +144,7 @@ def test_map_soqs():
             assert in_soqs == bb.map_soqs(in_soqs, soq_map)
         elif binst.i == 1:
             for k, val in bb.map_soqs(in_soqs, soq_map).items():
-                assert isinstance(val, Soquet)
+                assert BloqBuilder.is_single(val)
                 assert isinstance(val.binst, BloqInstance)
                 assert val.binst.i >= 100
         else:
@@ -156,7 +156,7 @@ def test_map_soqs():
 
     fsoqs = bb.map_soqs(cbloq.final_soqs(), soq_map)
     for k, val in fsoqs.items():
-        assert isinstance(val, Soquet)
+        assert BloqBuilder.is_single(val)
         assert isinstance(val.binst, BloqInstance)
         assert val.binst.i >= 100
     cbloq = bb.finalize(**fsoqs)
@@ -641,6 +641,40 @@ def test_get_soquet():
     assert soquet.reg.name == 'in'
     with pytest.raises(ValueError, match='Could not find the requested soquet'):
         _ = _get_soquet(binst=binst, reg_name='in', right=True, binst_graph=binst_graph)
+
+
+def test_can_tell_individual_from_ndsoquet():
+    s1 = Soquet(cast(BloqInstance, None), Register('test', QBit(), shape=(4,)), idx=(0,))
+    s2 = Soquet(cast(BloqInstance, None), Register('test', QBit(), shape=(4,)), idx=(1,))
+    s3 = Soquet(cast(BloqInstance, None), Register('test', QBit(), shape=(4,)), idx=(2,))
+    s4 = Soquet(cast(BloqInstance, None), Register('test', QBit(), shape=(4,)), idx=(3,))
+
+    # A ndarray of soquet objects should be SoquetT and we can tell by checking its shape.
+    ndsoq: SoquetT = np.array([s1, s2, s3, s4])
+    assert_type(ndsoq, SoquetT)
+    assert ndsoq.shape
+    assert ndsoq.shape == (4,)
+    assert ndsoq.item(2) == s3
+    with pytest.raises(ValueError, match=r'scalar'):
+        _ = ndsoq.item()
+
+    # A single soquet is still a valid SoquetT, and it has a false-y shape.
+    single_soq: SoquetT = s1
+    assert_type(single_soq, SoquetT)
+    assert not single_soq.shape
+    assert single_soq.shape == ()
+    single_soq_unwarp = single_soq.item()
+    assert single_soq_unwarp == s1
+
+    # A single soquet wrapped in a 0-dim ndarray is ok if you call `item()`.
+    single_soq2: SoquetT = np.asarray(s1)
+    assert_type(single_soq2, SoquetT)
+    assert not single_soq2.shape
+    assert single_soq2.shape == ()
+    single_soq2_unwrap = single_soq2.item()
+    assert hash(single_soq2_unwrap) == hash(s1)
+    assert single_soq2_unwrap == s1
+    assert isinstance(single_soq2_unwrap, Soquet)
 
 
 @pytest.mark.notebook

--- a/qualtran/_infra/quantum_graph.py
+++ b/qualtran/_infra/quantum_graph.py
@@ -19,7 +19,7 @@ from typing import Tuple, TYPE_CHECKING, Union
 from attrs import field, frozen
 
 if TYPE_CHECKING:
-    from qualtran import Bloq, Register
+    from qualtran import Bloq, BloqBuilder, QCDType, Register
 
 
 @frozen
@@ -103,6 +103,20 @@ class Soquet:
         for i, shape in zip(value, self.reg.shape):
             if i >= shape:
                 raise ValueError(f"Bad index {i} for {self.reg}.")
+        return value
+
+    @property
+    def dtype(self) -> 'QCDType':
+        return self.reg.dtype
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return ()
+
+    def item(self, *args) -> 'Soquet':
+        if args:
+            raise ValueError("Tried to index into a single soquet.")
+        return self
 
     def pretty(self) -> str:
         label = self.reg.name

--- a/qualtran/_infra/quantum_graph_test.py
+++ b/qualtran/_infra/quantum_graph_test.py
@@ -48,6 +48,9 @@ def test_soquet():
     assert soq.idx == ()
     assert soq.pretty() == 'x'
 
+    assert soq.item() == soq
+    assert soq.dtype == QAny(10)
+
 
 def test_soquet_idxed():
     binst = BloqInstance(TestTwoBitOp(), i=0)

--- a/qualtran/bloqs/arithmetic/subtraction.py
+++ b/qualtran/bloqs/arithmetic/subtraction.py
@@ -153,7 +153,7 @@ class Subtract(Bloq):
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         delta = self.b_dtype.bitsize - self.a_dtype.bitsize
-        costs = {
+        costs: Dict[Bloq, int] = {
             OnEach(self.b_dtype.bitsize, XGate()): 3,
             Add(QUInt(self.b_dtype.bitsize), QUInt(self.b_dtype.bitsize)): 1,
         }
@@ -196,7 +196,7 @@ class Subtract(Bloq):
                 a_split[delta], prefix = bb.add(
                     MultiTargetCNOT(delta), control=a_split[delta], targets=prefix
                 )
-            prefix = bb.add(Cast(prefix.reg.dtype, QAny(delta)), reg=prefix)
+            prefix = bb.add(Cast(prefix.dtype, QAny(delta)), reg=prefix)
             bb.free(prefix)
             a = bb.join(a_split[delta:], QUInt(self.a_dtype.bitsize))
         a = bb.add(Cast(QUInt(self.a_dtype.bitsize), self.a_dtype), reg=a)

--- a/qualtran/bloqs/basic_gates/rotation.py
+++ b/qualtran/bloqs/basic_gates/rotation.py
@@ -220,8 +220,7 @@ class CZPowGate(Bloq):
     def build_composite_bloq(self, bb: 'BloqBuilder', q: 'SoquetT') -> Dict[str, 'SoquetT']:
         from qualtran.bloqs.mcmt import And
 
-        q1, q2 = q  # type: ignore
-        (q1, q2), anc = bb.add(And(), ctrl=[q1, q2])
+        (q1, q2), anc = bb.add(And(), ctrl=q)
         anc = bb.add(ZPowGate(self.exponent, eps=self.eps), q=anc)
         (q1, q2) = bb.add(And().adjoint(), ctrl=[q1, q2], target=anc)
         return {'q': np.array([q1, q2])}

--- a/qualtran/bloqs/block_encoding/sparse_matrix.py
+++ b/qualtran/bloqs/block_encoding/sparse_matrix.py
@@ -237,8 +237,7 @@ class SparseMatrix(BlockEncoding):
         if is_symbolic(self.system_bitsize) or is_symbolic(self.row_oracle.num_nonzero):
             raise DecomposeTypeError(f"Cannot decompose symbolic {self=}")
 
-        assert not isinstance(ancilla, np.ndarray)
-        ancilla_bits = bb.split(ancilla)
+        ancilla_bits = bb.split(ancilla.item())
         q, l = ancilla_bits[0], bb.join(ancilla_bits[1:])
 
         l = bb.add(self.diffusion, target=l)

--- a/qualtran/bloqs/chemistry/pbc/first_quantization/select_and_prepare.py
+++ b/qualtran/bloqs/chemistry/pbc/first_quantization/select_and_prepare.py
@@ -153,11 +153,11 @@ class MultiplexedCSwap3D(Bloq):
         """
         # np.prod(()) returns a float (1.0), so take int
         size = int(np.prod(out_shape))
-        if isinstance(in_reg, np.ndarray):
+        if BloqBuilder.is_ndarray(in_reg):
             # split an array of bitsize qubits into flat list of qubits
             split_qubits = bb.split(bb.join(np.concatenate([bb.split(x) for x in in_reg.ravel()])))
         else:
-            split_qubits = bb.split(in_reg)
+            split_qubits = bb.split(in_reg.item())
         merged_qubits = np.array(
             [bb.join(split_qubits[i * bitsize : (i + 1) * bitsize]) for i in range(size)]
         )

--- a/qualtran/bloqs/chemistry/trotter/grid_ham/potential.py
+++ b/qualtran/bloqs/chemistry/trotter/grid_ham/potential.py
@@ -27,7 +27,6 @@ from qualtran import (
     QAny,
     Register,
     Signature,
-    Soquet,
     SoquetT,
 )
 from qualtran._infra.data_types import BQUInt
@@ -93,7 +92,7 @@ class PairPotential(Bloq):
     def build_composite_bloq(
         self, bb: BloqBuilder, *, system_i: SoquetT, system_j: SoquetT
     ) -> Dict[str, SoquetT]:
-        if isinstance(system_i, Soquet) or isinstance(system_j, Soquet):
+        if not (BloqBuilder.is_ndarray(system_i) and BloqBuilder.is_ndarray(system_j)):
             raise ValueError("system_i and system_j must be numpy arrays of Soquet")
         # compute r_i - r_j
         # r_i + (-r_j), in practice we need to flip the sign bit, but this is just 3 cliffords.
@@ -120,8 +119,8 @@ class PairPotential(Bloq):
         qrom_anc_c2 = bb.allocate(self.poly_bitsize)
         qrom_anc_c3 = bb.allocate(self.poly_bitsize)
         cast = Cast(
-            inp_dtype=sos.reg.dtype,
-            out_dtype=BQUInt(sos.reg.dtype.bitsize, iteration_length=len(self.qrom_data[0])),
+            inp_dtype=sos.dtype,
+            out_dtype=BQUInt(sos.dtype.bitsize, iteration_length=len(self.qrom_data[0])),
         )
         sos = bb.add(cast, reg=sos)
         qrom_bloq = QROM(
@@ -227,7 +226,7 @@ class PotentialEnergy(Bloq):
         return super().wire_symbol(reg, idx)
 
     def build_composite_bloq(self, bb: BloqBuilder, *, system: SoquetT) -> Dict[str, SoquetT]:
-        if isinstance(system, Soquet):
+        if not BloqBuilder.is_ndarray(system):
             raise ValueError("system must be a numpy array of Soquet")
         bitsize = (self.num_grid - 1).bit_length() + 1
         ij_pairs = np.triu_indices(self.num_elec, k=1)

--- a/qualtran/bloqs/data_loading/qroam_clean.py
+++ b/qualtran/bloqs/data_loading/qroam_clean.py
@@ -520,8 +520,8 @@ class QROAMClean(SelectSwapQROM):
         # Construct and return dictionary of final soquets.
         soqs |= {reg.name: soq for reg, soq in zip(self.control_registers, ctrl)}
         soqs |= {reg.name: soq for reg, soq in zip(self.selection_registers, selection)}
-        soqs |= {reg.name: soq.flat[1:] for reg, soq in zip(self.junk_registers, qrom_targets)}  # type: ignore[union-attr]
-        soqs |= {reg.name: soq.flat[0] for reg, soq in zip(self.target_registers, qrom_targets)}  # type: ignore[union-attr]
+        soqs |= {reg.name: soq.flat[1:] for reg, soq in zip(self.junk_registers, qrom_targets)}  # type: ignore[attr-defined]
+        soqs |= {reg.name: soq.flat[0] for reg, soq in zip(self.target_registers, qrom_targets)}  # type: ignore[attr-defined]
         return soqs
 
     def on_classical_vals(

--- a/qualtran/bloqs/for_testing/casting.py
+++ b/qualtran/bloqs/for_testing/casting.py
@@ -45,9 +45,9 @@ class TestCastToFrom(Bloq):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', *, a: 'Soquet', b: 'Soquet'
     ) -> Dict[str, 'Soquet']:
-        cast = Cast(b.reg.dtype, a.reg.dtype)
+        cast = Cast(QFxp(self.bitsize, self.bitsize), QUInt(self.bitsize))
         b = bb.add(cast, reg=b)
-        assert isinstance(a.reg.dtype, (QInt, QUInt, QMontgomeryUInt))
-        a, b = bb.add(Add(a.reg.dtype), a=a, b=b)
+        assert isinstance(a.dtype, (QInt, QUInt, QMontgomeryUInt))
+        a, b = bb.add(Add(QUInt(self.bitsize)), a=a, b=b)
         b = bb.add(cast.adjoint(), reg=b)
         return {'a': a, 'b': b}

--- a/qualtran/bloqs/for_testing/with_decomposition.py
+++ b/qualtran/bloqs/for_testing/with_decomposition.py
@@ -13,15 +13,12 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, TYPE_CHECKING
+from typing import Dict
 
 from attrs import frozen
 
-from qualtran import Bloq, BloqBuilder, Signature, Soquet
+from qualtran import Bloq, BloqBuilder, Signature, SoquetT
 from qualtran.bloqs.for_testing.atom import TestAtom
-
-if TYPE_CHECKING:
-    from qualtran import SoquetT
 
 
 @frozen
@@ -47,7 +44,7 @@ class TestParallelCombo(Bloq):
         return Signature.build(reg=3)
 
     def build_composite_bloq(self, bb: 'BloqBuilder', reg: 'SoquetT') -> Dict[str, 'SoquetT']:
-        assert isinstance(reg, Soquet)
+        assert BloqBuilder.is_single(reg)
         reg = bb.split(reg)
         for i in range(len(reg)):
             reg[i] = bb.add(TestAtom(), q=reg[i])

--- a/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp.py
+++ b/qualtran/bloqs/hamiltonian_simulation/hamiltonian_simulation_by_gqsp.py
@@ -19,7 +19,7 @@ import numpy as np
 from attrs import field, frozen
 from numpy.typing import NDArray
 
-from qualtran import Bloq, bloq_example, BloqDocSpec, CtrlSpec, Signature, Soquet
+from qualtran import Bloq, bloq_example, BloqBuilder, BloqDocSpec, CtrlSpec, Signature, SoquetT
 from qualtran.bloqs.basic_gates.su2_rotation import SU2RotationGate
 from qualtran.bloqs.bookkeeping import Always
 from qualtran.bloqs.qsp.generalized_qsp import GeneralizedQSP
@@ -32,7 +32,6 @@ from qualtran.linalg.polynomial.qsp_testing import scale_down_to_qsp_polynomial
 from qualtran.symbolics import is_symbolic, Shaped, SymbolicFloat, SymbolicInt
 
 if TYPE_CHECKING:
-    from qualtran import BloqBuilder, SoquetT
     from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
@@ -175,11 +174,11 @@ class HamiltonianSimulationByGQSP(Bloq):
         soqs, state_prep_ancilla = self.__add_prepare(bb, soqs, state_prep_ancilla, adjoint=True)
 
         for soq in state_prep_ancilla.values():
-            if isinstance(soq, Soquet):
-                bb.free(soq)
+            if BloqBuilder.is_ndarray(soq):
+                for soq_element in soq.reshape(-1):
+                    bb.free(soq_element.item())
             else:
-                for soq_element in soq:
-                    bb.free(cast(Soquet, soq_element))
+                bb.free(soq.item())
 
         return soqs
 

--- a/qualtran/bloqs/mcmt/and_bloq_test.py
+++ b/qualtran/bloqs/mcmt/and_bloq_test.py
@@ -22,7 +22,7 @@ import pytest
 from attrs import frozen
 
 import qualtran.testing as qlt_testing
-from qualtran import Bloq, BloqBuilder, Signature, Soquet, SoquetT
+from qualtran import Bloq, BloqBuilder, Signature, SoquetT
 from qualtran.bloqs.basic_gates import OneEffect, OneState, ZeroEffect, ZeroState
 from qualtran.bloqs.mcmt.and_bloq import _and_bloq, _multi_and, _multi_and_symb, And, MultiAnd
 from qualtran.cirq_interop.t_complexity_protocol import t_complexity, TComplexity
@@ -111,8 +111,6 @@ def test_inverse():
     bb = BloqBuilder()
     q0 = bb.add_register('q0', 1)
     q1 = bb.add_register('q1', 1)
-    assert isinstance(q0, Soquet)
-    assert isinstance(q1, Soquet)
     qs, trg = bb.add(And(), ctrl=[q0, q1])
     qs = bb.add(And(uncompute=True), ctrl=qs, target=trg)
     cbloq = bb.finalize(q0=qs[0], q1=qs[1])
@@ -197,8 +195,8 @@ class AndIdentity(Bloq):
     def build_composite_bloq(
         self, bb: 'BloqBuilder', q0: 'SoquetT', q1: 'SoquetT'
     ) -> Dict[str, 'SoquetT']:
-        assert isinstance(q0, Soquet)
-        assert isinstance(q1, Soquet)
+        assert BloqBuilder.is_single(q0)
+        assert BloqBuilder.is_single(q1)
         qs, trg = bb.add(And(), ctrl=[q0, q1])
         q0, q1 = bb.add(And(uncompute=True), ctrl=qs, target=trg)
         return {'q0': q0, 'q1': q1}
@@ -232,9 +230,6 @@ def test_multiand_adjoint():
     q0 = bb.add_register('q0', 1)
     q1 = bb.add_register('q1', 1)
     q2 = bb.add_register('q2', 1)
-    assert isinstance(q0, Soquet)
-    assert isinstance(q1, Soquet)
-    assert isinstance(q2, Soquet)
 
     qs, junk, trg = bb.add(MultiAnd((1, 1, 1)), ctrl=[q0, q1, q2])
     qs = bb.add(MultiAnd((1, 1, 1)).adjoint(), ctrl=qs, target=trg, junk=junk)

--- a/qualtran/bloqs/reflections/prepare_identity.py
+++ b/qualtran/bloqs/reflections/prepare_identity.py
@@ -63,8 +63,8 @@ class PrepareIdentity(PrepareOracle):
         return ()
 
     def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: Soquet) -> Dict[str, Soquet]:
-        for label, soq in soqs.items():
-            soqs[label] = bb.add(Identity(soq.reg.bitsize), q=soq)
+        for reg in self.selection_registers:
+            soqs[reg.name] = bb.add(Identity(reg.bitsize), q=soqs[reg.name])
         return soqs
 
     def adjoint(self) -> 'PrepareIdentity':

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -310,11 +310,8 @@ def _ensure_in_reg_exists(
                 soqs_to_join[qreg.qubits[0]] = soq
         elif len(in_reg_qubits) == 1 and qreg.qubits and qreg.qubits[0] in in_reg_qubits:
             # Cast single QBit registers to the appropriate single-bit register dtype.
-            err_msg = (
-                "Found non-QBit type register which shouldn't happen: "
-                f"{soq.reg.name} {soq.reg.dtype}"
-            )
-            assert isinstance(soq.reg.dtype, QBit), err_msg
+            err_msg = "Found non-QBit type register which shouldn't happen: " f"{soq}"
+            assert isinstance(soq.dtype, QBit), err_msg
             if not isinstance(in_reg.dtype, QBit):
                 qreg_to_qvar[in_reg] = bb.add(Cast(QBit(), in_reg.dtype), reg=soq)
             else:
@@ -517,8 +514,7 @@ def cirq_optree_to_cbloq(
         if reg.name not in in_quregs:
             raise ValueError(f"Register {reg.name} from signature must be present in in_quregs.")
         soqs = initial_soqs[reg.name]
-        if isinstance(soqs, Soquet):
-            soqs = np.array(soqs)
+        soqs = np.asarray(soqs)
         if in_quregs[reg.name].shape != soqs.shape:
             raise ValueError(
                 f"Shape {in_quregs[reg.name].shape} of cirq register "

--- a/qualtran/cirq_interop/_cirq_to_bloq_test.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq_test.py
@@ -32,7 +32,6 @@ from qualtran import (
     Register,
     Side,
     Signature,
-    Soquet,
     SoquetT,
 )
 from qualtran._infra.gate_with_registers import get_named_qubits
@@ -52,8 +51,8 @@ class TestCNOT(Bloq):
 
     def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
         ctrl, target = soqs['control'], soqs['target']
-        assert isinstance(ctrl, Soquet)
-        assert isinstance(target, Soquet)
+        assert BloqBuilder.is_single(ctrl)
+        assert BloqBuilder.is_single(target)
         ctrl, target = bb.add(CirqGateAsBloq(cirq.CNOT), q=[ctrl, target])
         return {'control': ctrl, 'target': target}
 

--- a/qualtran/simulation/xcheck_classical_quimb.py
+++ b/qualtran/simulation/xcheck_classical_quimb.py
@@ -17,7 +17,7 @@ from typing import cast, Dict, Iterable, Optional, TYPE_CHECKING
 
 import numpy as np
 
-from qualtran import Bloq, BloqBuilder, CompositeBloq, Register, Soquet, SoquetT
+from qualtran import Bloq, BloqBuilder, CompositeBloq, Register, SoquetT
 
 if TYPE_CHECKING:
     from qualtran.simulation.classical_sim import ClassicalValT
@@ -56,7 +56,7 @@ def _add_classical_bras(
         if reg.shape:
             reg_vals = np.asarray(vals[reg.name])
             reg_name = soqs[reg.name]
-            if isinstance(reg_name, Soquet):
+            if not BloqBuilder.is_ndarray(reg_name):
                 raise ValueError(f'soqs {reg.name} must be a numpy array: {soqs[reg.name]}')
             for idx in reg.all_idxs():
                 bb.add(IntEffect(val=reg_vals[idx], bitsize=reg.bitsize), val=reg_name[idx])


### PR DESCRIPTION
Switches the `SoquetT` union type alias to a `typing.Protocol`. This supports "duck typing", which is appropriate for the situation where `SoquetT` is used as a type annotation.

Specifically, `SoquetT` is now anything that has `.shape` and `.item(*args)`. With the addition of these properties/methods to the `Soquet` class, now this is satisfied by `Soquet` and `NDArray`. Note: we can't use mypy to annotate things with `NDArray[Soquet]` now or before due to limitations in numpy.

When users or developers need to dispatch depending on whether a `SoquetT` is a single soquet or an array thereof, they should use the new `BloqBuilder` methods. The example from the new docstring:

```python
        >>> soq_or_soqs: SoquetT
        ... if BloqBuilder.is_ndarray(soq_or_soqs):
        ...     first_soq = soq_or_soqs.reshape(-1).item(0)
        ... else:
        ...     # Note: `.item()` raises if not a single item.
        ...     first_soq = soq_or_soqs.item()
```

-----

In the protocol implementations and bloq standard library, this PR:
 - removes usage of `isinstance(..., Soquet)` to figure out if there's a single one or ndarray
 - uses new alias `soq.dtype` instead of `soq.reg.dtype`.

These changes are a preview of the scope of changes needed to resolve the things I want to deprecate in #1720.