### PR TITLE
Activate tests on minimal dependency install, part 2/n 

### DIFF
--- a/check/pytest-minimal-install
+++ b/check/pytest-minimal-install
@@ -17,7 +17,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 echo "=== Verifying optional packages are NOT installed ==="
-OPTIONAL_PACKAGES=(galois fxpmath quimb pydot protobuf pennylane IPython dash)
+OPTIONAL_PACKAGES=(galois fxpmath quimb pydot google.protobuf pennylane IPython dash)
 for pkg in "${OPTIONAL_PACKAGES[@]}"; do
     if python -c "import $pkg" 2>/dev/null; then
         echo "ERROR: '$pkg' is installed. Environment is not minimal."

--- a/check/pytest-minimal-install
+++ b/check/pytest-minimal-install
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-# Run pytest on qualtran's core directories, verifying that only minimal
-# dependencies are present.
+# Run pytest on a subset of qualtran that only requires minimal dependencies.
+#
+# This script runs tests for the entire qualtran package, excluding directories
+# and files that require optional dependencies not in requirements-minimal.txt.
 #
 # Prerequisites: the current Python environment must have qualtran installed
 # (with --no-deps) plus only the packages in requirements-minimal.txt and
-# pytest. See dev_tools/minimal-installs.md for setup instructions.
+# pytest.
 #
 # Usage:
-#   ./dev_tools/pytest-minimal-install
+#   ./check/pytest-minimal-install
 
 set -euo pipefail
 
@@ -24,20 +26,18 @@ for pkg in "${OPTIONAL_PACKAGES[@]}"; do
     echo "  ✓ $pkg is not installed (expected)"
 done
 
-pytest                                                                        \
-    qualtran/_infra/                                                          \
-    qualtran/dtype/                                                           \
-    qualtran/bloqs/manifest_test.py                                           \
-    qualtran/symbolics/                                                       \
-    qualtran/linalg/                                                          \
-    qualtran/bloqify_syntax/                                                  \
-    qualtran/l1/                                                              \
-    qualtran/rotation_synthesis/                                              \
-    qualtran/testing_test.py                                                  \
-    qualtran/resource_counting/                                               \
-    qualtran/surface_code/                                                    \
-    qualtran/cirq_interop/                                                    \
-    qualtran/simulation/classical_sim_test.py                                 \
-    --ignore=qualtran/surface_code/ui_test.py                                 \
-    --ignore=qualtran/cirq_interop/jupyter_tools_test.py                      \
+pytest                                                                      \
+    qualtran/                                                               \
+    qualtran/bloqs/manifest_test.py                                         \
+    --ignore=qualtran/bloqs/                                                \
+    --ignore=qualtran/serialization/                                        \
+    --ignore=qualtran/qref_interop/                                         \
+    --ignore=qualtran/simulation/tensor/                                    \
+    --ignore=qualtran/simulation/xcheck_classical_quimb_test.py             \
+    --ignore=qualtran/surface_code/ui_test.py                               \
+    --ignore=qualtran/cirq_interop/jupyter_tools_test.py                    \
+    --ignore=qualtran/drawing/graphviz_test.py                              \
+    --ignore=qualtran/drawing/bloq_counts_graph_test.py                     \
+    --ignore=qualtran/drawing/classical_sim_graph_test.py                   \
+    --ignore=qualtran/drawing/flame_graph_test.py                           \
     -m 'not slow' -v "$@"

--- a/check/pytest-minimal-install
+++ b/check/pytest-minimal-install
@@ -15,7 +15,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 echo "=== Verifying optional packages are NOT installed ==="
-OPTIONAL_PACKAGES=(galois fxpmath quimb pydot)
+OPTIONAL_PACKAGES=(galois fxpmath quimb pydot protobuf pennylane IPython dash)
 for pkg in "${OPTIONAL_PACKAGES[@]}"; do
     if python -c "import $pkg" 2>/dev/null; then
         echo "ERROR: '$pkg' is installed. Environment is not minimal."
@@ -24,8 +24,20 @@ for pkg in "${OPTIONAL_PACKAGES[@]}"; do
     echo "  ✓ $pkg is not installed (expected)"
 done
 
