### PR TITLE
Fix `Identity`'s ctrl_adder

### DIFF
--- a/qualtran/bloqs/basic_gates/identity.py
+++ b/qualtran/bloqs/basic_gates/identity.py
@@ -32,9 +32,9 @@ from qualtran import (
     Signature,
     SoquetT,
 )
+from qualtran.bloqs.bookkeeping import Partition
 from qualtran.drawing import Text, TextBox, WireSymbol
 from qualtran.symbolics import is_symbolic, SymbolicInt
-from qualtran.bloqs.bookkeeping import Partition
 
 if TYPE_CHECKING:
     import cirq

--- a/qualtran/bloqs/basic_gates/identity_test.py
+++ b/qualtran/bloqs/basic_gates/identity_test.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 import sympy
 
-from qualtran import BloqBuilder, CtrlSpec, Register, QBit
+from qualtran import BloqBuilder, CtrlSpec, QBit, Register
 from qualtran.bloqs.basic_gates import OneState
 from qualtran.bloqs.basic_gates.identity import _identity, _identity_n, _identity_symb, Identity
 from qualtran.simulation.classical_sim import (
@@ -111,9 +111,10 @@ def test_identity_ctrl_adder():
     ctrl_I, ctrl_adder = Identity(1).get_ctrl_system(CtrlSpec())
 
     bb = BloqBuilder()
-    ctrl_soqs = [bb.add_register(Register("ctrl_0", QBit()))]
-    in_soqs = {"q": bb.add_register(Register("q", QBit()))}
-    [ctrl_out], (out_reg,) = ctrl_adder(bb, ctrl_soqs=ctrl_soqs, in_soqs=in_soqs)
+    ctrl0 = bb.add_register(Register("ctrl_0", QBit()))
+    q = bb.add_register(Register("q", QBit()))
+    assert ctrl0 is not None and q is not None
+    [ctrl_out], (out_reg,) = ctrl_adder(bb, ctrl_soqs=[ctrl0], in_soqs={"q": q})
     composite = bb.finalize(ctrl_0=ctrl_out, q=out_reg)
     composite.flatten()
 


### PR DESCRIPTION
`Identity` is a special bloq: its controlled version is still an identity, but with a larger register, ie. calling `Identity(n).controlled(CtrlSpec(QAny(m)))` gets us `Identity(n+m)`

The old version of `ctrl_adder()` was using `Autopartition` which failed during decomposition as `Autopartition` is not designed to merge registers and pass them to the inner bloq.

This is fixed by this PR by replacing `Autopartition` with `Partition(s)`.

This fix is functional but the resulting `show_bloq()` output is less clean as the Partition steps are visible. An alternative (maybe better) fix is to keep using `Autopartition` but mark the control registers as `Unused()`, but It is weird conceptually to not use Identity(n+m) as the controlled Identity.  

This PR also adds a test covering this bug.