### PR TITLE
Fix `RowColumnOracle` Signature

### DIFF
--- a/qualtran/bloqs/block_encoding/sparse_matrix.py
+++ b/qualtran/bloqs/block_encoding/sparse_matrix.py
@@ -33,10 +33,10 @@ from qualtran import (
     QInt,
     QUInt,
     Register,
+    Side,
     Signature,
     Soquet,
     SoquetT,
-    Side,
 )
 from qualtran.bloqs.arithmetic import Add, AddK
 from qualtran.bloqs.basic_gates import Ry, Swap


### PR DESCRIPTION
The row and column oracle are defined as such ([Lin Lin (2022). Ch. 6.5.](https://arxiv.org/abs/2201.08309)): 
$O_c\ket{\ell}\ket{j}=\ket{c(j, \ell)}\ket{j}$, where $c(j,\ell)$ gives the $\ell$-th non zero entry in the $j$-th column.

So indeed, in input the value of l is bounded by the number of non zero entries in the matrix. But in output, the value of  $c(j,\ell)$ is unbounded as the $\ell$-th non zero entry can be anywhere in the column.

So the Signature of `RowColumnOracle` is incorrect and that was making `assert_consistent_classical_action` throwing errors it should not have. 

This is fixed by this PR.