### PR TITLE
Enable reference docs for rotation synthesis

### DIFF
--- a/dev_tools/qualtran_dev_tools/make_reference_docs/_make.py
+++ b/dev_tools/qualtran_dev_tools/make_reference_docs/_make.py
@@ -73,7 +73,6 @@ MINIMAL_SKIP_CANONPATHS = [
     'qualtran.linalg',
     'qualtran._infra.gate_with_registers.GateWithRegisters',
     'qualtran.resource_counting.t_counts_from_sigma',
-    'qualtran.rotation_synthesis',  # TODO: https://github.com/quantumlib/Qualtran/issues/1767
 ]
 MINIMAL = True
 

--- a/qualtran/rotation_synthesis/channels/_channel.py
+++ b/qualtran/rotation_synthesis/channels/_channel.py
@@ -44,6 +44,7 @@ class UnitaryChannel(Channel):
     r"""A Unitary operation.
 
     The unitary matrix of an $SU(2)$ matrix is defined with two complex numbers $u, v$ as
+
     $$
     \begin{bmatrix}
     u & -v^*\\
@@ -51,6 +52,7 @@ class UnitaryChannel(Channel):
     \end{bmatrix}
     $$
     for clifford+T unitarys the matrix can be written as
+
     $$
     \frac{1}{\sqrt{2(2+\sqrt{2})^n}}
     \begin{bmatrix}
@@ -203,11 +205,13 @@ class ProjectiveChannel(Channel):
     This channel applies the following circuit where $V$ is the `rotation` channel and $C$ is the
     correction channel.
 
+    ```
     q: ─────────@───V───@───────Y───C───
                 │       │       ║   ║
     ancilla: ───X───────X───M───╫───╫───
                             ║   ║   ║
     m: ═════════════════════@═══^═══^═══
+    ```
 
     Attributes:
         rotation: This first half of the channel (i.e. $V$).

--- a/qualtran/rotation_synthesis/lattice/_ipe.py
+++ b/qualtran/rotation_synthesis/lattice/_ipe.py
@@ -35,7 +35,7 @@ def enumerate_1d(
 ) -> Iterator[rings.ZSqrt2]:
     r"""Yield points $p \in \mathbb{Z}[\sqrt{2}]$ contained in the region.
 
-    Point $p$ belongs to the region iff $p \in inter$ and $p^sbullet \in \texit{comp_inter}$
+    Point $p$ belongs to the region iff $p \in \textit{inter}$ and $p^\bullet \in \textit{comp_inter}$
 
     Follows section 4 of https://arxiv.org/abs/1403.2975
 
