### PR TITLE
Replace cirq.ops.op_tree.OpTree with cirq.OP_TREE

### DIFF
--- a/qualtran/bloqs/mcmt/and_bloq.py
+++ b/qualtran/bloqs/mcmt/and_bloq.py
@@ -312,7 +312,7 @@ class MultiAnd(Bloq):
         control_values: Tuple[SymbolicInt, ...],
         ancillas: NDArray[cirq.Qid],
         target: cirq.Qid,
-    ) -> cirq.ops.op_tree.OpTree:
+    ) -> Iterator[cirq.OP_TREE]:
         """Decomposes multi-controlled `And` in-terms of an `And` ladder of size #controls- 2."""
 
         if len(controls) == 2:

--- a/qualtran/bloqs/swap_network/cswap_approx.py
+++ b/qualtran/bloqs/swap_network/cswap_approx.py
@@ -72,7 +72,7 @@ class CSwapApprox(GateWithRegisters):
     ) -> Iterator[cirq.OP_TREE]:
         ctrl, target_x, target_y = quregs['ctrl'], quregs['x'], quregs['y']
 
-        def g(q: cirq.Qid, adjoint=False) -> cirq.ops.op_tree.OpTree:
+        def g(q: cirq.Qid, adjoint=False) -> Iterator[cirq.OP_TREE]:
             yield [cirq.S(q), cirq.H(q)]
             yield cirq.T(q) ** (1 - 2 * adjoint)
             yield [cirq.H(q), cirq.S(q) ** -1]

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -15,13 +15,13 @@
 """Cirq gates/circuits to Qualtran Bloqs conversion."""
 import abc
 import itertools
-import numbers
 import warnings
 from functools import cached_property
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING, TypeVar, Union
 
 import cirq
 import numpy as np
+import sympy
 from attrs import field, frozen
 from numpy.typing import NDArray
 
@@ -434,9 +434,9 @@ def cirq_gate_to_bloq(gate: cirq.Gate) -> Bloq:
         return CIRQ_TYPE_TO_BLOQ_MAP[gate.__class__](exponent=gate.exponent)
 
     if isinstance(gate, cirq.GlobalPhaseGate):
-        if isinstance(gate.coefficient, numbers.Complex):
-            return GlobalPhase.from_coefficient(coefficient=complex(gate.coefficient))
-        return GlobalPhase.from_coefficient(coefficient=gate.coefficient)
+        if isinstance(gate.coefficient, sympy.Expr):
+            return GlobalPhase.from_coefficient(coefficient=gate.coefficient)
+        return GlobalPhase.from_coefficient(coefficient=complex(gate.coefficient))
 
     # No known basic gate, wrap the cirq gate in a CirqGateAsBloq wrapper.
     return CirqGateAsBloq(gate)


### PR DESCRIPTION
- Replace `cirq.ops.op_tree.OpTree` with `cirq.OP_TREE`
- Fix flagged coefficient type for GlobalPhase

Towards #1708