-pytest                               \
-    qualtran/_infra/                 \
-    qualtran/dtype/                  \
-    qualtran/bloqs/manifest_test.py  \
-    -v "$@"
+pytest                                                                        \
+    qualtran/_infra/                                                          \
+    qualtran/dtype/                                                           \
+    qualtran/bloqs/manifest_test.py                                           \
+    qualtran/symbolics/                                                       \
+    qualtran/linalg/                                                          \
+    qualtran/bloqify_syntax/                                                  \
+    qualtran/l1/                                                              \
+    qualtran/rotation_synthesis/                                              \
+    qualtran/testing_test.py                                                  \
+    qualtran/resource_counting/                                               \
+    qualtran/surface_code/                                                    \
+    qualtran/cirq_interop/                                                    \
+    qualtran/simulation/classical_sim_test.py                                 \
+    --ignore=qualtran/surface_code/ui_test.py                                 \
+    --ignore=qualtran/cirq_interop/jupyter_tools_test.py                      \
+    -m 'not slow' -v "$@"

--- a/check/pytest-minimal-install
+++ b/check/pytest-minimal-install
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Run pytest on a subset of qualtran that only requires minimal dependencies.
+# Run pytest on qualtran, verifying that only minimal dependencies are present.
 #
 # This script runs tests for the entire qualtran package, excluding directories
 # and files that require optional dependencies not in requirements-minimal.txt.
 #
 # Prerequisites: the current Python environment must have qualtran installed
 # (with --no-deps) plus only the packages in requirements-minimal.txt and
-# pytest.
+# pytest. See dev_tools/minimal-installs.md for setup instructions.
 #
 # Usage:
 #   ./check/pytest-minimal-install
@@ -28,7 +28,6 @@ done
 
 pytest                                                                      \
     qualtran/                                                               \
-    qualtran/bloqs/manifest_test.py                                         \
     --ignore=qualtran/bloqs/                                                \
     --ignore=qualtran/serialization/                                        \
     --ignore=qualtran/qref_interop/                                         \
@@ -41,3 +40,6 @@ pytest                                                                      \
     --ignore=qualtran/drawing/classical_sim_graph_test.py                   \
     --ignore=qualtran/drawing/flame_graph_test.py                           \
     -m 'not slow' -v "$@"
+
+# Run manifest_test.py separately to verify all bloq classes can be imported.
+pytest qualtran/bloqs/manifest_test.py -v "$@"

--- a/qualtran/cirq_interop/_bloq_to_cirq_test.py
+++ b/qualtran/cirq_interop/_bloq_to_cirq_test.py
@@ -107,6 +107,7 @@ class SwapTestWithOnlyTensorData(Bloq):
 
 @pytest.mark.parametrize('n', [1, 2, 3, 4])
 def test_bloq_as_cirq_gate_uses_tensor_data_for_unitary(n: int):
+    pytest.importorskip('quimb')
     unitary_one = cirq.unitary(BloqAsCirqGate(SwapTest(n)))
     unitary_two = cirq.unitary(BloqAsCirqGate(SwapTestWithOnlyTensorData(n)))
     np.testing.assert_allclose(unitary_one, unitary_two)
@@ -324,6 +325,7 @@ class ComputeUncompute(Bloq):
 
 
 def test_compute_uncompute_simulation():
+    pytest.importorskip('quimb')
     # From https://github.com/quantumlib/Qualtran/issues/1488
     u1 = ComputeUncompute().tensor_contract()
     u2 = cirq.unitary(BloqAsCirqGate(ComputeUncompute()))

--- a/qualtran/cirq_interop/_cirq_to_bloq_test.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq_test.py
@@ -226,9 +226,7 @@ def test_cirq_gate_as_bloq_for_left_only_gates():
     bloq = CirqGateAsBloq(gate=LeftOnlyGate())
     cbloq = qlt_testing.assert_valid_bloq_decomposition(bloq)
 