@@ -84,7 +84,7 @@ def enumerate_1d(
 def enumerate_upright(
     r: _geometry.Rectangle, comp_r: _geometry.Rectangle, config: mc.MathConfig
 ) -> Iterator[rings.ZW]:
-    r"""Yield $p \in \mathbb{Z}[e^{i \pi/4}]$ such that $p \in r$ and $p^\sbullet \in \textit{comp_r}$
+    r"""Yield $p \in \mathbb{Z}[e^{i \pi/4}]$ such that $p \in r$ and $p^\bullet \in \textit{comp_r}$
 
     Follows section 5 of https://arxiv.org/abs/1403.2975
 
@@ -94,7 +94,7 @@ def enumerate_upright(
         config: The MathConfig to use.
 
     Yields:
-        Points $p$ such that $p \in r$ and $p^\sbullet \in \textit{comp_r}$
+        Points $p$ such that $p \in r$ and $p^\bullet \in \textit{comp_r}$
     """
     second_part = tuple(enumerate_1d(r.y_bounds, comp_r.y_bounds, config))
     for a in enumerate_1d(r.x_bounds, comp_r.x_bounds, config):

--- a/qualtran/rotation_synthesis/lattice/_state.py
+++ b/qualtran/rotation_synthesis/lattice/_state.py
@@ -56,7 +56,7 @@ class GridOperatorAction:
 class SelingerState:
     r"""A state is a region in space defined by two ellipses (A, B).
 
-    A point $p$ belongs to the region iff $p \in A$ and $p^\bullet in B$. Where
+    A point $p$ belongs to the region iff $p \in A$ and $p^\bullet \in B$. Where
     $p^\bullet$ is the sqrt2-conjugate of $p$.
 
     Attributes:

--- a/qualtran/rotation_synthesis/matrix/_clifford_t_repr.py
+++ b/qualtran/rotation_synthesis/matrix/_clifford_t_repr.py
@@ -82,13 +82,17 @@ def _xz_sequence(
 def to_sequence(matrix: _su2_ct.SU2CliffordT, fmt: str = 'xyz') -> tuple[str, ...]:
     r"""Returns a sequence of Clifford+T that produces the given matrix.
 
+    Allowable format strings are
+     - 'xyz' uses Tx, Ty, Tz gates.
+     - 'xz' uses $Tx, Tz, Tx^\dagger, Tz^\dagger$
+
     Args:
         matrix: The matrix to represent.
-        fmt: A string from the set {'xz', 'xyz'} representing the allowed T gates where
-            - 'xyz' uses Tx, Ty, Tz gates.
-            - 'xz' uses $Tx, Tz, Tx^\dagger, Tz^\dagger$
+        fmt: A string from the set {'xz', 'xyz'} representing the allowed T gates described above.
+
     Returns:
         A tuple of strings representing the gates.
+
     Raises:
         ValueError: If `fmt` is not supported.
     """

--- a/qualtran/rotation_synthesis/matrix/_su2_ct.py
+++ b/qualtran/rotation_synthesis/matrix/_su2_ct.py
@@ -37,7 +37,7 @@ class SU2CliffordT:
     Where $u, v \in \mathbb{Z}[e^{i \pi/4}]$ and $n$ is the needed number of $T$ gates with a
     determinant $\frac{1}{2(2+\sqrt{2})^n} (|u|^2 + |v|^2) = 1$.
 
-    Instances of this class represent the matrix [[u, -v^*], [v, u^*]] with the scaling factor
+    Instances of this class represent the matrix `[[u, -v^*], [v, u^*]]` with the scaling factor
     being implicit.
 
     Attributes:

--- a/qualtran/rotation_synthesis/protocols/_fallback.py
+++ b/qualtran/rotation_synthesis/protocols/_fallback.py
@@ -113,11 +113,13 @@ class Fallback(_protocol.ApproxProblem):
     r"""Approximate a Z-rotation with a fallback channel.
 
     Approximate the $Rz(2\theta)$ with the channel
+    ```
     q: ─────────@───V───@───────Y───C───
                 │       │       ║   ║
     ancilla: ───X───────X───M───╫───╫───
                             ║   ║   ║
     m: ═════════════════════@═══^═══^═══
+    ```
 
     where a cheap (in terms of T gates) rotation `V` is applied and then depending on
     the result of the measurement we may need to apply an expensive correction. The problem

--- a/qualtran/rotation_synthesis/relative_norm/_clifford_t.py
+++ b/qualtran/rotation_synthesis/relative_norm/_clifford_t.py
@@ -56,7 +56,7 @@ class CliffordTRelativeNormSolver:
     r"""A relative norm solver for the Clifford+T Gateset.
 
     The class implements the relative norm solver described in section Algorithm 2 in
-    https://arxiv.org/abs/2203.10064. For Clifford+T, $O_K = \mathbb{Z}[\zsqrt{2}]$ and
+    https://arxiv.org/abs/2203.10064. For Clifford+T, $O_K = \mathbb{Z}[\sqrt{2}]$ and
     $O_L = \mathbb{Z}[e^{i pi/4}]$.
     """
 


### PR DESCRIPTION
 - enable reference doc generation for the `rotation_synthesis` module.
 - Fix some latex issues, including some places where sphinx/mathjax is more sensitive 

Fixes #1767 