### PR TITLE
Use math instead of numpy functions for angle calculations in `PrepareUniformSuperposition`

### DIFF
--- a/qualtran/bloqs/state_preparation/prepare_uniform_superposition.py
+++ b/qualtran/bloqs/state_preparation/prepare_uniform_superposition.py
@@ -123,7 +123,7 @@ class PrepareUniformSuperposition(GateWithRegisters):
             return
 
         ancilla = context.qubit_manager.qalloc(1)
-        theta = np.arccos(1 - (2 ** np.floor(np.log2(l))) / l)
+        theta = acos(1 - (2 ** floor(log2(l))) / l)
         yield LessThanConstant(logL, l).on_registers(x=logL_qubits, target=ancilla)
         yield cirq.Rz(rads=theta)(*ancilla)
         yield LessThanConstant(logL, l).on_registers(x=logL_qubits, target=ancilla) ** -1  # type: ignore[operator]


### PR DESCRIPTION
numpy functions don't work when `n` is large. math functions continue to work. 