-    assert (
-        cbloq.debug_text()
-        == """\
+    assert cbloq.debug_text() == """\
 CNOT<0>
   LeftDangle.q[0] -> ctrl
   LeftDangle.q[1] -> target
@@ -241,7 +239,6 @@ cirq.reset<1>
 cirq.reset<2>
   CNOT<0>.target -> q
   q -> RightDangle.q[1]"""
-    )
 
 
 def test_gwr_for_left_only_gates():

--- a/qualtran/cirq_interop/_cirq_to_bloq_test.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq_test.py
@@ -83,6 +83,7 @@ def test_cirq_gate_as_bloq_for_trivial_gates():
 
 
 def test_cirq_gate_as_bloq_tensor_contract_for_and_gate():
+    pytest.importorskip('quimb')
     and_gate = And()
     bb = BloqBuilder()
     ctrl = [bb.add(OneState()) for _ in range(2)]
@@ -114,6 +115,7 @@ def test_bloq_decompose():
 
 
 def test_cirq_circuit_to_cbloq():
+    pytest.importorskip('quimb')
     qubits = cirq.LineQubit.range(6)
     circuit = cirq.testing.random_circuit(qubits, n_moments=7, op_density=1.0, random_state=52)
 
@@ -294,6 +296,7 @@ def test_cirq_optree_to_cbloq_op_conversion_method():
     When provided, op_conversion_method should be called for each operation
     instead of the default _extract_bloq_from_op.
     """
+    pytest.importorskip('quimb')
     qubits = cirq.LineQubit.range(3)
     circuit = cirq.Circuit(cirq.H(qubits[0]), cirq.CNOT(qubits[0], qubits[1]), cirq.T(qubits[2]))
 

--- a/qualtran/conftest.py
+++ b/qualtran/conftest.py
@@ -77,6 +77,7 @@ def assert_equivalent_bloq_example_counts_for_pytest(bloq_ex: BloqExample):
 
 
 def assert_bloq_example_serializes_for_pytest(bloq_ex: BloqExample):
+    pytest.importorskip('google.protobuf')
     if bloq_ex.name in [
         'prep_sparse',
         'thc_prep',

--- a/qualtran/resource_counting/_qubit_counts_test.py
+++ b/qualtran/resource_counting/_qubit_counts_test.py
@@ -24,7 +24,6 @@ from qualtran.bloqs.for_testing.with_decomposition import (
     TestIndependentParallelCombo,
     TestSerialCombo,
 )
-
 from qualtran.resource_counting import get_cost_cache, get_cost_value, QubitCount
 from qualtran.resource_counting._qubit_counts import _cbloq_max_width
 from qualtran.resource_counting.generalizers import ignore_split_join

--- a/qualtran/resource_counting/_qubit_counts_test.py
+++ b/qualtran/resource_counting/_qubit_counts_test.py
@@ -24,7 +24,7 @@ from qualtran.bloqs.for_testing.with_decomposition import (
     TestIndependentParallelCombo,
     TestSerialCombo,
 )
-from qualtran.drawing import show_bloq
+
 from qualtran.resource_counting import get_cost_cache, get_cost_value, QubitCount
 from qualtran.resource_counting._qubit_counts import _cbloq_max_width
 from qualtran.resource_counting.generalizers import ignore_split_join
@@ -56,7 +56,6 @@ def test_max_width_disconnected_components():
 
 
 def test_max_width_simple():
-    show_bloq(TestSerialCombo().decompose_bloq())
     max_width = _cbloq_max_width(TestSerialCombo().decompose_bloq()._binst_graph)
     assert max_width == 1
 

--- a/qualtran/simulation/classical_sim_test.py
+++ b/qualtran/simulation/classical_sim_test.py
@@ -263,6 +263,7 @@ def test_multidimensional_classical_sim_for_large_int():
 
 
 def test_multidimensional_classical_sim_for_gqf():
+    pytest.importorskip('galois')
     dtype = QGF(2, 2)
     x = dtype.gf_type.elements
     bloq = TestMultiDimensionalReg(dtype, len(x), (dtype.gf_type,))


### PR DESCRIPTION
 - switch from including subdirectories to the minimal install check to excluding incompatible directories
 - small fixes to enable a broader swath of testing