### PR TITLE
Move LUP decomposition based circuit construction logic from `GF2MulK` to `SynthesizeLRCircuit` bloq

### DIFF
--- a/qualtran/bloqs/gf_arithmetic/gf2_multiplication_test.py
+++ b/qualtran/bloqs/gf_arithmetic/gf2_multiplication_test.py
@@ -52,10 +52,12 @@ def test_gf2_multiplication_symbolic(bloq_autotester):
 def test_synthesize_lr_circuit(m: int):
     matrix = GF2MulMBUC(m).reduction_matrix_q
     bloq = SynthesizeLRCircuit(matrix)
+    cbloq = bloq.decompose_bloq()
     bloq_adj = bloq.adjoint()
     QGFM, GFM = QGF(2, m), GF(2**m)
     for i in GFM.elements:
         bloq_out = bloq.call_classically(q=np.array(QGFM.to_bits(i)))[0]
+        assert np.all(bloq_out == cbloq.call_classically(q=np.array(QGFM.to_bits(i)))[0])
         bloq_adj_out = bloq_adj.call_classically(q=bloq_out)[0]
         assert isinstance(bloq_adj_out, np.ndarray)
         assert i == QGFM.from_bits([*bloq_adj_out])
@@ -66,10 +68,12 @@ def test_synthesize_lr_circuit(m: int):
 def test_synthesize_lr_circuit_slow(m):
     matrix = GF2MulMBUC(m).reduction_matrix_q
     bloq = SynthesizeLRCircuit(matrix)
+    cbloq = bloq.decompose_bloq()
     bloq_adj = bloq.adjoint()
     QGFM, GFM = QGF(2, m), GF(2**m)
     for i in GFM.elements:
         bloq_out = bloq.call_classically(q=np.array(QGFM.to_bits(i)))[0]
+        assert np.all(bloq_out == cbloq.call_classically(q=np.array(QGFM.to_bits(i)))[0])
         bloq_adj_out = bloq_adj.call_classically(q=bloq_out)[0]
         assert isinstance(bloq_adj_out, np.ndarray)
         assert i == QGFM.from_bits([*bloq_adj_out])

--- a/qualtran/bloqs/gf_arithmetic/gf2_square.py
+++ b/qualtran/bloqs/gf_arithmetic/gf2_square.py
@@ -69,7 +69,7 @@ class GF2Square(Bloq):
         r"""$m \times m$ matrix that maps the input $x^{i}$ to $x^{2 * i} % P(x)$"""
         m = int(self.bitsize)
         f = self.qgf.gf_type.irreducible_poly
-        M = np.zeros((m, m))
+        M = np.zeros((m, m), dtype=int)
         alpha = [0] * m
         for i in range(m):
             # x ** (2 * i) % f


### PR DESCRIPTION
The decomposition in `GF2MulK` works for any LR circuit and so it's better to have it in the `SynthesizeLRCircuit` bloq. Both `GF2MulK` and `GF2Square` will now have an explicit decomposition. 