### PR TITLE
Add QIntState, QUIntState; no attrs shenanigans 

### DIFF
--- a/dev_tools/qualtran_dev_tools/notebook_specs.py
+++ b/dev_tools/qualtran_dev_tools/notebook_specs.py
@@ -221,7 +221,7 @@ BASIC_GATES: List[NotebookSpecV2] = [
             qualtran.bloqs.basic_gates.qconst._QUINT_EFFECT_DOC,
             qualtran.bloqs.basic_gates.qconst._QINT_STATE_DOC,
             qualtran.bloqs.basic_gates.qconst._QINT_EFFECT_DOC,
-        ]
+        ],
     ),
     NotebookSpecV2(
         title='Measurement',

--- a/dev_tools/qualtran_dev_tools/notebook_specs.py
+++ b/dev_tools/qualtran_dev_tools/notebook_specs.py
@@ -214,6 +214,16 @@ BASIC_GATES: List[NotebookSpecV2] = [
         ],
     ),
     NotebookSpecV2(
+        title='Quantum Constants',
+        module=qualtran.bloqs.basic_gates.qconst,
+        bloq_specs=[
+            qualtran.bloqs.basic_gates.qconst._QUINT_STATE_DOC,
+            qualtran.bloqs.basic_gates.qconst._QUINT_EFFECT_DOC,
+            qualtran.bloqs.basic_gates.qconst._QINT_STATE_DOC,
+            qualtran.bloqs.basic_gates.qconst._QINT_EFFECT_DOC,
+        ]
+    ),
+    NotebookSpecV2(
         title='Measurement',
         module=qualtran.bloqs.basic_gates.z_basis,
         path_stem='measurement',

--- a/docs/bloqs/index.rst
+++ b/docs/bloqs/index.rst
@@ -41,6 +41,7 @@ Bloqs Library
     basic_gates/y_gate.ipynb
     mcmt/and_bloq.ipynb
     basic_gates/states_and_effects.ipynb
+    basic_gates/qconst.ipynb
     basic_gates/measurement.ipynb
     basic_gates/swap.ipynb
     swap_network/swap_network.ipynb

--- a/qualtran/bloqs/basic_gates/__init__.py
+++ b/qualtran/bloqs/basic_gates/__init__.py
@@ -28,6 +28,7 @@ from .hadamard import CHadamard, Hadamard
 from .identity import Identity
 from .on_each import OnEach
 from .power import Power
+from .qconst import QIntEffect, QIntState, QUIntEffect, QUIntState
 from .rotation import CRy, CRz, CZPowGate, Rx, Ry, Rz, XPowGate, YPowGate, ZPowGate
 from .s_gate import SGate
 from .su2_rotation import SU2RotationGate
@@ -36,7 +37,6 @@ from .t_gate import TGate
 from .toffoli import Toffoli
 from .x_basis import MeasureX, MinusEffect, MinusState, PlusEffect, PlusState, XGate
 from .y_gate import CYGate, YGate
-from .qconst import QIntEffect, QIntState, QUIntEffect, QUIntState
 from .z_basis import (
     CZ,
     IntEffect,

--- a/qualtran/bloqs/basic_gates/__init__.py
+++ b/qualtran/bloqs/basic_gates/__init__.py
@@ -36,6 +36,7 @@ from .t_gate import TGate
 from .toffoli import Toffoli
 from .x_basis import MeasureX, MinusEffect, MinusState, PlusEffect, PlusState, XGate
 from .y_gate import CYGate, YGate
+from .qconst import QIntEffect, QIntState, QUIntEffect, QUIntState
 from .z_basis import (
     CZ,
     IntEffect,

--- a/qualtran/bloqs/basic_gates/qconst.ipynb
+++ b/qualtran/bloqs/basic_gates/qconst.ipynb
@@ -1,0 +1,448 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0a4a9f57",
+   "metadata": {
+    "cq.autogen": "title_cell"
+   },
+   "source": [
+    "# Quantum Constants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc4b7279",
+   "metadata": {
+    "cq.autogen": "top_imports"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran import Bloq, CompositeBloq, BloqBuilder, Signature, Register\n",
+    "from qualtran import QBit, QInt, QUInt, QAny\n",
+    "from qualtran.drawing import show_bloq, show_call_graph, show_counts_sigma\n",
+    "from typing import *\n",
+    "import numpy as np\n",
+    "import sympy\n",
+    "import cirq"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f4cda4c",
+   "metadata": {
+    "cq.autogen": "QUIntState.bloq_doc.md"
+   },
+   "source": [
+    "## `QUIntState`\n",
+    "The state |val> for an unsigned integer val of type QUInt(bitsize)\n",
+    "\n",
+    "#### Parameters\n",
+    " - `val`: the classical value\n",
+    " - `bitsize`: The bitsize of the register \n",
+    "\n",
+    "#### Registers\n",
+    " - `val`: The register of size `bitsize` which initializes the value `val`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6aa2d166",
+   "metadata": {
+    "cq.autogen": "QUIntState.bloq_doc.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.basic_gates import QUIntState"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32a3573d",
+   "metadata": {
+    "cq.autogen": "QUIntState.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80d6eed7",
+   "metadata": {
+    "cq.autogen": "QUIntState.quint_state"
+   },
+   "outputs": [],
+   "source": [
+    "quint_state = QUIntState(5, bitsize=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "183b9281",
+   "metadata": {
+    "cq.autogen": "QUIntState.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7636fab8",
+   "metadata": {
+    "cq.autogen": "QUIntState.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([quint_state],\n",
+    "           ['`quint_state`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "933fcdb7",
+   "metadata": {
+    "cq.autogen": "QUIntState.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5355b77e",
+   "metadata": {
+    "cq.autogen": "QUIntState.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.generalizers import ignore_split_join\n",
+    "quint_state_g, quint_state_sigma = quint_state.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
+    "show_call_graph(quint_state_g)\n",
+    "show_counts_sigma(quint_state_sigma)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2636827",
+   "metadata": {
+    "cq.autogen": "QUIntEffect.bloq_doc.md"
+   },
+   "source": [
+    "## `QUIntEffect`\n",
+    "The effect <val| for an unsigned integer val of type QUInt(bitsize)\n",
+    "\n",
+    "#### Parameters\n",
+    " - `val`: the classical value\n",
+    " - `bitsize`: The bitsize of the register \n",
+    "\n",
+    "#### Registers\n",
+    " - `val`: The register of size `bitsize` which de-allocates the value `val`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67492f72",
+   "metadata": {
+    "cq.autogen": "QUIntEffect.bloq_doc.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.basic_gates import QUIntEffect"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f4eda8d",
+   "metadata": {
+    "cq.autogen": "QUIntEffect.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa8b39cd",
+   "metadata": {
+    "cq.autogen": "QUIntEffect.quint_effect"
+   },
+   "outputs": [],
+   "source": [
+    "quint_effect = QUIntEffect(5, bitsize=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "424f7caa",
+   "metadata": {
+    "cq.autogen": "QUIntEffect.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a71e36a",
+   "metadata": {
+    "cq.autogen": "QUIntEffect.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([quint_effect],\n",
+    "           ['`quint_effect`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cefae971",
+   "metadata": {
+    "cq.autogen": "QUIntEffect.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d121bcf0",
+   "metadata": {
+    "cq.autogen": "QUIntEffect.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.generalizers import ignore_split_join\n",
+    "quint_effect_g, quint_effect_sigma = quint_effect.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
+    "show_call_graph(quint_effect_g)\n",
+    "show_counts_sigma(quint_effect_sigma)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f411061",
+   "metadata": {
+    "cq.autogen": "QIntState.bloq_doc.md"
+   },
+   "source": [
+    "## `QIntState`\n",
+    "The state |val> for a signed integer val of type QInt(bitsize)\n",
+    "\n",
+    "#### Parameters\n",
+    " - `val`: the classical value\n",
+    " - `bitsize`: The bitsize of the register \n",
+    "\n",
+    "#### Registers\n",
+    " - `val`: The register of size `bitsize` which initializes the value `val`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c947fbd",
+   "metadata": {
+    "cq.autogen": "QIntState.bloq_doc.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.basic_gates import QIntState"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbe1be4f",
+   "metadata": {
+    "cq.autogen": "QIntState.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5da5b7ca",
+   "metadata": {
+    "cq.autogen": "QIntState.qint_state"
+   },
+   "outputs": [],
+   "source": [
+    "qint_state = QIntState(-5, bitsize=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6257049f",
+   "metadata": {
+    "cq.autogen": "QIntState.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a372ed9",
+   "metadata": {
+    "cq.autogen": "QIntState.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([qint_state],\n",
+    "           ['`qint_state`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d494a7b8",
+   "metadata": {
+    "cq.autogen": "QIntState.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8622bfe",
+   "metadata": {
+    "cq.autogen": "QIntState.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.generalizers import ignore_split_join\n",
+    "qint_state_g, qint_state_sigma = qint_state.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
+    "show_call_graph(qint_state_g)\n",
+    "show_counts_sigma(qint_state_sigma)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bcfc048e",
+   "metadata": {
+    "cq.autogen": "QIntEffect.bloq_doc.md"
+   },
+   "source": [
+    "## `QIntEffect`\n",
+    "The effect <val| for a signed integer val of type QInt(bitsize)\n",
+    "\n",
+    "#### Parameters\n",
+    " - `val`: the classical value\n",
+    " - `bitsize`: The bitsize of the register \n",
+    "\n",
+    "#### Registers\n",
+    " - `val`: The register of size `bitsize` which de-allocates the value `val`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de338444",
+   "metadata": {
+    "cq.autogen": "QIntEffect.bloq_doc.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.basic_gates import QIntEffect"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09a286ae",
+   "metadata": {
+    "cq.autogen": "QIntEffect.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdf64b3c",
+   "metadata": {
+    "cq.autogen": "QIntEffect.qint_effect"
+   },
+   "outputs": [],
+   "source": [
+    "qint_effect = QIntEffect(-5, bitsize=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf730554",
+   "metadata": {
+    "cq.autogen": "QIntEffect.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b381444e",
+   "metadata": {
+    "cq.autogen": "QIntEffect.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([qint_effect],\n",
+    "           ['`qint_effect`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ff2c45f",
+   "metadata": {
+    "cq.autogen": "QIntEffect.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61f359bb",
+   "metadata": {
+    "cq.autogen": "QIntEffect.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.generalizers import ignore_split_join\n",
+    "qint_effect_g, qint_effect_sigma = qint_effect.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
+    "show_call_graph(qint_effect_g)\n",
+    "show_counts_sigma(qint_effect_sigma)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/qualtran/bloqs/basic_gates/qconst.py
+++ b/qualtran/bloqs/basic_gates/qconst.py
@@ -99,7 +99,9 @@ class _QConst(Bloq):
 
     def build_composite_bloq(self, bb: 'BloqBuilder', **val: 'SoquetT') -> Dict[str, 'SoquetT']:
         if is_symbolic(self.qdtype) or is_symbolic(self.val):
-            raise DecomposeTypeError(f'Symbolic qdtype {self.qdtype} or val {self.val} not supported')
+            raise DecomposeTypeError(
+                f'Symbolic qdtype {self.qdtype} or val {self.val} not supported'
+            )
         bits = np.asarray(self.qdtype.to_bits(self.val))
         if self.state:
             assert not val

--- a/qualtran/bloqs/basic_gates/qconst.py
+++ b/qualtran/bloqs/basic_gates/qconst.py
@@ -1,0 +1,378 @@
+#  Copyright 2026 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from functools import cached_property
+from typing import Dict, Iterable, List, Mapping, Optional, Set, Tuple, TYPE_CHECKING, Union, cast
+
+import numpy as np
+import sympy
+from attrs import frozen
+from numpy.typing import NDArray
+
+from qualtran import (
+    Bloq,
+    bloq_example,
+    BloqBuilder,
+    BloqDocSpec,
+    DecomposeTypeError,
+    QDType,
+    QInt,
+    QUInt,
+    Register,
+    Side,
+    Signature,
+    Soquet,
+    SoquetT,
+)
+from qualtran.bloqs.bookkeeping import ArbitraryClifford
+from qualtran.drawing import directional_text_box, Text, WireSymbol
+from qualtran.symbolics import is_symbolic, SymbolicInt
+
+if TYPE_CHECKING:
+    from qualtran.resource_counting import BloqCountDictT, BloqCountT, SympySymbolAllocator
+    from qualtran.simulation.classical_sim import ClassicalValRetT, ClassicalValT
+
+
+@frozen
+class _QConst(Bloq):
+    """Represent a classical integer vector (state or effect) with a given quantum data type.
+
+    Args:
+        val: the classical value.
+        qdtype: The quantum data type.
+        state: True if this is a state; an effect otherwise.
+
+    Registers:
+        val: The register of type `qdtype` which initializes/de-allocates the value `val`.
+    """
+
+    val: SymbolicInt
+    qdtype: QDType
+    state: bool
+
+    def __attrs_post_init__(self):
+        if is_symbolic(self.val) or is_symbolic(self.qdtype):
+            return
+
+        self.qdtype.assert_valid_classical_val(self.val)
+
+    @cached_property
+    def signature(self) -> Signature:
+        side = Side.RIGHT if self.state else Side.LEFT
+        return Signature([Register('val', self.qdtype, side=side)])
+
+    @staticmethod
+    def _build_composite_state(bb: 'BloqBuilder', bits: NDArray[np.uint8]) -> Dict[str, 'SoquetT']:
+        from qualtran.bloqs.basic_gates.z_basis import ZeroState, OneState
+        states = [ZeroState(), OneState()]
+        xs = []
+        for bit in bits:
+            x = bb.add(states[bit])
+            xs.append(x)
+        xs = np.array(xs)
+
+        return {'val': bb.join(xs)}
+
+    @staticmethod
+    def _build_composite_effect(
+        bb: 'BloqBuilder', val: 'Soquet', bits: NDArray[np.uint8]
+    ) -> Dict[str, 'SoquetT']:
+        from qualtran.bloqs.basic_gates.z_basis import ZeroEffect, OneEffect
+        xs = bb.split(val)
+        effects = [ZeroEffect(), OneEffect()]
+        for i, bit in enumerate(bits):
+            bb.add(effects[bit], q=xs[i])
+        return {}
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', **val: 'SoquetT') -> Dict[str, 'SoquetT']:
+        if is_symbolic(self.qdtype):
+            raise DecomposeTypeError(f'Symbolic qdtype {self.qdtype} not supported')
+        bits = np.asarray(self.qdtype.to_bits(self.val))
+        if self.state:
+            assert not val
+            return self._build_composite_state(bb, bits)
+        else:
+            return self._build_composite_effect(bb, cast(Soquet, val['val']), bits)
+
+    def on_classical_vals(self, *, val: Optional[int] = None) -> Dict[str, Union[int, sympy.Expr]]:
+        if self.state:
+            assert val is None
+            return {'val': self.val}
+
+        assert val == self.val, val
+        return {}
+
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        return {ArbitraryClifford(self.qdtype.num_bits): 1}
+
+    def adjoint(self) -> 'Bloq':
+        return _QConst(val=self.val, qdtype=self.qdtype, state=not self.state)
+
+    def __str__(self) -> str:
+        s = f'{self.val}'
+        return f'QConst({s})'
+
+    def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
+        if reg is None:
+            return Text('')
+
+        return directional_text_box(text=f'{self.val}', side=reg.side)
+
+
+@frozen
+class QIntState(Bloq):
+    """The state |val> for a signed integer val of type QInt(bitsize)
+
+    Args:
+        val: the classical value
+        bitsize: The bitsize of the register
+
+    Registers:
+        val: The register of size `bitsize` which initializes the value `val`.
+    """
+
+    val: SymbolicInt
+    bitsize: SymbolicInt
+
+    def __attrs_post_init__(self):
+        if is_symbolic(self.val) or is_symbolic(self.bitsize):
+            return
+        QInt(self.bitsize).assert_valid_classical_val(self.val)
+
+    @cached_property
+    def _impl(self):
+        return _QConst(val=self.val, qdtype=QInt(self.bitsize), state=True)
+
+    @property
+    def signature(self) -> 'Signature':
+        return self._impl.signature
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
+        return self._impl.build_composite_bloq(bb, **soqs)
+
+    def on_classical_vals(
+        self, **vals: Union['sympy.Symbol', 'ClassicalValT']
+    ) -> Mapping[str, 'ClassicalValRetT']:
+        return self._impl.on_classical_vals(**vals)
+
+    def build_call_graph(
+        self, ssa: 'SympySymbolAllocator'
+    ) -> Union['BloqCountDictT', Set['BloqCountT']]:
+        return self._impl.build_call_graph(ssa)
+
+    def wire_symbol(
+        self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
+    ) -> 'WireSymbol':
+        return self._impl.wire_symbol(reg, idx)
+
+    def adjoint(self) -> 'QIntEffect':
+        return QIntEffect(val=self.val, bitsize=self.bitsize)
+
+    def __str__(self):
+        return f'QIntState({self.val})'
+
+
+@bloq_example
+def _qint_state() -> QIntState:
+    qint_state = QIntState(-5, bitsize=8)
+    return qint_state
+
+
+_QINT_STATE_DOC = BloqDocSpec(bloq_cls=QIntState, examples=[_qint_state])
+
+
+@frozen
+class QIntEffect(Bloq):
+    """The effect <val| for a signed integer val of type QInt(bitsize)
+
+    Args:
+        val: the classical value
+        bitsize: The bitsize of the register
+
+    Registers:
+        val: The register of size `bitsize` which de-allocates the value `val`.
+    """
+
+    val: SymbolicInt
+    bitsize: SymbolicInt
+
+    def __attrs_post_init__(self):
+        if is_symbolic(self.val) or is_symbolic(self.bitsize):
+            return
+        QInt(self.bitsize).assert_valid_classical_val(self.val)
+
+    @cached_property
+    def _impl(self):
+        return _QConst(val=self.val, qdtype=QInt(self.bitsize), state=False)
+
+    @property
+    def signature(self) -> 'Signature':
+        return self._impl.signature
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
+        return self._impl.build_composite_bloq(bb, **soqs)
+
+    def on_classical_vals(
+        self, **vals: Union['sympy.Symbol', 'ClassicalValT']
+    ) -> Mapping[str, 'ClassicalValRetT']:
+        return self._impl.on_classical_vals(**vals)
+
+    def build_call_graph(
+        self, ssa: 'SympySymbolAllocator'
+    ) -> Union['BloqCountDictT', Set['BloqCountT']]:
+        return self._impl.build_call_graph(ssa)
+
+    def wire_symbol(
+        self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
+    ) -> 'WireSymbol':
+        return self._impl.wire_symbol(reg, idx)
+
+    def adjoint(self) -> 'QIntState':
+        return QIntState(val=self.val, bitsize=self.bitsize)
+
+    def __str__(self):
+        return f'QIntEffect({self.val})'
+
+
+@bloq_example
+def _qint_effect() -> QIntEffect:
+    qint_effect = QIntEffect(-5, bitsize=8)
+    return qint_effect
+
+
+_QINT_EFFECT_DOC = BloqDocSpec(bloq_cls=QIntEffect, examples=[_qint_effect])
+
+
+@frozen
+class QUIntState(Bloq):
+    """The state |val> for an unsigned integer val of type QUInt(bitsize)
+
+    Args:
+        val: the classical value
+        bitsize: The bitsize of the register
+
+    Registers:
+        val: The register of size `bitsize` which initializes the value `val`.
+    """
+
+    val: SymbolicInt
+    bitsize: SymbolicInt
+
+    def __attrs_post_init__(self):
+        if is_symbolic(self.val) or is_symbolic(self.bitsize):
+            return
+        QUInt(self.bitsize).assert_valid_classical_val(self.val)
+
+    @cached_property
+    def _impl(self):
+        return _QConst(val=self.val, qdtype=QUInt(self.bitsize), state=True)
+
+    @property
+    def signature(self) -> 'Signature':
+        return self._impl.signature
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
+        return self._impl.build_composite_bloq(bb, **soqs)
+
+    def on_classical_vals(
+        self, **vals: Union['sympy.Symbol', 'ClassicalValT']
+    ) -> Mapping[str, 'ClassicalValRetT']:
+        return self._impl.on_classical_vals(**vals)
+
+    def build_call_graph(
+        self, ssa: 'SympySymbolAllocator'
+    ) -> Union['BloqCountDictT', Set['BloqCountT']]:
+        return self._impl.build_call_graph(ssa)
+
+    def wire_symbol(
+        self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
+    ) -> 'WireSymbol':
+        return self._impl.wire_symbol(reg, idx)
+
+    def adjoint(self) -> 'QUIntEffect':
+        return QUIntEffect(val=self.val, bitsize=self.bitsize)
+
+    def __str__(self):
+        return f'QUIntState({self.val})'
+
+
+@bloq_example
+def _quint_state() -> QUIntState:
+    quint_state = QUIntState(5, bitsize=8)
+    return quint_state
+
+
+_QUINT_STATE_DOC = BloqDocSpec(bloq_cls=QUIntState, examples=[_quint_state])
+
+
+@frozen
+class QUIntEffect(Bloq):
+    """The effect <val| for an unsigned integer val of type QUInt(bitsize)
+
+    Args:
+        val: the classical value
+        bitsize: The bitsize of the register
+
+    Registers:
+        val: The register of size `bitsize` which de-allocates the value `val`.
+    """
+
+    val: SymbolicInt
+    bitsize: SymbolicInt
+
+    def __attrs_post_init__(self):
+        if is_symbolic(self.val) or is_symbolic(self.bitsize):
+            return
+        QUInt(self.bitsize).assert_valid_classical_val(self.val)
+
+    @cached_property
+    def _impl(self):
+        return _QConst(val=self.val, qdtype=QUInt(self.bitsize), state=False)
+
+    @property
+    def signature(self) -> 'Signature':
+        return self._impl.signature
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
+        return self._impl.build_composite_bloq(bb, **soqs)
+
+    def on_classical_vals(
+        self, **vals: Union['sympy.Symbol', 'ClassicalValT']
+    ) -> Mapping[str, 'ClassicalValRetT']:
+        return self._impl.on_classical_vals(**vals)
+
+    def build_call_graph(
+        self, ssa: 'SympySymbolAllocator'
+    ) -> Union['BloqCountDictT', Set['BloqCountT']]:
+        return self._impl.build_call_graph(ssa)
+
+    def wire_symbol(
+        self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
+    ) -> 'WireSymbol':
+        return self._impl.wire_symbol(reg, idx)
+
+    def adjoint(self) -> 'QUIntState':
+        return QUIntState(val=self.val, bitsize=self.bitsize)
+
+    def __str__(self):
+        return f'QUIntEffect({self.val})'
+
+
+@bloq_example
+def _quint_effect() -> QUIntEffect:
+    quint_effect = QUIntEffect(5, bitsize=8)
+    return quint_effect
+
+
+_QUINT_EFFECT_DOC = BloqDocSpec(bloq_cls=QUIntEffect, examples=[_quint_effect])

--- a/qualtran/bloqs/basic_gates/qconst.py
+++ b/qualtran/bloqs/basic_gates/qconst.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import Dict, Iterable, List, Mapping, Optional, Set, Tuple, TYPE_CHECKING, Union, cast
+from typing import cast, Dict, Iterable, List, Mapping, Optional, Set, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 import sympy
@@ -74,7 +74,8 @@ class _QConst(Bloq):
 
     @staticmethod
     def _build_composite_state(bb: 'BloqBuilder', bits: NDArray[np.uint8]) -> Dict[str, 'SoquetT']:
-        from qualtran.bloqs.basic_gates.z_basis import ZeroState, OneState
+        from qualtran.bloqs.basic_gates.z_basis import OneState, ZeroState
+
         states = [ZeroState(), OneState()]
         xs = []
         for bit in bits:
@@ -88,7 +89,8 @@ class _QConst(Bloq):
     def _build_composite_effect(
         bb: 'BloqBuilder', val: 'Soquet', bits: NDArray[np.uint8]
     ) -> Dict[str, 'SoquetT']:
-        from qualtran.bloqs.basic_gates.z_basis import ZeroEffect, OneEffect
+        from qualtran.bloqs.basic_gates.z_basis import OneEffect, ZeroEffect
+
         xs = bb.split(val)
         effects = [ZeroEffect(), OneEffect()]
         for i, bit in enumerate(bits):

--- a/qualtran/bloqs/basic_gates/qconst.py
+++ b/qualtran/bloqs/basic_gates/qconst.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from functools import cached_property
-from typing import cast, Dict, Iterable, List, Mapping, Optional, Set, Tuple, TYPE_CHECKING, Union
+from typing import cast, Dict, Mapping, Optional, Set, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 import sympy

--- a/qualtran/bloqs/basic_gates/qconst.py
+++ b/qualtran/bloqs/basic_gates/qconst.py
@@ -98,8 +98,8 @@ class _QConst(Bloq):
         return {}
 
     def build_composite_bloq(self, bb: 'BloqBuilder', **val: 'SoquetT') -> Dict[str, 'SoquetT']:
-        if is_symbolic(self.qdtype):
-            raise DecomposeTypeError(f'Symbolic qdtype {self.qdtype} not supported')
+        if is_symbolic(self.qdtype) or is_symbolic(self.val):
+            raise DecomposeTypeError(f'Symbolic qdtype {self.qdtype} or val {self.val} not supported')
         bits = np.asarray(self.qdtype.to_bits(self.val))
         if self.state:
             assert not val

--- a/qualtran/bloqs/basic_gates/qconst_test.py
+++ b/qualtran/bloqs/basic_gates/qconst_test.py
@@ -140,3 +140,7 @@ def test_state_effect_composition():
     cbloq = bb.finalize()
     val = cbloq.tensor_contract()
     np.testing.assert_allclose(val, 1.0)
+
+@pytest.mark.notebook
+def test_notebook():
+    qlt_testing.execute_notebook('qconst')

--- a/qualtran/bloqs/basic_gates/qconst_test.py
+++ b/qualtran/bloqs/basic_gates/qconst_test.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 
 import qualtran.testing as qlt_testing
-from qualtran import BloqBuilder, QInt, QUInt
+from qualtran import BloqBuilder
 from qualtran.bloqs.basic_gates.qconst import (
     _qint_effect,
     _qint_state,

--- a/qualtran/bloqs/basic_gates/qconst_test.py
+++ b/qualtran/bloqs/basic_gates/qconst_test.py
@@ -18,14 +18,14 @@ import pytest
 import qualtran.testing as qlt_testing
 from qualtran import BloqBuilder, QInt, QUInt
 from qualtran.bloqs.basic_gates.qconst import (
-    QIntState,
-    QIntEffect,
-    QUIntState,
-    QUIntEffect,
-    _qint_state,
     _qint_effect,
-    _quint_state,
+    _qint_state,
     _quint_effect,
+    _quint_state,
+    QIntEffect,
+    QIntState,
+    QUIntEffect,
+    QUIntState,
 )
 
 
@@ -140,6 +140,7 @@ def test_state_effect_composition():
     cbloq = bb.finalize()
     val = cbloq.tensor_contract()
     np.testing.assert_allclose(val, 1.0)
+
 
 @pytest.mark.notebook
 def test_notebook():

--- a/qualtran/bloqs/basic_gates/qconst_test.py
+++ b/qualtran/bloqs/basic_gates/qconst_test.py
@@ -1,0 +1,142 @@
+#  Copyright 2026 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import numpy as np
+import pytest
+
+import qualtran.testing as qlt_testing
+from qualtran import BloqBuilder, QInt, QUInt
+from qualtran.bloqs.basic_gates.qconst import (
+    QIntState,
+    QIntEffect,
+    QUIntState,
+    QUIntEffect,
+    _qint_state,
+    _qint_effect,
+    _quint_state,
+    _quint_effect,
+)
+
+
+def test_qint_state_autotester(bloq_autotester):
+    bloq_autotester(_qint_state)
+
+
+def test_qint_effect_autotester(bloq_autotester):
+    bloq_autotester(_qint_effect)
+
+
+def test_quint_state_autotester(bloq_autotester):
+    bloq_autotester(_quint_state)
+
+
+def test_quint_effect_autotester(bloq_autotester):
+    bloq_autotester(_quint_effect)
+
+
+def test_qint_state_manual():
+    # Valid signed values for 8-bit signed integer: [-128, 127]
+    k = QIntState(-5, bitsize=8)
+    assert str(k) == 'QIntState(-5)'
+    (val,) = k.call_classically()
+    assert val == -5
+
+    # Test boundaries
+    assert QIntState(127, bitsize=8).call_classically() == (127,)
+    assert QIntState(-128, bitsize=8).call_classically() == (-128,)
+
+    with pytest.raises(ValueError):
+        QIntState(128, bitsize=8)
+
+    with pytest.raises(ValueError):
+        QIntState(-129, bitsize=8)
+
+    # Test decomposition and tensor contracting
+    qlt_testing.assert_valid_bloq_decomposition(k)
+    np.testing.assert_allclose(k.tensor_contract(), k.decompose_bloq().tensor_contract())
+
+
+def test_qint_effect_manual():
+    k = QIntEffect(-5, bitsize=8)
+    assert str(k) == 'QIntEffect(-5)'
+    ret = k.call_classically(val=-5)
+    assert ret == ()
+
+    with pytest.raises(AssertionError):
+        k.call_classically(val=-6)
+
+    qlt_testing.assert_valid_bloq_decomposition(k)
+    np.testing.assert_allclose(k.tensor_contract(), k.decompose_bloq().tensor_contract())
+
+
+def test_quint_state_manual():
+    # Valid unsigned values for 8-bit unsigned integer: [0, 255]
+    k = QUIntState(5, bitsize=8)
+    assert str(k) == 'QUIntState(5)'
+    (val,) = k.call_classically()
+    assert val == 5
+
+    # Test boundaries
+    assert QUIntState(255, bitsize=8).call_classically() == (255,)
+    assert QUIntState(0, bitsize=8).call_classically() == (0,)
+
+    with pytest.raises(ValueError):
+        QUIntState(256, bitsize=8)
+
+    with pytest.raises(ValueError):
+        QUIntState(-1, bitsize=8)
+
+    qlt_testing.assert_valid_bloq_decomposition(k)
+    np.testing.assert_allclose(k.tensor_contract(), k.decompose_bloq().tensor_contract())
+
+
+def test_quint_effect_manual():
+    k = QUIntEffect(5, bitsize=8)
+    assert str(k) == 'QUIntEffect(5)'
+    ret = k.call_classically(val=5)
+    assert ret == ()
+
+    with pytest.raises(AssertionError):
+        k.call_classically(val=6)
+
+    qlt_testing.assert_valid_bloq_decomposition(k)
+    np.testing.assert_allclose(k.tensor_contract(), k.decompose_bloq().tensor_contract())
+
+
+def test_state_effect_adjoint():
+    state = QIntState(-10, bitsize=6)
+    effect = QIntEffect(-10, bitsize=6)
+    assert state.adjoint() == effect
+    assert effect.adjoint() == state
+
+    state_u = QUIntState(10, bitsize=6)
+    effect_u = QUIntEffect(10, bitsize=6)
+    assert state_u.adjoint() == effect_u
+    assert effect_u.adjoint() == state_u
+
+
+def test_state_effect_composition():
+    bb = BloqBuilder()
+    q0 = bb.add(QIntState(-10, bitsize=6))
+    bb.add(QIntEffect(-10, bitsize=6), val=q0)
+    cbloq = bb.finalize()
+    val = cbloq.tensor_contract()
+    np.testing.assert_allclose(val, 1.0)
+
+    bb = BloqBuilder()
+    q0 = bb.add(QUIntState(10, bitsize=6))
+    bb.add(QUIntEffect(10, bitsize=6), val=q0)
+    cbloq = bb.finalize()
+    val = cbloq.tensor_contract()
+    np.testing.assert_allclose(val, 1.0)

--- a/qualtran/bloqs/basic_gates/states_and_effects.ipynb
+++ b/qualtran/bloqs/basic_gates/states_and_effects.ipynb
@@ -412,7 +412,10 @@
    },
    "source": [
     "## `IntState`\n",
-    "The state |val> for non-negative integer val\n",
+    "The state |val> for non-negative (unsigned) integer val\n",
+    "\n",
+    "Please prefer QUIntState for new code, which makes it clear that the resultant\n",
+    "datatype is a `QUInt` unsigned integer.\n",
     "\n",
     "#### Parameters\n",
     " - `val`: the classical value\n",
@@ -514,6 +517,9 @@
    "source": [
     "## `IntEffect`\n",
     "The effect <val| for non-negative integer val\n",
+    "\n",
+    "Please prefer QUIntEffect for new code, which makes it clear that the incoming\n",
+    "datatype is a `QUInt` unsigned integer.\n",
     "\n",
     "#### Parameters\n",
     " - `val`: the classical value\n",

--- a/qualtran/bloqs/basic_gates/x_basis.py
+++ b/qualtran/bloqs/basic_gates/x_basis.py
@@ -127,12 +127,6 @@ class _XVector(metaclass=abc.ABCMeta):
         return directional_text_box(s, side=reg.side)
 
 
-def _hide_base_fields(cls, fields):
-    # for use in attrs `field_trasnformer`.
-    return [
-        field.evolve(repr=False) if field.name in ['bit', 'state'] else field for field in fields
-    ]
-
 
 @frozen
 class PlusState(_XVector, Bloq):
@@ -162,7 +156,7 @@ def _plus_state() -> PlusState:
 _PLUS_STATE_DOC = BloqDocSpec(bloq_cls=PlusState, examples=[_plus_state])
 
 
-@frozen(init=False, field_transformer=_hide_base_fields)
+@frozen
 class PlusEffect(_XVector, Bloq):
     """The effect <+|"""
 
@@ -190,6 +184,7 @@ def _plus_effect() -> PlusEffect:
 _PLUS_EFFECT_DOC = BloqDocSpec(bloq_cls=PlusEffect, examples=[_plus_effect])
 
 
+@frozen
 class MinusState(_XVector, Bloq):
     """The state |->"""
 
@@ -217,7 +212,7 @@ def _minus_state() -> MinusState:
 _MINUS_STATE_DOC = BloqDocSpec(bloq_cls=MinusState, examples=[_minus_state])
 
 
-@frozen(init=False, field_transformer=_hide_base_fields)
+@frozen
 class MinusEffect(_XVector, Bloq):
     """The effect <-|"""
 

--- a/qualtran/bloqs/basic_gates/x_basis.py
+++ b/qualtran/bloqs/basic_gates/x_basis.py
@@ -256,7 +256,6 @@ class XGate(Bloq):
     def signature(self) -> 'Signature':
         return Signature.build(q=1)
 
-
     def decompose_bloq(self) -> 'CompositeBloq':
         raise DecomposeTypeError(f"{self} is atomic")
 

--- a/qualtran/bloqs/basic_gates/x_basis.py
+++ b/qualtran/bloqs/basic_gates/x_basis.py
@@ -56,7 +56,7 @@ _MINUS = np.array([1, -1], dtype=np.complex128) / np.sqrt(2)
 _PAULIX = np.array([[0, 1], [1, 0]], dtype=np.complex128)
 
 
-class _XVector(metaclass=abc.ABCMeta):
+class _XVector(Bloq, metaclass=abc.ABCMeta):
     """The |+> or |-> state or effect.
 
     Please use the explicitly named subclasses instead of the boolean arguments.
@@ -127,7 +127,7 @@ class _XVector(metaclass=abc.ABCMeta):
 
 
 @frozen
-class PlusState(_XVector, Bloq):
+class PlusState(_XVector):
     """The state |+>"""
 
     @property
@@ -155,7 +155,7 @@ _PLUS_STATE_DOC = BloqDocSpec(bloq_cls=PlusState, examples=[_plus_state])
 
 
 @frozen
-class PlusEffect(_XVector, Bloq):
+class PlusEffect(_XVector):
     """The effect <+|"""
 
     @property
@@ -183,7 +183,7 @@ _PLUS_EFFECT_DOC = BloqDocSpec(bloq_cls=PlusEffect, examples=[_plus_effect])
 
 
 @frozen
-class MinusState(_XVector, Bloq):
+class MinusState(_XVector):
     """The state |->"""
 
     @property
@@ -211,7 +211,7 @@ _MINUS_STATE_DOC = BloqDocSpec(bloq_cls=MinusState, examples=[_minus_state])
 
 
 @frozen
-class MinusEffect(_XVector, Bloq):
+class MinusEffect(_XVector):
     """The effect <-|"""
 
     @property

--- a/qualtran/bloqs/basic_gates/x_basis.py
+++ b/qualtran/bloqs/basic_gates/x_basis.py
@@ -30,7 +30,6 @@ from qualtran import (
     CtrlSpec,
     DecomposeTypeError,
     QBit,
-    QVar,
     Register,
     Side,
     Signature,
@@ -125,7 +124,6 @@ class _XVector(metaclass=abc.ABCMeta):
             return Text('')
         s = '-' if self.bit else '+'
         return directional_text_box(s, side=reg.side)
-
 
 
 @frozen

--- a/qualtran/bloqs/basic_gates/x_basis.py
+++ b/qualtran/bloqs/basic_gates/x_basis.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import abc
 from functools import cached_property
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
@@ -25,9 +25,12 @@ from qualtran import (
     BloqBuilder,
     BloqDocSpec,
     CBit,
+    CompositeBloq,
     ConnectionT,
     CtrlSpec,
+    DecomposeTypeError,
     QBit,
+    QVar,
     Register,
     Side,
     Signature,
@@ -54,8 +57,7 @@ _MINUS = np.array([1, -1], dtype=np.complex128) / np.sqrt(2)
 _PAULIX = np.array([[0, 1], [1, 0]], dtype=np.complex128)
 
 
-@frozen
-class _XVector(Bloq):
+class _XVector(metaclass=abc.ABCMeta):
     """The |+> or |-> state or effect.
 
     Please use the explicitly named subclasses instead of the boolean arguments.
@@ -68,17 +70,20 @@ class _XVector(Bloq):
 
     """
 
-    bit: bool
-    state: bool = True
-    n: int = 1
+    @property
+    @abc.abstractmethod
+    def bit(self) -> bool: ...
 
-    def __attrs_post_init__(self):
-        if self.n != 1:
-            raise NotImplementedError("Come back later.")
+    @property
+    @abc.abstractmethod
+    def state(self) -> bool: ...
 
     @cached_property
     def signature(self) -> 'Signature':
         return Signature([Register('q', QBit(), side=Side.RIGHT if self.state else Side.LEFT)])
+
+    def decompose_bloq(self) -> 'CompositeBloq':
+        raise DecomposeTypeError(f"{self} is atomic")
 
     def my_tensors(
         self, incoming: Dict[str, 'ConnectionT'], outgoing: Dict[str, 'ConnectionT']
@@ -100,7 +105,7 @@ class _XVector(Bloq):
 
         import cirq
 
-        (q,) = qubit_manager.qalloc(self.n)
+        (q,) = qubit_manager.qalloc(n=1)
 
         if self.bit:
             op = cirq.CircuitOperation(cirq.FrozenCircuit(cirq.X(q), cirq.H(q)))
@@ -129,15 +134,23 @@ def _hide_base_fields(cls, fields):
     ]
 
 
-@frozen(init=False, field_transformer=_hide_base_fields)
-class PlusState(_XVector):
+@frozen
+class PlusState(_XVector, Bloq):
     """The state |+>"""
 
-    def __init__(self, n: int = 1):
-        self.__attrs_init__(bit=False, state=True, n=n)
+    @property
+    def state(self) -> bool:
+        return True
+
+    @property
+    def bit(self) -> bool:
+        return False
 
     def adjoint(self) -> 'Bloq':
         return PlusEffect()
+
+    def __str__(self):
+        return 'PlusState'
 
 
 @bloq_example
@@ -150,14 +163,22 @@ _PLUS_STATE_DOC = BloqDocSpec(bloq_cls=PlusState, examples=[_plus_state])
 
 
 @frozen(init=False, field_transformer=_hide_base_fields)
-class PlusEffect(_XVector):
+class PlusEffect(_XVector, Bloq):
     """The effect <+|"""
 
-    def __init__(self, n: int = 1):
-        self.__attrs_init__(bit=False, state=False, n=n)
+    @property
+    def state(self) -> bool:
+        return False
+
+    @property
+    def bit(self) -> bool:
+        return False
 
     def adjoint(self) -> 'Bloq':
         return PlusState()
+
+    def __str__(self):
+        return 'PlusEffect'
 
 
 @bloq_example
@@ -169,15 +190,22 @@ def _plus_effect() -> PlusEffect:
 _PLUS_EFFECT_DOC = BloqDocSpec(bloq_cls=PlusEffect, examples=[_plus_effect])
 
 
-@frozen(init=False, field_transformer=_hide_base_fields)
-class MinusState(_XVector):
+class MinusState(_XVector, Bloq):
     """The state |->"""
 
-    def __init__(self, n: int = 1):
-        self.__attrs_init__(bit=True, state=True, n=n)
+    @property
+    def bit(self) -> bool:
+        return True
+
+    @property
+    def state(self) -> bool:
+        return True
 
     def adjoint(self) -> 'Bloq':
         return MinusEffect()
+
+    def __str__(self):
+        return 'MinusState'
 
 
 @bloq_example
@@ -190,14 +218,22 @@ _MINUS_STATE_DOC = BloqDocSpec(bloq_cls=MinusState, examples=[_minus_state])
 
 
 @frozen(init=False, field_transformer=_hide_base_fields)
-class MinusEffect(_XVector):
+class MinusEffect(_XVector, Bloq):
     """The effect <-|"""
 
-    def __init__(self, n: int = 1):
-        self.__attrs_init__(bit=True, state=False, n=n)
+    @property
+    def bit(self) -> bool:
+        return True
+
+    @property
+    def state(self) -> bool:
+        return False
 
     def adjoint(self) -> 'Bloq':
         return MinusState()
+
+    def __str__(self):
+        return 'MinusEffect'
 
 
 @bloq_example
@@ -219,6 +255,10 @@ class XGate(Bloq):
     @cached_property
     def signature(self) -> 'Signature':
         return Signature.build(q=1)
+
+
+    def decompose_bloq(self) -> 'CompositeBloq':
+        raise DecomposeTypeError(f"{self} is atomic")
 
     def adjoint(self) -> 'Bloq':
         return self
@@ -275,7 +315,7 @@ class XGate(Bloq):
         from qualtran.drawing import ModPlus
 
         if reg is None:
-            return Text('X')
+            return Text('')
 
         return ModPlus()
 

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -156,12 +156,6 @@ class _ZVector(Bloq, metaclass=abc.ABCMeta):
         return directional_text_box(s, side=reg.side)
 
 
-def _hide_base_fields(cls, fields):
-    # for use in attrs `field_transformer`.
-    return [
-        field.evolve(repr=False) if field.name in ['bit', 'state'] else field for field in fields
-    ]
-
 
 @frozen
 class ZeroState(_ZVector):
@@ -219,7 +213,7 @@ def _zero_effect() -> ZeroEffect:
 _ZERO_EFFECT_DOC = BloqDocSpec(bloq_cls=ZeroEffect, examples=[_zero_effect])
 
 
-@frozen(init=False, field_transformer=_hide_base_fields)
+@frozen
 class OneState(_ZVector):
     """The state |1>"""
 
@@ -247,7 +241,7 @@ def _one_state() -> OneState:
 _ONE_STATE_DOC = BloqDocSpec(bloq_cls=OneState, examples=[_one_state])
 
 
-@frozen(init=False, field_transformer=_hide_base_fields)
+@frozen
 class OneEffect(_ZVector):
     """The effect <1|"""
 

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -14,7 +14,6 @@
 import abc
 from functools import cached_property
 from typing import (
-    cast,
     Dict,
     Iterable,
     List,
@@ -30,7 +29,6 @@ from typing import (
 import numpy as np
 import sympy
 from attrs import frozen
-from numpy.typing import NDArray
 
 from qualtran import (
     AddControlledT,
@@ -44,19 +42,14 @@ from qualtran import (
     CtrlSpec,
     DecomposeTypeError,
     QBit,
-    QDType,
-    QInt,
     QUInt,
-    QVar,
     Register,
     Side,
     Signature,
-    Soquet,
     SoquetT,
 )
-from qualtran.bloqs.bookkeeping import ArbitraryClifford
 from qualtran.drawing import Circle, directional_text_box, Text, TextBox, WireSymbol
-from qualtran.symbolics import is_symbolic, SymbolicInt
+from qualtran.symbolics import SymbolicInt
 
 if TYPE_CHECKING:
     import cirq
@@ -154,7 +147,6 @@ class _ZVector(Bloq, metaclass=abc.ABCMeta):
             return Text('')
         s = '1' if self.bit else '0'
         return directional_text_box(s, side=reg.side)
-
 
 
 @frozen

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -524,6 +524,7 @@ class IntState(Bloq):
     @cached_property
     def _impl(self):
         from qualtran.bloqs.basic_gates.qconst import _QConst
+
         return _QConst(val=self.val, qdtype=QUInt(self.bitsize), state=True)
 
     @property
@@ -591,6 +592,7 @@ class IntEffect(Bloq):
     @cached_property
     def _impl(self):
         from qualtran.bloqs.basic_gates.qconst import _QConst
+
         return _QConst(val=self.val, qdtype=QUInt(self.bitsize), state=False)
 
     @property

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -535,8 +535,8 @@ class IntState(Bloq):
     ) -> 'WireSymbol':
         return self._impl.wire_symbol(reg, idx)
 
-    def __str__(self):
-        return f'IntState({self.val})'
+    def __str__(self) -> str:
+        return f'|{self.val}>'
 
 
 @bloq_example
@@ -603,8 +603,8 @@ class IntEffect(Bloq):
     ) -> 'WireSymbol':
         return self._impl.wire_symbol(reg, idx)
 
-    def __str__(self):
-        return f'IntEffect({self.val})'
+    def __str__(self) -> str:
+        return f'<{self.val}|'
 
 
 @bloq_example

--- a/qualtran/bloqs/basic_gates/z_basis.py
+++ b/qualtran/bloqs/basic_gates/z_basis.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import abc
 from functools import cached_property
 from typing import (
     cast,
@@ -21,12 +21,12 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Set,
     Tuple,
     TYPE_CHECKING,
     Union,
 )
 
-import attrs
 import numpy as np
 import sympy
 from attrs import frozen
@@ -43,9 +43,11 @@ from qualtran import (
     ConnectionT,
     CtrlSpec,
     DecomposeTypeError,
-    QAny,
     QBit,
     QDType,
+    QInt,
+    QUInt,
+    QVar,
     Register,
     Side,
     Signature,
@@ -54,7 +56,7 @@ from qualtran import (
 )
 from qualtran.bloqs.bookkeeping import ArbitraryClifford
 from qualtran.drawing import Circle, directional_text_box, Text, TextBox, WireSymbol
-from qualtran.symbolics import SymbolicInt
+from qualtran.symbolics import is_symbolic, SymbolicInt
 
 if TYPE_CHECKING:
     import cirq
@@ -63,7 +65,7 @@ if TYPE_CHECKING:
     from pennylane.wires import Wires
 
     from qualtran.cirq_interop import CirqQuregT
-    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
+    from qualtran.resource_counting import BloqCountDictT, BloqCountT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValRetT, ClassicalValT
 
 _ZERO = np.array([1, 0], dtype=np.complex128)
@@ -71,8 +73,7 @@ _ONE = np.array([0, 1], dtype=np.complex128)
 _PAULIZ = np.array([[1, 0], [0, -1]], dtype=np.complex128)
 
 
-@frozen
-class _ZVector(Bloq):
+class _ZVector(Bloq, metaclass=abc.ABCMeta):
     """The |0> or |1> state or effect.
 
     Please use the explicitly named subclasses instead of the boolean arguments.
@@ -85,13 +86,13 @@ class _ZVector(Bloq):
 
     """
 
-    bit: bool
-    state: bool = True
-    n: int = 1
+    @property
+    @abc.abstractmethod
+    def bit(self) -> bool: ...
 
-    def __attrs_post_init__(self):
-        if self.n != 1:
-            raise NotImplementedError("Come back later.")
+    @property
+    @abc.abstractmethod
+    def state(self) -> bool: ...
 
     @cached_property
     def signature(self) -> 'Signature':
@@ -134,7 +135,7 @@ class _ZVector(Bloq):
 
         import cirq
 
-        (q,) = qubit_manager.qalloc(self.n)
+        (q,) = qubit_manager.qalloc(1)
 
         if self.bit:
             op = cirq.X(q)
@@ -162,15 +163,23 @@ def _hide_base_fields(cls, fields):
     ]
 
 
-@frozen(init=False, field_transformer=_hide_base_fields)
+@frozen
 class ZeroState(_ZVector):
     """The state |0>"""
 
-    def __init__(self, n: int = 1):
-        self.__attrs_init__(bit=False, state=True, n=n)
+    @property
+    def bit(self) -> bool:
+        return False
+
+    @property
+    def state(self) -> bool:
+        return True
 
     def adjoint(self) -> 'Bloq':
         return ZeroEffect()
+
+    def __str__(self):
+        return 'ZeroState'
 
 
 @bloq_example
@@ -182,15 +191,23 @@ def _zero_state() -> ZeroState:
 _ZERO_STATE_DOC = BloqDocSpec(bloq_cls=ZeroState, examples=[_zero_state])
 
 
-@frozen(init=False, field_transformer=_hide_base_fields)
+@frozen
 class ZeroEffect(_ZVector):
     """The effect <0|"""
 
-    def __init__(self, n: int = 1):
-        self.__attrs_init__(bit=False, state=False, n=n)
+    @property
+    def bit(self) -> bool:
+        return False
+
+    @property
+    def state(self) -> bool:
+        return False
 
     def adjoint(self) -> 'Bloq':
         return ZeroState()
+
+    def __str__(self):
+        return 'ZeroEffect'
 
 
 @bloq_example
@@ -206,11 +223,19 @@ _ZERO_EFFECT_DOC = BloqDocSpec(bloq_cls=ZeroEffect, examples=[_zero_effect])
 class OneState(_ZVector):
     """The state |1>"""
 
-    def __init__(self, n: int = 1):
-        self.__attrs_init__(bit=True, state=True, n=n)
+    @property
+    def bit(self) -> bool:
+        return True
+
+    @property
+    def state(self) -> bool:
+        return True
 
     def adjoint(self) -> 'Bloq':
         return OneEffect()
+
+    def __str__(self):
+        return 'OneState'
 
 
 @bloq_example
@@ -226,11 +251,19 @@ _ONE_STATE_DOC = BloqDocSpec(bloq_cls=OneState, examples=[_one_state])
 class OneEffect(_ZVector):
     """The effect <1|"""
 
-    def __init__(self, n: int = 1):
-        self.__attrs_init__(bit=True, state=False, n=n)
+    @property
+    def bit(self) -> bool:
+        return True
+
+    @property
+    def state(self) -> bool:
+        return False
 
     def adjoint(self) -> 'Bloq':
         return OneState()
+
+    def __str__(self):
+        return 'OneEffect'
 
 
 @bloq_example
@@ -420,6 +453,9 @@ class MeasureZ(Bloq):
     def on_classical_vals(self, q: int) -> Mapping[str, 'ClassicalValRetT']:
         return {'c': q}
 
+    def decompose_bloq(self) -> 'CompositeBloq':
+        raise DecomposeTypeError(f"{self} is atomic.")
+
     def my_tensors(
         self, incoming: Dict[str, 'ConnectionT'], outgoing: Dict[str, 'ConnectionT']
     ) -> List['qtn.Tensor']:
@@ -439,6 +475,15 @@ class MeasureZ(Bloq):
         )
         return [t, DiscardInd((meas_result, 0))]
 
+    def as_cirq_op(
+        self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'  # type: ignore[type-var]
+    ) -> Tuple[Union['cirq.Operation', None], Dict[str, 'CirqQuregT']]:  # type: ignore[type-var]
+
+        import cirq
+
+        (q,) = cirq_quregs['q']
+        return cirq.measure(q), {}
+
 
 @bloq_example
 def _meas_z() -> MeasureZ:
@@ -450,100 +495,11 @@ _MEASURE_Z_DOC = BloqDocSpec(bloq_cls=MeasureZ, examples=[_meas_z])
 
 
 @frozen
-class _IntVector(Bloq):
-    """Represent a classical non-negative integer vector (state or effect).
+class IntState(Bloq):
+    """The state |val> for non-negative (unsigned) integer val
 
-    Args:
-        val: the classical value
-        bitsize: The bitsize of the register
-        state: True if this is a state; an effect otherwise.
-
-    Registers:
-        val: The register of size `bitsize` which initializes the value `val`.
-    """
-
-    val: Union[int, sympy.Expr] = attrs.field()
-    bitsize: Union[int, sympy.Expr]
-    state: bool
-
-    @val.validator
-    def check(self, attribute, val):
-        if isinstance(val, sympy.Expr) or isinstance(self.bitsize, sympy.Expr):
-            return
-
-        if val < 0:
-            raise ValueError("`val` must be positive")
-
-        if val >= 2**self.bitsize:
-            raise ValueError(f"`val` is too big for bitsize {self.bitsize}")
-
-    @cached_property
-    def dtype(self) -> QDType:
-        if self.bitsize == 1:
-            return QBit()
-        return QAny(self.bitsize)
-
-    @cached_property
-    def signature(self) -> Signature:
-        side = Side.RIGHT if self.state else Side.LEFT
-        return Signature([Register('val', self.dtype, side=side)])
-
-    @staticmethod
-    def _build_composite_state(bb: 'BloqBuilder', bits: NDArray[np.uint8]) -> Dict[str, 'SoquetT']:
-        states = [ZeroState(), OneState()]
-        xs = []
-        for bit in bits:
-            x = bb.add(states[bit])
-            xs.append(x)
-        xs = np.array(xs)
-
-        return {'val': bb.join(xs)}
-
-    @staticmethod
-    def _build_composite_effect(
-        bb: 'BloqBuilder', val: 'Soquet', bits: NDArray[np.uint8]
-    ) -> Dict[str, 'SoquetT']:
-        xs = bb.split(val)
-        effects = [ZeroEffect(), OneEffect()]
-        for i, bit in enumerate(bits):
-            bb.add(effects[bit], q=xs[i])
-        return {}
-
-    def build_composite_bloq(self, bb: 'BloqBuilder', **val: 'SoquetT') -> Dict[str, 'SoquetT']:
-        if isinstance(self.bitsize, sympy.Expr):
-            raise DecomposeTypeError(f'Symbolic bitsize {self.bitsize} not supported')
-        bits = np.asarray(self.dtype.to_bits(self.val))
-        if self.state:
-            assert not val
-            return self._build_composite_state(bb, bits)
-        else:
-            return self._build_composite_effect(bb, cast(Soquet, val['val']), bits)
-
-    def on_classical_vals(self, *, val: Optional[int] = None) -> Dict[str, Union[int, sympy.Expr]]:
-        if self.state:
-            assert val is None
-            return {'val': self.val}
-
-        assert val == self.val, val
-        return {}
-
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
-        return {ArbitraryClifford(self.bitsize): 1}
-
-    def __str__(self) -> str:
-        s = f'{self.val}'
-        return f'|{s}>' if self.state else f'<{s}|'
-
-    def wire_symbol(self, reg: Optional[Register], idx: Tuple[int, ...] = tuple()) -> 'WireSymbol':
-        if reg is None:
-            return Text('')
-
-        return directional_text_box(text=f'{self.val}', side=reg.side)
-
-
-@frozen(init=False, field_transformer=_hide_base_fields)
-class IntState(_IntVector):
-    """The state |val> for non-negative integer val
+    Please prefer QUIntState for new code, which makes it clear that the resultant
+    datatype is a `QUInt` unsigned integer.
 
     Args:
         val: the classical value
@@ -553,8 +509,47 @@ class IntState(_IntVector):
         val: The register of size `bitsize` which initializes the value `val`.
     """
 
-    def __init__(self, val: SymbolicInt, bitsize: SymbolicInt):
-        self.__attrs_init__(val=val, bitsize=bitsize, state=True)
+    val: SymbolicInt
+    bitsize: SymbolicInt
+
+    def __attrs_post_init__(self):
+        import warnings
+
+        warnings.warn(
+            "IntState will be deprecated. Use QUIntState instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+
+    @cached_property
+    def _impl(self):
+        from qualtran.bloqs.basic_gates.qconst import _QConst
+        return _QConst(val=self.val, qdtype=QUInt(self.bitsize), state=True)
+
+    @property
+    def signature(self) -> 'Signature':
+        return self._impl.signature
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
+        return self._impl.build_composite_bloq(bb, **soqs)
+
+    def on_classical_vals(
+        self, **vals: Union['sympy.Symbol', 'ClassicalValT']
+    ) -> Mapping[str, 'ClassicalValRetT']:
+        return self._impl.on_classical_vals(**vals)
+
+    def build_call_graph(
+        self, ssa: 'SympySymbolAllocator'
+    ) -> Union['BloqCountDictT', Set['BloqCountT']]:
+        return self._impl.build_call_graph(ssa)
+
+    def wire_symbol(
+        self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
+    ) -> 'WireSymbol':
+        return self._impl.wire_symbol(reg, idx)
+
+    def __str__(self):
+        return f'IntState({self.val})'
 
 
 @bloq_example
@@ -566,9 +561,12 @@ def _int_state() -> IntState:
 _INT_STATE_DOC = BloqDocSpec(bloq_cls=IntState, examples=[_int_state])
 
 
-@frozen(init=False, field_transformer=_hide_base_fields)
-class IntEffect(_IntVector):
+@frozen
+class IntEffect(Bloq):
     """The effect <val| for non-negative integer val
+
+    Please prefer QUIntEffect for new code, which makes it clear that the incoming
+    datatype is a `QUInt` unsigned integer.
 
     Args:
         val: the classical value
@@ -578,8 +576,47 @@ class IntEffect(_IntVector):
         val: The register of size `bitsize` which de-allocates the value `val`.
     """
 
-    def __init__(self, val: SymbolicInt, bitsize: SymbolicInt):
-        self.__attrs_init__(val=val, bitsize=bitsize, state=False)
+    val: SymbolicInt
+    bitsize: SymbolicInt
+
+    def __attrs_post_init__(self):
+        import warnings
+
+        warnings.warn(
+            "IntEffect is deprecated. Use QUIntEffect instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+
+    @cached_property
+    def _impl(self):
+        from qualtran.bloqs.basic_gates.qconst import _QConst
+        return _QConst(val=self.val, qdtype=QUInt(self.bitsize), state=False)
+
+    @property
+    def signature(self) -> 'Signature':
+        return self._impl.signature
+
+    def build_composite_bloq(self, bb: 'BloqBuilder', **soqs: 'SoquetT') -> Dict[str, 'SoquetT']:
+        return self._impl.build_composite_bloq(bb, **soqs)
+
+    def on_classical_vals(
+        self, **vals: Union['sympy.Symbol', 'ClassicalValT']
+    ) -> Mapping[str, 'ClassicalValRetT']:
+        return self._impl.on_classical_vals(**vals)
+
+    def build_call_graph(
+        self, ssa: 'SympySymbolAllocator'
+    ) -> Union['BloqCountDictT', Set['BloqCountT']]:
+        return self._impl.build_call_graph(ssa)
+
+    def wire_symbol(
+        self, reg: Optional['Register'], idx: Tuple[int, ...] = tuple()
+    ) -> 'WireSymbol':
+        return self._impl.wire_symbol(reg, idx)
+
+    def __str__(self):
+        return f'IntEffect({self.val})'
 
 
 @bloq_example

--- a/qualtran/bloqs/basic_gates/z_basis_test.py
+++ b/qualtran/bloqs/basic_gates/z_basis_test.py
@@ -76,7 +76,7 @@ def test_int_effect(bloq_autotester):
 
 def test_zero_state_manual():
     bloq = ZeroState()
-    assert str(bloq) == '|0>'
+    assert str(bloq) == 'ZeroState'
     assert not bloq.bit
     vector = bloq.tensor_contract()
     should_be = np.array([1, 0])
@@ -86,13 +86,6 @@ def test_zero_state_manual():
     assert x == 0
 
     assert get_cost_value(bloq, QECGatesCost()) == GateCounts()
-
-
-def test_multiq_zero_state():
-    # Verifying the attrs trickery that I can plumb through *some*
-    # of the attributes but pre-specify others.
-    with pytest.raises(NotImplementedError):
-        _ = ZeroState(n=10)
 
 
 def test_one_state_manual():
@@ -167,21 +160,21 @@ def test_zero_state_effect(bit):
 
 def test_int_state_manual():
     k = IntState(255, bitsize=8)
-    assert str(k) == '|255>'
+    assert str(k) == 'IntState(255)'
     (val,) = k.call_classically()
     assert val == 255
 
     with pytest.raises(ValueError):
-        _ = IntState(255, bitsize=7)
+        IntState(255, bitsize=7).call_classically()
     with pytest.raises(ValueError):
-        _ = IntState(-1, bitsize=8)
+        _ = IntState(-1, bitsize=8).call_classically()
 
     np.testing.assert_allclose(k.tensor_contract(), k.decompose_bloq().tensor_contract())
 
 
 def test_int_effect_manual():
     k = IntEffect(255, bitsize=8)
-    assert str(k) == '<255|'
+    assert str(k) == 'IntEffect(255)'
     ret = k.call_classically(val=255)
     assert ret == ()
 
@@ -236,6 +229,11 @@ def test_zgate_manual():
 
     assert bloq_is_clifford(z)
     assert t_complexity(z) == TComplexity(clifford=1)
+
+
+def test_z_isnt_classical():
+    with pytest.raises(ValueError, match=r'imparts a phase.*'):
+        ZGate().call_classically(q=1)
 
 
 def test_cz_manual():

--- a/qualtran/bloqs/basic_gates/z_basis_test.py
+++ b/qualtran/bloqs/basic_gates/z_basis_test.py
@@ -160,7 +160,7 @@ def test_zero_state_effect(bit):
 
 def test_int_state_manual():
     k = IntState(255, bitsize=8)
-    assert str(k) == 'IntState(255)'
+    assert str(k) == '|255>'
     (val,) = k.call_classically()
     assert val == 255
 
@@ -174,7 +174,7 @@ def test_int_state_manual():
 
 def test_int_effect_manual():
     k = IntEffect(255, bitsize=8)
-    assert str(k) == 'IntEffect(255)'
+    assert str(k) == '<255|'
     ret = k.call_classically(val=255)
     assert ret == ()
 

--- a/qualtran/serialization/resolver_dict.py
+++ b/qualtran/serialization/resolver_dict.py
@@ -39,6 +39,7 @@ import qualtran.bloqs.basic_gates.s_gate
 import qualtran.bloqs.basic_gates.swap
 import qualtran.bloqs.basic_gates.t_gate
 import qualtran.bloqs.basic_gates.toffoli
+import qualtran.bloqs.basic_gates.qconst
 import qualtran.bloqs.basic_gates.x_basis
 import qualtran.bloqs.basic_gates.y_gate
 import qualtran.bloqs.basic_gates.z_basis
@@ -253,6 +254,10 @@ RESOLVER_DICT = {
     "qualtran.bloqs.basic_gates.x_basis.XGate": qualtran.bloqs.basic_gates.x_basis.XGate,
     "qualtran.bloqs.basic_gates.y_gate.YGate": qualtran.bloqs.basic_gates.y_gate.YGate,
     "qualtran.bloqs.basic_gates.y_gate.CYGate": qualtran.bloqs.basic_gates.y_gate.CYGate,
+    "qualtran.bloqs.basic_gates.qconst.QIntEffect": qualtran.bloqs.basic_gates.qconst.QIntEffect,
+    "qualtran.bloqs.basic_gates.qconst.QIntState": qualtran.bloqs.basic_gates.qconst.QIntState,
+    "qualtran.bloqs.basic_gates.qconst.QUIntEffect": qualtran.bloqs.basic_gates.qconst.QUIntEffect,
+    "qualtran.bloqs.basic_gates.qconst.QUIntState": qualtran.bloqs.basic_gates.qconst.QUIntState,
     "qualtran.bloqs.basic_gates.z_basis.IntEffect": qualtran.bloqs.basic_gates.z_basis.IntEffect,
     "qualtran.bloqs.basic_gates.z_basis.IntState": qualtran.bloqs.basic_gates.z_basis.IntState,
     "qualtran.bloqs.basic_gates.z_basis.OneEffect": qualtran.bloqs.basic_gates.z_basis.OneEffect,

--- a/qualtran/serialization/resolver_dict.py
+++ b/qualtran/serialization/resolver_dict.py
@@ -34,12 +34,12 @@ import qualtran.bloqs.basic_gates.cnot
 import qualtran.bloqs.basic_gates.hadamard
 import qualtran.bloqs.basic_gates.identity
 import qualtran.bloqs.basic_gates.on_each
+import qualtran.bloqs.basic_gates.qconst
 import qualtran.bloqs.basic_gates.rotation
 import qualtran.bloqs.basic_gates.s_gate
 import qualtran.bloqs.basic_gates.swap
 import qualtran.bloqs.basic_gates.t_gate
 import qualtran.bloqs.basic_gates.toffoli
-import qualtran.bloqs.basic_gates.qconst
 import qualtran.bloqs.basic_gates.x_basis
 import qualtran.bloqs.basic_gates.y_gate
 import qualtran.bloqs.basic_gates.z_basis

--- a/qualtran/simulation/xcheck_classical_quimb.py
+++ b/qualtran/simulation/xcheck_classical_quimb.py
@@ -27,8 +27,8 @@ if TYPE_CHECKING:
 def _add_classical_kets(
     bb: BloqBuilder, registers: Iterable[Register], vals: Dict[str, 'ClassicalValT']
 ) -> Dict[str, 'SoquetT']:
-    """Use `bb` to add `IntState` for all the `vals`."""
-    from qualtran.bloqs.basic_gates import IntState
+    """Use `bb` to add `QUIntState` for all the `vals`."""
+    from qualtran.bloqs.basic_gates import QUIntState
 
     soqs: Dict[str, 'SoquetT'] = {}
     for reg in registers:
@@ -36,9 +36,9 @@ def _add_classical_kets(
             reg_vals = np.asarray(vals[reg.name])
             soq = np.empty(reg.shape, dtype=object)
             for idx in reg.all_idxs():
-                soq[idx] = bb.add(IntState(val=reg_vals[idx], bitsize=reg.bitsize))
+                soq[idx] = bb.add(QUIntState(val=reg_vals[idx], bitsize=reg.bitsize))
         else:
-            soq = bb.add(IntState(val=cast(int, vals[reg.name]), bitsize=reg.bitsize))
+            soq = bb.add(QUIntState(val=cast(int, vals[reg.name]), bitsize=reg.bitsize))
 
         soqs[reg.name] = soq
     return soqs
@@ -50,8 +50,8 @@ def _add_classical_bras(
     vals: Dict[str, 'ClassicalValT'],
     soqs: Dict[str, 'SoquetT'],
 ) -> None:
-    """Use `bb` to add `IntEffect` on `soqs` for all the `vals`."""
-    from qualtran.bloqs.basic_gates import IntEffect
+    """Use `bb` to add `QUIntEffect` on `soqs` for all the `vals`."""
+    from qualtran.bloqs.basic_gates import QUIntEffect
 
     for reg in registers:
         if reg.shape:
@@ -60,10 +60,10 @@ def _add_classical_bras(
             if not BloqBuilder.is_ndarray(reg_name):
                 raise ValueError(f'soqs {reg.name} must be a numpy array: {soqs[reg.name]}')
             for idx in reg.all_idxs():
-                bb.add(IntEffect(val=reg_vals[idx], bitsize=reg.bitsize), val=reg_name[idx])
+                bb.add(QUIntEffect(val=reg_vals[idx], bitsize=reg.bitsize), val=reg_name[idx])
         else:
             bb.add(
-                IntEffect(val=cast(int, vals[reg.name]), bitsize=reg.bitsize), val=soqs[reg.name]
+                QUIntEffect(val=cast(int, vals[reg.name]), bitsize=reg.bitsize), val=soqs[reg.name]
             )
 
 


### PR DESCRIPTION
QIntState preceded the quantum data types, and is a bit of a misnomer as it generates an unsigned integer representation. With this PR, I've kept QIntState for backwards compatibility and added a PendingDeprecationWarning.

This PR adds QIntState and QUIntState with 1:1 mapping to their QDType. More such "quantum constants" can be added. Fixes https://github.com/quantumlib/Qualtran/issues/1165

I've also refactored the Zero/OneState/Effect bloq classes to avoid the strange attrs field overloading because it does not play nice with any metaprogramming one might want to do to e.g. extract fields from bloq classes. 