### PR TITLE
Fix #1693: add `autoescape=True`

### DIFF
--- a/dev_tools/qualtran_dev_tools/reference_docs.py
+++ b/dev_tools/qualtran_dev_tools/reference_docs.py
@@ -88,6 +88,7 @@ def mixin_custom_template(template_name: str) -> Type:
         JINJA_ENV = jinja2.Environment(
             trim_blocks=True,
             lstrip_blocks=True,
+            autoescape=True,
             loader=jinja2.FileSystemLoader(TEMPLATE_SEARCH_PATH),
         )
 


### PR DESCRIPTION
This fixes the silly security scan warning about possible dangers of leaving the default value of the `autoscape` (`False`).