### PR TITLE
Update stale reversible sampling helper reference

### DIFF
--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
@@ -461,7 +461,7 @@ class SparseStatePreparationAliasSampling(PrepareOracle):
             precision: The desired accuracy to represent each probability
                 (which sets mu size and keep/alt integers).
                 See `qualtran.linalg.lcu_util.preprocess_probabilities_for_reversible_sampling`
-                with `unnormalized_probabilities` for more information.
+                for more information.
         """
         mu = sub_bit_prec_from_epsilon(n_coeff, precision)
         selection_bitsize = bit_length(n_coeff - 1)

--- a/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
+++ b/qualtran/bloqs/state_preparation/state_preparation_alias_sampling.py
@@ -460,8 +460,8 @@ class SparseStatePreparationAliasSampling(PrepareOracle):
             sum_of_terms: Sum of absolute values of the input probabilities.
             precision: The desired accuracy to represent each probability
                 (which sets mu size and keep/alt integers).
-                See `qualtran.linalg.lcu_util.preprocess_lcu_coefficients_for_reversible_sampling`
-                for more information.
+                See `qualtran.linalg.lcu_util.preprocess_probabilities_for_reversible_sampling`
+                with `unnormalized_probabilities` for more information.
         """
         mu = sub_bit_prec_from_epsilon(n_coeff, precision)
         selection_bitsize = bit_length(n_coeff - 1)


### PR DESCRIPTION
The docstring references `preprocess_lcu_coefficients_for_reversible_sampling` but it seems like this method was replaced with `preprocess_probabilities_for_reversible_sampling`.