### PR TITLE
Fix compatibility with Cirq >= 1.7 CYPowGate

### DIFF
--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -416,14 +416,15 @@ def cirq_gate_to_bloq(gate: cirq.Gate) -> Bloq:
         cirq.TOFFOLI: Toffoli(),
         cirq.X: XGate(),
         cirq.Y: YGate(),
-        # cirq.CY in Cirq >= 1.7
-        getattr(cirq, 'CY', cirq.ControlledGate(cirq.Y)): CYGate(),
+        cirq.ControlledGate(cirq.Y): CYGate(),
         cirq.Z: ZGate(),
         cirq.CZ: CZ(),
         cirq.SWAP: TwoBitSwap(),
         cirq.CSWAP: CSwap(1),
         cirq.I: Identity(),
     }
+    if hasattr(cirq, 'CY'):
+        CIRQ_GATE_TO_BLOQ_MAP[cirq.CY] = CYGate()  # cirq >= 1.7
     if gate in CIRQ_GATE_TO_BLOQ_MAP:
         return CIRQ_GATE_TO_BLOQ_MAP[gate]
 

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -416,7 +416,7 @@ def cirq_gate_to_bloq(gate: cirq.Gate) -> Bloq:
         cirq.TOFFOLI: Toffoli(),
         cirq.X: XGate(),
         cirq.Y: YGate(),
-        cirq.ControlledGate(cirq.Y): CYGate(),
+        getattr(cirq, 'CY', cirq.ControlledGate(cirq.Y)): CYGate(),
         cirq.Z: ZGate(),
         cirq.CZ: CZ(),
         cirq.SWAP: TwoBitSwap(),

--- a/qualtran/cirq_interop/_cirq_to_bloq.py
+++ b/qualtran/cirq_interop/_cirq_to_bloq.py
@@ -416,6 +416,7 @@ def cirq_gate_to_bloq(gate: cirq.Gate) -> Bloq:
         cirq.TOFFOLI: Toffoli(),
         cirq.X: XGate(),
         cirq.Y: YGate(),
+        # cirq.CY in Cirq >= 1.7
         getattr(cirq, 'CY', cirq.ControlledGate(cirq.Y)): CYGate(),
         cirq.Z: ZGate(),
         cirq.CZ: CZ(),

--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -25,6 +25,7 @@ from .decompose_protocol import _decompose_once_considering_known_decomposition
 _T_GATESET = cirq.Gateset(cirq.T, cirq.T**-1, unroll_circuit_op=False)
 _ROTS_GATES = [cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate, cirq.CZPowGate]
 if hasattr(cirq, 'CYPowGate'):
+    # cirq.CY in Cirq >= 1.7
     _ROTS_GATES.append(cirq.CYPowGate)
 _ROTS_GATESET = cirq.Gateset(*_ROTS_GATES)
 
@@ -168,7 +169,7 @@ def _t_complexity_from_strategies(
 
 @cachetools.cached(cachetools.LRUCache(128), key=_get_hash, info=True)
 def _t_complexity_for_gate_or_op(
-    gate_or_op: Union[cirq.Gate, cirq.Operation, Bloq]
+    gate_or_op: Union[cirq.Gate, cirq.Operation, Bloq],
 ) -> Optional[TComplexity]:
     if isinstance(gate_or_op, cirq.Operation) and gate_or_op.gate is not None:
         gate_or_op = gate_or_op.gate

--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -23,7 +23,10 @@ from qualtran.symbolics import ceil, log2, SymbolicFloat, SymbolicInt
 from .decompose_protocol import _decompose_once_considering_known_decomposition
 
 _T_GATESET = cirq.Gateset(cirq.T, cirq.T**-1, unroll_circuit_op=False)
-_ROTS_GATESET = cirq.Gateset(cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate, cirq.CZPowGate)
+_ROTS_GATES = [cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate, cirq.CZPowGate]
+if hasattr(cirq, 'CYPowGate'):
+    _ROTS_GATES.append(cirq.CYPowGate)
+_ROTS_GATESET = cirq.Gateset(*_ROTS_GATES)
 
 
 @attrs.frozen

--- a/qualtran/cirq_interop/t_complexity_protocol.py
+++ b/qualtran/cirq_interop/t_complexity_protocol.py
@@ -23,7 +23,7 @@ from qualtran.symbolics import ceil, log2, SymbolicFloat, SymbolicInt
 from .decompose_protocol import _decompose_once_considering_known_decomposition
 
 _T_GATESET = cirq.Gateset(cirq.T, cirq.T**-1, unroll_circuit_op=False)
-_ROTS_GATES = [cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate, cirq.CZPowGate]
+_ROTS_GATES: list[type[cirq.Gate]] = [cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate, cirq.CZPowGate]
 if hasattr(cirq, 'CYPowGate'):
     # cirq.CY in Cirq >= 1.7
     _ROTS_GATES.append(cirq.CYPowGate)

--- a/qualtran/cirq_interop/t_complexity_protocol_test.py
+++ b/qualtran/cirq_interop/t_complexity_protocol_test.py
@@ -120,13 +120,11 @@ def test_gates():
     assert t_complexity_compat(cirq.FREDKIN) == TComplexity(t=7, clifford=14)
 
     # TODO: https://github.com/quantumlib/Qualtran/issues/237
-    assert t_complexity_compat(cirq.H.controlled()) == TComplexity(
-        clifford=4, rotations=2
-    ) or t_complexity_compat(  # cirq <=1.4
-        cirq.H.controlled()
-    ) == TComplexity(
-        t=2, clifford=4, rotations=2
-    )
+    assert t_complexity_compat(cirq.H.controlled()) in [
+        TComplexity(clifford=4, rotations=2),  # cirq >= 1.5
+        TComplexity(t=2, clifford=4, rotations=2),  # cirq <= 1.4
+        TComplexity(t=1, clifford=1, rotations=1),  # cirq >= 1.7 (CYPowGate)
+    ]
     assert t_complexity(CHadamard()) == TComplexity(clifford=4, rotations=2)
 
     # Global phase


### PR DESCRIPTION
Fixes #1889 

Cirq introduced `cirq.CY` and `cirq.CYPowGate` whereas our cirq interop was relying on `cirq.ControlledGate(cirq.Y))`