### PR TITLE
Support annotations, `qcast`, and custom ast node hooks for QLT IR

### DIFF
--- a/qualtran/bloqs/bookkeeping/qcast.py
+++ b/qualtran/bloqs/bookkeeping/qcast.py
@@ -1,0 +1,36 @@
+#  Copyright 2026 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""A generic bookkeeping bloq for casting operations based only on a signature."""
+
+from attrs import frozen
+
+from qualtran import CompositeBloq, DecomposeTypeError, Signature
+from qualtran.bloqs.bookkeeping._bookkeeping_bloq import _BookkeepingBloq
+
+
+@frozen
+class QCast(_BookkeepingBloq):
+    """A generic bookkeeping bloq for casting operations based only on signature.
+
+    Qualtran-IR (*.qlt) `qcast` declarations get evaluated into one of these.
+
+    Args:
+        signature: The quantum signature of the casting operation.
+    """
+
+    signature: Signature
+
+    def decompose_bloq(self) -> 'CompositeBloq':
+        raise DecomposeTypeError(f'{self} is atomic')

--- a/qualtran/bloqs/bookkeeping/qcast_test.py
+++ b/qualtran/bloqs/bookkeeping/qcast_test.py
@@ -1,0 +1,48 @@
+#  Copyright 2026 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+import qualtran as qlt
+import qualtran.dtype as qdt
+from qualtran.bloqs.bookkeeping.qcast import QCast
+
+
+def test_qcast_is_bookkeeping():
+    from qualtran.bloqs.bookkeeping._bookkeeping_bloq import _BookkeepingBloq
+
+    sig = qlt.Signature([qlt.Register('reg', qdt.QUInt(4))])
+    bloq = QCast(signature=sig)
+    assert isinstance(bloq, _BookkeepingBloq)
+
+
+def test_qcast_signature():
+    sig = qlt.Signature([qlt.Register('reg', qdt.QBit())])
+    bloq = QCast(signature=sig)
+    assert bloq.signature is sig
+
+
+def test_qcast_decompose_raises():
+    sig = qlt.Signature([qlt.Register('x', qdt.QBit())])
+    bloq = QCast(signature=sig)
+    with pytest.raises(qlt.DecomposeTypeError, match='is atomic'):
+        bloq.decompose_bloq()
+
+
+def test_qcast_equality():
+    sig1 = qlt.Signature([qlt.Register('x', qdt.QBit())])
+    sig2 = qlt.Signature([qlt.Register('x', qdt.QBit())])
+    sig3 = qlt.Signature([qlt.Register('y', qdt.QUInt(4))])
+    assert QCast(signature=sig1) == QCast(signature=sig2)
+    assert QCast(signature=sig1) != QCast(signature=sig3)

--- a/qualtran/l1/__init__.py
+++ b/qualtran/l1/__init__.py
@@ -18,5 +18,5 @@ from ._eval import eval_cvalue_node, eval_module
 from ._parse import dump_ast, parse_module, parse_objectstring
 from ._parse_eval import load_bloq, load_module, load_objectstring
 from ._to_cobject_node import dump_objectstring, to_cobject_node
-from ._to_l1 import dump_l1, dump_root_l1, L1ModuleBuilder
+from ._to_l1 import dump_l1, dump_root_l1, L1ModuleBuilder, signature_to_l1_entries
 from ._vm import StandardQualtranArchitectureAgnosticVirtualMachine

--- a/qualtran/l1/_ast_to_code.py
+++ b/qualtran/l1/_ast_to_code.py
@@ -137,7 +137,7 @@ class L1ASTPrinter(L1VisitorBase):
         r = super().visit(node)
 
         if r['lvalues']:
-            rets = ', '.join(self.visit(lv) for lv in r['lvalues'])
+            rets = ', '.join(str(lv) for lv in r['lvalues'])
         else:
             rets = '|'
         qargs = ', '.join(r['qargs'])

--- a/qualtran/l1/_ast_to_code.py
+++ b/qualtran/l1/_ast_to_code.py
@@ -24,9 +24,11 @@ from .nodes import (
     L1ASTNode,
     L1Module,
     LiteralNode,
+    LValueNode,
     QArgNode,
     QArgValueNode,
     QCallNode,
+    QCastNode,
     QDefExternNode,
     QDefImplNode,
     QDTypeNode,
@@ -51,6 +53,7 @@ class L1ASTPrinter(L1VisitorBase):
         s += '\n\n'.join(r['qdefs'])
         return s
 
+
     @visit.register
     def _(self, node: QDefExternNode):
         r = super().visit(node)
@@ -59,6 +62,14 @@ class L1ASTPrinter(L1VisitorBase):
         signature = ', '.join(r['qsignature'])
         s += f"[{signature}]"
 
+        return s
+
+    @visit.register
+    def _(self, node: QCastNode):
+        r = super().visit(node)
+        s = f"qcast {r['bloq_key']}\n"
+        signature = ', '.join(r['qsignature'])
+        s += f"[{signature}]"
         return s
 
     @visit.register
@@ -94,6 +105,8 @@ class L1ASTPrinter(L1VisitorBase):
             dt1 = dts[1] if dts[1] is not None else '|'
             dtype = f"{dt0} -> {dt1}"
         s = f"{r['name']}: {dtype}"
+        if node.annotation:
+            s += f" @ {node.annotation.canonical_str()}"
         return s
 
     @visit.register
@@ -109,6 +122,12 @@ class L1ASTPrinter(L1VisitorBase):
         return f"{r['dtype']}"
 
     @visit.register
+    def _(self, node: LValueNode):
+        if node.annotation:
+            return f"{node.name} @ {node.annotation.canonical_str()}"
+        return node.name
+
+    @visit.register
     def _(self, node: AliasAssignmentNode):
         super().visit(node)
         return f"{node.alias}", f" = {node.bloq_key}"
@@ -118,11 +137,14 @@ class L1ASTPrinter(L1VisitorBase):
         r = super().visit(node)
 
         if r['lvalues']:
-            rets = ', '.join(r['lvalues'])
+            rets = ', '.join(self.visit(lv) for lv in r['lvalues'])
         else:
             rets = '|'
         qargs = ', '.join(r['qargs'])
-        return (rets, f" = {r['bloq_key']}", f"[{qargs}]")
+        s = f" = {r['bloq_key']}"
+        if node.annotation:
+            s += f" @ {node.annotation.canonical_str()}"
+        return (rets, s, f"[{qargs}]")
 
     @visit.register
     def _(self, node: QReturnNode):
@@ -141,7 +163,10 @@ class L1ASTPrinter(L1VisitorBase):
     def _(self, node: QArgNode):
         r = super().visit(node)
         value = self.nested_val_str(r['value'])
-        return f"{r['key']}={value}"
+        s = f"{r['key']}={value}"
+        if node.annotation:
+            s += f" @ {node.annotation.canonical_str()}"
+        return s
 
     @visit.register
     def _(self, node: QArgValueNode):

--- a/qualtran/l1/_ast_to_code.py
+++ b/qualtran/l1/_ast_to_code.py
@@ -53,7 +53,6 @@ class L1ASTPrinter(L1VisitorBase):
         s += '\n\n'.join(r['qdefs'])
         return s
 
-
     @visit.register
     def _(self, node: QDefExternNode):
         r = super().visit(node)

--- a/qualtran/l1/_ast_visitor_base.py
+++ b/qualtran/l1/_ast_visitor_base.py
@@ -18,13 +18,14 @@ from typing import Any, cast, Dict
 
 import attrs
 
-from ._parse import (
+from .nodes import (
     CObjectNode,
     L1ASTNode,
     L1Module,
     QArgNode,
     QArgValueNode,
     QCallNode,
+    QCastNode,
     QDefExternNode,
     QDefImplNode,
     QDTypeNode,
@@ -43,7 +44,9 @@ class L1VisitorBase(metaclass=abc.ABCMeta):
 
     @visit.register
     def _(self, node: L1Module):
-        record = {'qdefs': [self.visit(qdef) for qdef in node.qdefs]}
+        record = {
+            'qdefs': [self.visit(qdef) for qdef in node.qdefs],
+        }
         return record
 
     @visit.register
@@ -63,6 +66,13 @@ class L1VisitorBase(metaclass=abc.ABCMeta):
         record['qsignature'] = [self.visit(sig_entry) for sig_entry in node.qsignature]
         record['cobject_from'] = self.visit(node.cobject_from)
         return record
+
+    @visit.register
+    def _(self, node: QCastNode):
+        record: Dict[str, Any] = {'bloq_key': node.bloq_key}
+        record['qsignature'] = [self.visit(sig_entry) for sig_entry in node.qsignature]
+        return record
+
 
     @visit.register
     def _(self, node: QSignatureEntry):

--- a/qualtran/l1/_ast_visitor_base.py
+++ b/qualtran/l1/_ast_visitor_base.py
@@ -22,6 +22,7 @@ from .nodes import (
     CObjectNode,
     L1ASTNode,
     L1Module,
+    LValueNode,
     QArgNode,
     QArgValueNode,
     QCallNode,
@@ -94,10 +95,17 @@ class L1VisitorBase(metaclass=abc.ABCMeta):
         return record
 
     @visit.register
+    def _(self, node: LValueNode):
+        record: Dict[str, Any] = {'name': node.name}
+        if node.annotation is not None:
+            record['annotation'] = self.visit(node.annotation)
+        return record
+
+    @visit.register
     def _(self, node: QCallNode):
         record: Dict[str, Any] = {
             'bloq_key': node.bloq_key,
-            'lvalues': [lv for lv in node.lvalues],
+            'lvalues': [self.visit(lv) for lv in node.lvalues],
             'qargs': [self.visit(qa) for qa in node.qargs],
         }
         return record

--- a/qualtran/l1/_ast_visitor_base.py
+++ b/qualtran/l1/_ast_visitor_base.py
@@ -45,9 +45,7 @@ class L1VisitorBase(metaclass=abc.ABCMeta):
 
     @visit.register
     def _(self, node: L1Module):
-        record = {
-            'qdefs': [self.visit(qdef) for qdef in node.qdefs],
-        }
+        record = {'qdefs': [self.visit(qdef) for qdef in node.qdefs]}
         return record
 
     @visit.register
@@ -73,7 +71,6 @@ class L1VisitorBase(metaclass=abc.ABCMeta):
         record: Dict[str, Any] = {'bloq_key': node.bloq_key}
         record['qsignature'] = [self.visit(sig_entry) for sig_entry in node.qsignature]
         return record
-
 
     @visit.register
     def _(self, node: QSignatureEntry):

--- a/qualtran/l1/_dtypes.py
+++ b/qualtran/l1/_dtypes.py
@@ -13,13 +13,13 @@
 #  limitations under the License.
 
 from functools import lru_cache
-from typing import cast, Dict, Optional, Tuple, Type
+from typing import cast, Dict, Tuple, Type
 
 import qualtran as qlt
 import qualtran.dtype as qdt
 
 from . import nodes as qualtran_l1_nodes
-from .nodes import CArgNode, CObjectNode, L1Nodes, LiteralNode, QDTypeNode
+from .nodes import CObjectNode, L1Nodes, QDTypeNode
 
 
 @lru_cache
@@ -60,11 +60,7 @@ def get_builtin_qdtypes() -> Tuple[Type['qdt.QCDType'], ...]:
     return tuple(get_builtin_qdtype_mapping().values())
 
 
-def to_qdtype_node(
-    dtype: 'qlt.QCDType',
-    *,
-    nodes: L1Nodes = qualtran_l1_nodes,
-) -> CObjectNode:
+def to_qdtype_node(dtype: 'qlt.QCDType', *, nodes: L1Nodes = qualtran_l1_nodes) -> CObjectNode:
     """Convert a QCDType object to its equivalent AST node.
 
     This includes special casing for 'builtin' datatypes. Otherwise, it uses
@@ -111,11 +107,7 @@ def to_qdtype_node(
     return dtype_node
 
 
-def reg_to_qdtype_node(
-    reg: 'qlt.Register',
-    *,
-    nodes: L1Nodes = qualtran_l1_nodes,
-) -> QDTypeNode:
+def reg_to_qdtype_node(reg: 'qlt.Register', *, nodes: L1Nodes = qualtran_l1_nodes) -> QDTypeNode:
     """Extract the shaped dtype from a register and return it as an AST node.
 
     This includes special casing for 'builtin' datatypes. Otherwise, it uses

--- a/qualtran/l1/_dtypes.py
+++ b/qualtran/l1/_dtypes.py
@@ -13,12 +13,13 @@
 #  limitations under the License.
 
 from functools import lru_cache
-from typing import cast, Dict, Tuple, Type
+from typing import cast, Dict, Optional, Tuple, Type
 
 import qualtran as qlt
 import qualtran.dtype as qdt
 
-from .nodes import CArgNode, CObjectNode, LiteralNode, QDTypeNode
+from . import nodes as qualtran_l1_nodes
+from .nodes import CArgNode, CObjectNode, L1Nodes, LiteralNode, QDTypeNode
 
 
 @lru_cache
@@ -59,46 +60,69 @@ def get_builtin_qdtypes() -> Tuple[Type['qdt.QCDType'], ...]:
     return tuple(get_builtin_qdtype_mapping().values())
 
 
-def reg_to_qdtype_node(reg: 'qlt.Register') -> QDTypeNode:
-    """Extract the shaped dtype from a register and return it as an AST node.
+def to_qdtype_node(
+    dtype: 'qlt.QCDType',
+    *,
+    nodes: L1Nodes = qualtran_l1_nodes,
+) -> CObjectNode:
+    """Convert a QCDType object to its equivalent AST node.
 
     This includes special casing for 'builtin' datatypes. Otherwise, it uses
     the generic `object_to_cobject_node` for the data type object, which may not load if
     `safe=True`.
+
+    Args:
+        dtype: The data type to serialize.
+        nodes: The module providing the AST node constructors.
     """
-    dtype = reg.dtype
     if dtype == qdt.QBit():
-        dtype_node = CObjectNode('QBit', [])
+        dtype_node = nodes.CObjectNode('QBit', [])
     elif dtype == qdt.CBit():
-        dtype_node = CObjectNode('CBit', [])
+        dtype_node = nodes.CObjectNode('CBit', [])
     elif isinstance(dtype, (qdt.QAny, qdt.QInt, qdt.QUInt, qdt.QIntSignMag, qdt.QIntOnesComp)):
-        dtype_node = CObjectNode(
-            dtype.__class__.__name__, cargs=[CArgNode(None, LiteralNode(cast(int, dtype.bitsize)))]
+        dtype_node = nodes.CObjectNode(
+            dtype.__class__.__name__,
+            cargs=[nodes.CArgNode(None, nodes.LiteralNode(cast(int, dtype.bitsize)))],
         )
     elif isinstance(dtype, qdt.BQUInt):
-        dtype_node = CObjectNode(
+        dtype_node = nodes.CObjectNode(
             'BQUInt',
             cargs=[
-                CArgNode(None, LiteralNode(cast(int, dtype.bitsize))),
-                CArgNode(None, LiteralNode(cast(int, dtype.iteration_length))),
+                nodes.CArgNode(None, nodes.LiteralNode(cast(int, dtype.bitsize))),
+                nodes.CArgNode(None, nodes.LiteralNode(cast(int, dtype.iteration_length))),
             ],
         )
     elif isinstance(dtype, qdt.QFxp):
-        dtype_node = CObjectNode(
+        dtype_node = nodes.CObjectNode(
             'QFxp',
             cargs=[
-                CArgNode(None, LiteralNode(cast(int, dtype.bitsize))),
-                CArgNode(None, LiteralNode(cast(int, dtype.num_frac))),
-                CArgNode('signed', LiteralNode(dtype.signed)),
+                nodes.CArgNode(None, nodes.LiteralNode(cast(int, dtype.bitsize))),
+                nodes.CArgNode(None, nodes.LiteralNode(cast(int, dtype.num_frac))),
+                nodes.CArgNode('signed', nodes.LiteralNode(dtype.signed)),
             ],
         )
 
     else:
         from ._to_cobject_node import to_cobject_node
 
-        cval_node = to_cobject_node(dtype)
-        assert isinstance(cval_node, CObjectNode)
+        cval_node = to_cobject_node(dtype, nodes=nodes)
+        assert isinstance(cval_node, nodes.CObjectNode)
         dtype_node = cval_node
 
+    return dtype_node
+
+
+def reg_to_qdtype_node(
+    reg: 'qlt.Register',
+    *,
+    nodes: L1Nodes = qualtran_l1_nodes,
+) -> QDTypeNode:
+    """Extract the shaped dtype from a register and return it as an AST node.
+
+    This includes special casing for 'builtin' datatypes. Otherwise, it uses
+    the generic `object_to_cobject_node` for the data type object, which may not load if
+    `safe=True`.
+    """
+    dtype_node = to_qdtype_node(reg.dtype, nodes=nodes)
     shape = reg.shape if reg._shape else None
-    return QDTypeNode(dtype=dtype_node, shape=shape)
+    return nodes.QDTypeNode(dtype=dtype_node, shape=shape)

--- a/qualtran/l1/_dtypes.py
+++ b/qualtran/l1/_dtypes.py
@@ -106,7 +106,6 @@ def to_qdtype_node(
         from ._to_cobject_node import to_cobject_node
 
         cval_node = to_cobject_node(dtype, nodes=nodes)
-        assert isinstance(cval_node, nodes.CObjectNode)
         dtype_node = cval_node
 
     return dtype_node

--- a/qualtran/l1/_eval.py
+++ b/qualtran/l1/_eval.py
@@ -66,11 +66,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-SymbolID: TypeAlias = str
-
-# Backwards compatibility alias
-BloqKey = SymbolID
-
+BloqKey: TypeAlias = str
 
 
 
@@ -395,10 +391,10 @@ def eval_qcast_node(
 
 
 def eval_bloq_maybe_aliased(
-    key: SymbolID,
-    qdefs: Dict[SymbolID, QDefNode],
-    qlocals: Mapping[SymbolID, Union[SymbolID, 'SoquetT']],
-    bloqs: Dict[SymbolID, Bloq],
+    key: BloqKey,
+    qdefs: Dict[BloqKey, QDefNode],
+    qlocals: Mapping[BloqKey, Union[BloqKey, 'SoquetT']],
+    bloqs: Dict[BloqKey, Bloq],
     safe: bool = True,
 ) -> 'qualtran.Bloq':
     """Recursively load bloqs.
@@ -463,8 +459,8 @@ def eval_qarg_nodes(qargs: Sequence[QArgNode], qlocals: Mapping[str, 'qualtran.S
 
 def _eval_qdef_impl_node(
     qdef: QDefImplNode,
-    qdefs: Dict[SymbolID, QDefNode],
-    bloqs: Dict[SymbolID, Bloq],
+    qdefs: Dict[BloqKey, QDefNode],
+    bloqs: Dict[BloqKey, Bloq],
     *,
     safe: bool,
 ) -> 'qualtran.CompositeBloq':
@@ -491,7 +487,7 @@ def _eval_qdef_impl_node(
     signature: Signature = eval_qsignature(
         qdef.qsignature, safe=safe
     )
-    qlocals: Dict[str, Union['SoquetT', SymbolID]]
+    qlocals: Dict[str, Union['SoquetT', BloqKey]]
     bb, qlocals = BloqBuilder.from_signature(signature)
     subbloq_aliases: Dict[Bloq, str] = {}
 
@@ -556,8 +552,8 @@ def _eval_qdef_impl_node(
 
 def eval_qdef_impl_node(
     qdef: QDefImplNode,
-    qdefs: Dict[SymbolID, QDefNode],
-    bloqs: Dict[SymbolID, Bloq],
+    qdefs: Dict[BloqKey, QDefNode],
+    bloqs: Dict[BloqKey, Bloq],
     *,
     safe: bool = True,
 ) -> 'qualtran.CompositeBloq':
@@ -573,7 +569,7 @@ def eval_qdef_impl_node(
         raise
 
 
-def eval_module(m: L1Module, *, safe: bool = True) -> Dict[SymbolID, 'qualtran.Bloq']:
+def eval_module(m: L1Module, *, safe: bool = True) -> Dict[BloqKey, 'qualtran.Bloq']:
     """Evaluate a parsed L1Module.
 
     This will call `eval_qdef_impl_node` or `eval_qdef_extern_node` on each qdef in the
@@ -582,8 +578,8 @@ def eval_module(m: L1Module, *, safe: bool = True) -> Dict[SymbolID, 'qualtran.B
 
     """
 
-    qdefs: Dict[SymbolID, QDefNode] = {qdef.bloq_key: qdef for qdef in m.qdefs}
-    bloqs: Dict[SymbolID, Bloq] = {}
+    qdefs: Dict[BloqKey, QDefNode] = {qdef.bloq_key: qdef for qdef in m.qdefs}
+    bloqs: Dict[BloqKey, Bloq] = {}
     for qdef in m.qdefs:
         bk = qdef.bloq_key
 

--- a/qualtran/l1/_eval.py
+++ b/qualtran/l1/_eval.py
@@ -34,7 +34,6 @@ import attrs
 import numpy as np
 import sympy
 
-import qualtran.dtype as qdt
 from qualtran import Bloq, BloqBuilder, BloqError, CompositeBloq, Register, Side, Signature, SoquetT
 from qualtran.bloqs.manifest import BLOQ_CLASS_NAMES
 
@@ -67,7 +66,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 BloqKey: TypeAlias = str
-
 
 
 @lru_cache
@@ -250,11 +248,7 @@ def eval_cvalue_node(node: CValueNode, *, safe: bool = True) -> Any:
     raise TypeError(f"Unknown AST node type: {type(node)}")
 
 
-def _resolve_cobject_dtype(
-    cobject: CObjectNode,
-    *,
-    safe: bool = True,
-) -> 'qualtran.QCDType':
+def _resolve_cobject_dtype(cobject: CObjectNode, *, safe: bool = True) -> 'qualtran.QCDType':
     """Resolve a CObjectNode to a QCDType instance.
 
     Resolution priority:
@@ -287,9 +281,7 @@ def _resolve_cobject_dtype(
 
 
 def eval_qdtype_node(
-    dt: QDTypeNode,
-    *,
-    safe: bool = True,
+    dt: QDTypeNode, *, safe: bool = True
 ) -> Tuple['qualtran.QCDType', Sequence[int]]:
     """Evaluate a QDTypeNode to a (QCDType, shape) pair."""
     resolved_dt = _resolve_cobject_dtype(dt.dtype, safe=safe)
@@ -299,9 +291,7 @@ def eval_qdtype_node(
 
 
 def eval_qsignature(
-    entries: Sequence[QSignatureEntry],
-    *,
-    safe: bool = True,
+    entries: Sequence[QSignatureEntry], *, safe: bool = True
 ) -> 'qualtran.Signature':
     registers = []
     for entry in entries:
@@ -342,18 +332,13 @@ def eval_qsignature(
 @attrs.frozen
 class _PlaceholderBloq(Bloq):
     """Could not evaluate an extern qdef, but got a valid signature."""
+
     signature: Signature
 
 
-def eval_qdef_extern_node(
-    qdef: QDefExternNode,
-    *,
-    safe: bool = True,
-) -> 'qualtran.Bloq':
+def eval_qdef_extern_node(qdef: QDefExternNode, *, safe: bool = True) -> 'qualtran.Bloq':
     """Evaluate an extern node by loading in the bloq using Python."""
-    signature: Signature = eval_qsignature(
-        qdef.qsignature, safe=safe
-    )
+    signature: Signature = eval_qsignature(qdef.qsignature, safe=safe)
 
     if qdef.cobject_from is None:
         raise ValueError("The `from` clause is required for an extern qdef.")
@@ -375,17 +360,11 @@ def eval_qdef_extern_node(
     return bloq
 
 
-def eval_qcast_node(
-    qdef: QCastNode,
-    *,
-    safe: bool = True,
-) -> 'qualtran.Bloq':
+def eval_qcast_node(qdef: QCastNode, *, safe: bool = True) -> 'qualtran.Bloq':
     """Evaluate a qcast node by constructing a QCast bloq from its signature."""
     from qualtran.bloqs.bookkeeping.qcast import QCast
 
-    signature: Signature = eval_qsignature(
-        qdef.qsignature, safe=safe
-    )
+    signature: Signature = eval_qsignature(qdef.qsignature, safe=safe)
     logger.info("Evaluating qcast %s", qdef.bloq_key)
     return QCast(signature=signature)
 
@@ -416,22 +395,20 @@ def eval_bloq_maybe_aliased(
         alias = qlocals[key]
         if not isinstance(alias, str):
             raise ValueError(f"Expected a bloq key local variable, but got {alias} for {key}")
-        return eval_bloq_maybe_aliased(
-            alias, qdefs, qlocals, bloqs, safe=safe,
-        )
+        return eval_bloq_maybe_aliased(alias, qdefs, qlocals, bloqs, safe=safe)
 
     if key in qdefs:
         qdef = qdefs[key]
         if isinstance(qdef, QDefExternNode):
-            bloq = eval_qdef_extern_node(qdef, safe=safe, )
+            bloq = eval_qdef_extern_node(qdef, safe=safe)
             bloqs[key] = bloq
             return bloq
         elif isinstance(qdef, QCastNode):
-            bloq = eval_qcast_node(qdef, safe=safe, )
+            bloq = eval_qcast_node(qdef, safe=safe)
             bloqs[key] = bloq
             return bloq
         elif isinstance(qdef, QDefImplNode):
-            bloq = eval_qdef_impl_node(qdef, qdefs, bloqs, safe=safe, )
+            bloq = eval_qdef_impl_node(qdef, qdefs, bloqs, safe=safe)
             bloqs[key] = bloq
             return bloq
         else:
@@ -458,11 +435,7 @@ def eval_qarg_nodes(qargs: Sequence[QArgNode], qlocals: Mapping[str, 'qualtran.S
 
 
 def _eval_qdef_impl_node(
-    qdef: QDefImplNode,
-    qdefs: Dict[BloqKey, QDefNode],
-    bloqs: Dict[BloqKey, Bloq],
-    *,
-    safe: bool,
+    qdef: QDefImplNode, qdefs: Dict[BloqKey, QDefNode], bloqs: Dict[BloqKey, Bloq], *, safe: bool
 ) -> 'qualtran.CompositeBloq':
     """Evaluate a QDefImplNode, which defines a bloq implementation through a series of statements.
 
@@ -473,10 +446,10 @@ def _eval_qdef_impl_node(
 
     Args:
         qdef: The node to evaluate.
-        qdefs: A registry mapping symbol_id to its un-evaluated qdef _or_ another symbol_id.
-            This function will add symbol_id-to-symbol_id alias mappings when evaluating
+        qdefs: A registry mapping bloq key to its un-evaluated qdef _or_ another bloq key.
+            This function will add bloq-key-to-bloq-key alias mappings when evaluating
             AliasAssignmentNode statements.
-        bloqs: A registry mapping symbol_id to previously-evaluated bloqs.
+        bloqs: A registry mapping bloq key to previously-evaluated bloqs.
 
     Returns:
         An evaluated qualtran.Bloq. The *caller* of this function is responsible for updating
@@ -484,11 +457,10 @@ def _eval_qdef_impl_node(
     """
     logger.info("Evaluating qdef impl %s", qdef.bloq_key)
 
-    signature: Signature = eval_qsignature(
-        qdef.qsignature, safe=safe
-    )
-    qlocals: Dict[str, Union['SoquetT', BloqKey]]
-    bb, qlocals = BloqBuilder.from_signature(signature)
+    signature: Signature = eval_qsignature(qdef.qsignature, safe=safe)
+    qlocals: Dict[str, Union['SoquetT', BloqKey]] = {}
+    bb, initial_qlocals = BloqBuilder.from_signature(signature)
+    qlocals.update(initial_qlocals)
     subbloq_aliases: Dict[Bloq, str] = {}
 
     stmt: StatementNode
@@ -498,16 +470,12 @@ def _eval_qdef_impl_node(
 
         if isinstance(stmt, AliasAssignmentNode):
             qlocals[stmt.alias] = stmt.bloq_key  # type: ignore[assignment]
-            bloq = eval_bloq_maybe_aliased(
-                stmt.bloq_key, qdefs, qlocals, bloqs, safe=safe,
-            )
+            bloq = eval_bloq_maybe_aliased(stmt.bloq_key, qdefs, qlocals, bloqs, safe=safe)
             subbloq_aliases[bloq] = stmt.alias
 
         elif isinstance(stmt, QCallNode):
-            bloq = eval_bloq_maybe_aliased(
-                stmt.bloq_key, qdefs, qlocals, bloqs, safe=safe,
-            )
-            qkwargs = eval_qarg_nodes(stmt.qargs, qlocals)
+            bloq = eval_bloq_maybe_aliased(stmt.bloq_key, qdefs, qlocals, bloqs, safe=safe)
+            qkwargs = eval_qarg_nodes(stmt.qargs, qlocals)  # type: ignore[arg-type]
             qrets = bb.add_t(bloq, **qkwargs)
             if len(qrets) != len(stmt.lvalues):
                 raise BloqError(
@@ -517,7 +485,7 @@ def _eval_qdef_impl_node(
                 qlocals[lval.name] = qret
 
         elif isinstance(stmt, QReturnNode):
-            qkwargs = eval_qarg_nodes(stmt.ret_mapping, qlocals)
+            qkwargs = eval_qarg_nodes(stmt.ret_mapping, qlocals)  # type: ignore[arg-type]
             cbloq = bb.finalize(**qkwargs)
             break
 
@@ -560,9 +528,7 @@ def eval_qdef_impl_node(
     # Wrapper to un-roll error messages.
     # See `_eval_qdef_impl_node` for details about this function.
     try:
-        return _eval_qdef_impl_node(
-            qdef=qdef, qdefs=qdefs, bloqs=bloqs, safe=safe,
-        )
+        return _eval_qdef_impl_node(qdef=qdef, qdefs=qdefs, bloqs=bloqs, safe=safe)
     except Exception as e:
         logger.error("%s", e)
         logger.error("During evaluation of %s", qdef.bloq_key)
@@ -575,7 +541,6 @@ def eval_module(m: L1Module, *, safe: bool = True) -> Dict[BloqKey, 'qualtran.Bl
     This will call `eval_qdef_impl_node` or `eval_qdef_extern_node` on each qdef in the
     L1Module. Note that `eval_qdef_impl_node` is recursive, so bloqs will be evaluated
     in a depth-first traversal.
-
     """
 
     qdefs: Dict[BloqKey, QDefNode] = {qdef.bloq_key: qdef for qdef in m.qdefs}

--- a/qualtran/l1/_eval.py
+++ b/qualtran/l1/_eval.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 import importlib
 import logging
+import warnings
 from functools import lru_cache
 from typing import (
     Any,
@@ -33,17 +34,8 @@ import attrs
 import numpy as np
 import sympy
 
-from qualtran import (
-    Bloq,
-    BloqBuilder,
-    BloqError,
-    CompositeBloq,
-    QCDType,
-    Register,
-    Side,
-    Signature,
-    SoquetT,
-)
+import qualtran.dtype as qdt
+from qualtran import Bloq, BloqBuilder, BloqError, CompositeBloq, Register, Side, Signature, SoquetT
 from qualtran.bloqs.manifest import BLOQ_CLASS_NAMES
 
 from ._dtypes import get_builtin_qdtype_mapping
@@ -58,6 +50,7 @@ from .nodes import (
     QArgNode,
     QArgValueNode,
     QCallNode,
+    QCastNode,
     QDefExternNode,
     QDefImplNode,
     QDefNode,
@@ -73,14 +66,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-BloqKey: TypeAlias = str
+SymbolID: TypeAlias = str
+
+# Backwards compatibility alias
+BloqKey = SymbolID
 
 
-@lru_cache
-def _get_custom_dtypes() -> Dict[str, type[QCDType]]:
-    # TODO: Custom data types.
-    dtypes: Dict[str, type[QCDType]] = {f'{k._pkg_()}.{k.__name__}': k for k in []}  # type: ignore
-    return dtypes
 
 
 @lru_cache
@@ -88,6 +79,16 @@ def _get_safe_loadables() -> Dict[str, type[Any]]:
     from qualtran import CtrlSpec, Register
 
     return {'CtrlSpec': CtrlSpec, 'Register': Register}
+
+
+@lru_cache
+def _get_safe_import_names() -> frozenset[str]:
+    """Return the set of fully-qualified names that are safe to import.
+
+    This is derived from `BLOQ_CLASS_NAMES` plus the module prefixes of the
+    safe-loadable types and builtin dtypes.
+    """
+    return frozenset(BLOQ_CLASS_NAMES)
 
 
 def eval_carg_nodes(
@@ -192,6 +193,11 @@ class UnevaluatedCValue:
 
 
 def _eval_imported(name: str, args: Sequence[Any], kwargs: Dict[str, Any]):
+    """Import and instantiate a class by its fully-qualified dotted name.
+
+    This is inherently unsafe. Callers must gate access (e.g. via the
+    bloq manifest allowlist) before calling this function.
+    """
     name_parts = name.split('.')
     package = '.'.join(name_parts[:-1])
     logger.debug("importing %s", package)
@@ -226,16 +232,20 @@ def eval_cvalue_node(node: CValueNode, *, safe: bool = True) -> Any:
             return cls(*args, **kwargs)
 
         # Allowlisted importable bloq classes
-        if '.' in node.name and node.name in BLOQ_CLASS_NAMES:
-            return _eval_imported(node.name, args, kwargs)
+        if '.' in node.name and node.name in _get_safe_import_names():
+            try:
+                return _eval_imported(node.name, args, kwargs)
+            except (ImportError, AttributeError) as e:
+                warnings.warn(f"Could not evaluate {node}: {e}")
+                # Fall through
 
-        # Unknown (safe mode): return unevaluated
+        # This is where our safe journey ends; anything left is returned unevaluated (no import).
         if safe:
             uneval_cargs: list[tuple[Optional[str], Any]] = [(None, arg) for arg in args]
             uneval_cargs.extend((k, v) for k, v in kwargs.items())
             return UnevaluatedCValue(name=node.name, cargs=uneval_cargs)
 
-        # Unknown, unsafe: use `importlib` to load the class.
+        # Otherwise, unsafe arbitrary import via importlib.
         if '.' not in node.name:
             raise ValueError(f"Unknown CValueNode {node}.")
         return _eval_imported(node.name, args, kwargs)
@@ -243,47 +253,86 @@ def eval_cvalue_node(node: CValueNode, *, safe: bool = True) -> Any:
     raise TypeError(f"Unknown AST node type: {type(node)}")
 
 
-def eval_qdtype_node(dt: QDTypeNode) -> Tuple['qualtran.QCDType', Sequence[int]]:
-    context = get_builtin_qdtype_mapping() | _get_custom_dtypes()
-    try:
-        dt_cls = context[dt.dtype.name]
-    except KeyError as e:
-        raise ValueError(f"Unknown data type {dt.dtype.name}") from e
-    args, kwargs = eval_carg_nodes(dt.dtype.cargs)
-    qdt = dt_cls(*args, **kwargs)
+def _resolve_cobject_dtype(
+    cobject: CObjectNode,
+    *,
+    safe: bool = True,
+) -> 'qualtran.QCDType':
+    """Resolve a CObjectNode to a QCDType instance.
 
+    Resolution priority:
+        1. Builtin dtype constructors (QAny, QUInt, etc.)
+        2. Manifest-gated import (dotted names)
+
+    Raises:
+        ImportError: If ``safe=True`` and a dotted name is not on the manifest.
+        ValueError: If the dtype name cannot be resolved.
+    """
+
+    # 1. Builtin dtype constructors
+    builtins = get_builtin_qdtype_mapping()
+    if cobject.name in builtins:
+        dt_cls = builtins[cobject.name]
+        args, kwargs = eval_carg_nodes(cobject.cargs, safe=safe)
+        return dt_cls(*args, **kwargs)
+
+    # 2. Manifest-gated import for dotted names
+    if '.' in cobject.name:
+        if safe and cobject.name not in _get_safe_import_names():
+            raise ImportError(
+                f"Cannot import dtype '{cobject.name}' with safe=True: "
+                f"not in the bloq manifest allowlist."
+            )
+        args, kwargs = eval_carg_nodes(cobject.cargs, safe=safe)
+        return _eval_imported(cobject.name, args, kwargs)
+
+    raise ValueError(f"Unknown data type '{cobject.name}'")
+
+
+def eval_qdtype_node(
+    dt: QDTypeNode,
+    *,
+    safe: bool = True,
+) -> Tuple['qualtran.QCDType', Sequence[int]]:
+    """Evaluate a QDTypeNode to a (QCDType, shape) pair."""
+    resolved_dt = _resolve_cobject_dtype(dt.dtype, safe=safe)
     if dt.shape is not None:
-        qshape = tuple(v for v in dt.shape)
-    else:
-        qshape = ()
-    return qdt, qshape
+        return resolved_dt, tuple(dt.shape)
+    return resolved_dt, ()
 
 
-def eval_qsignature(entries: Sequence[QSignatureEntry]) -> 'qualtran.Signature':
+def eval_qsignature(
+    entries: Sequence[QSignatureEntry],
+    *,
+    safe: bool = True,
+) -> 'qualtran.Signature':
     registers = []
     for entry in entries:
         # One dtype: THRU register.
         if isinstance(entry.dtype, QDTypeNode):
-            dtype, shape = eval_qdtype_node(entry.dtype)
+            dtype, shape = eval_qdtype_node(entry.dtype, safe=safe)
             registers.append(
                 Register(name=entry.name, dtype=dtype, side=Side.THRU, shape=tuple(shape))
             )
             continue
 
         # Two dtypes: LEFT and/or RIGHT registers
-        assert isinstance(entry.dtype, tuple)
-        assert len(entry.dtype) == 2
+        if not isinstance(entry.dtype, tuple) or len(entry.dtype) != 2:
+            raise ValueError(
+                f"Expected a 2-tuple of QDTypeNodes for entry '{entry.name}', got {entry.dtype!r}"
+            )
         d1, d2 = entry.dtype
-        assert d1 is not None or d2 is not None
+        if d1 is None and d2 is None:
+            raise ValueError(f"Both LEFT and RIGHT dtypes are None for entry '{entry.name}'")
         # LEFT
         if d1 is not None:
-            d1type, d1shape = eval_qdtype_node(d1)
+            d1type, d1shape = eval_qdtype_node(d1, safe=safe)
             registers.append(
                 Register(name=entry.name, dtype=d1type, side=Side.LEFT, shape=tuple(d1shape))
             )
         # RIGHT
         if d2 is not None:
-            d2type, d2shape = eval_qdtype_node(d2)
+            d2type, d2shape = eval_qdtype_node(d2, safe=safe)
             registers.append(
                 Register(name=entry.name, dtype=d2type, side=Side.RIGHT, shape=tuple(d2shape))
             )
@@ -293,23 +342,63 @@ def eval_qsignature(entries: Sequence[QSignatureEntry]) -> 'qualtran.Signature':
     return sig
 
 
-def eval_qdef_extern_node(qdef: QDefExternNode, *, safe: bool = True) -> 'qualtran.Bloq':
+@attrs.frozen
+class _PlaceholderBloq(Bloq):
+    """Could not evaluate an extern qdef, but got a valid signature."""
+    signature: Signature
+
+
+def eval_qdef_extern_node(
+    qdef: QDefExternNode,
+    *,
+    safe: bool = True,
+) -> 'qualtran.Bloq':
     """Evaluate an extern node by loading in the bloq using Python."""
-    logger.info("Linking qdef extern %s from %s", qdef.bloq_key, qdef.cobject_from)
+    signature: Signature = eval_qsignature(
+        qdef.qsignature, safe=safe
+    )
+
     if qdef.cobject_from is None:
         raise ValueError("The `from` clause is required for an extern qdef.")
+    from_str = qdef.cobject_from.canonical_str()
+    logger.info("Linking qdef extern %s from %s", qdef.bloq_key, from_str)
     try:
         bloq = eval_cvalue_node(qdef.cobject_from, safe=safe)
     except (ValueError, ImportError, AttributeError, TypeError) as e:
-        raise ValueError(*e.args, f'in {qdef}') from e
+        warnings.warn(f'{e} in {qdef}')
+        bloq = None
+
+    if not isinstance(bloq, Bloq):
+        warnings.warn(
+            f"Error linking qdef extern {qdef.bloq_key} from {from_str}: "
+            f"The from clause evaluated to {bloq!r} instead of a Bloq object."
+        )
+        return _PlaceholderBloq(signature=signature)
+
     return bloq
 
 
+def eval_qcast_node(
+    qdef: QCastNode,
+    *,
+    safe: bool = True,
+) -> 'qualtran.Bloq':
+    """Evaluate a qcast node by constructing a QCast bloq from its signature."""
+    from qualtran.bloqs.bookkeeping.qcast import QCast
+
+    signature: Signature = eval_qsignature(
+        qdef.qsignature, safe=safe
+    )
+    logger.info("Evaluating qcast %s", qdef.bloq_key)
+    return QCast(signature=signature)
+
+
 def eval_bloq_maybe_aliased(
-    key: BloqKey,
-    qdefs: Dict[BloqKey, QDefNode],
-    qlocals: Mapping[BloqKey, Union[BloqKey, 'SoquetT']],
-    bloqs: Dict[BloqKey, Bloq],
+    key: SymbolID,
+    qdefs: Dict[SymbolID, QDefNode],
+    qlocals: Mapping[SymbolID, Union[SymbolID, 'SoquetT']],
+    bloqs: Dict[SymbolID, Bloq],
+    safe: bool = True,
 ) -> 'qualtran.Bloq':
     """Recursively load bloqs.
 
@@ -329,26 +418,29 @@ def eval_bloq_maybe_aliased(
     if key in qlocals:
         alias = qlocals[key]
         if not isinstance(alias, str):
-            raise ValueError(f"Expected a bloq key local varibale, but got {alias} for {key}")
-        return eval_bloq_maybe_aliased(alias, qdefs, qlocals, bloqs)
+            raise ValueError(f"Expected a bloq key local variable, but got {alias} for {key}")
+        return eval_bloq_maybe_aliased(
+            alias, qdefs, qlocals, bloqs, safe=safe,
+        )
 
     if key in qdefs:
         qdef = qdefs[key]
         if isinstance(qdef, QDefExternNode):
-            bloq = eval_qdef_extern_node(qdef)
+            bloq = eval_qdef_extern_node(qdef, safe=safe, )
+            bloqs[key] = bloq
+            return bloq
+        elif isinstance(qdef, QCastNode):
+            bloq = eval_qcast_node(qdef, safe=safe, )
             bloqs[key] = bloq
             return bloq
         elif isinstance(qdef, QDefImplNode):
-            bloq = eval_qdef_impl_node(qdef, qdefs, bloqs)
+            bloq = eval_qdef_impl_node(qdef, qdefs, bloqs, safe=safe, )
             bloqs[key] = bloq
             return bloq
         else:
             raise TypeError(f"Unknown qdef type {qdef}")
 
-    if key not in qdefs:
-        raise ValueError(f"Could not resolve {key}")
-
-    raise TypeError(f"Could not resolve {key}")
+    raise ValueError(f"Could not resolve {key}")
 
 
 def eval_qarg_value(val: NestedQArgValue, qlocals: Mapping[str, 'qualtran.SoquetT']):
@@ -369,7 +461,11 @@ def eval_qarg_nodes(qargs: Sequence[QArgNode], qlocals: Mapping[str, 'qualtran.S
 
 
 def _eval_qdef_impl_node(
-    qdef: QDefImplNode, qdefs: Dict[BloqKey, QDefNode], bloqs: Dict[BloqKey, Bloq], *, safe: bool
+    qdef: QDefImplNode,
+    qdefs: Dict[SymbolID, QDefNode],
+    bloqs: Dict[SymbolID, Bloq],
+    *,
+    safe: bool,
 ) -> 'qualtran.CompositeBloq':
     """Evaluate a QDefImplNode, which defines a bloq implementation through a series of statements.
 
@@ -380,10 +476,10 @@ def _eval_qdef_impl_node(
 
     Args:
         qdef: The node to evaluate.
-        qdefs: A registry mapping bloq key to its un-evaluated qdef _or_ another bloq key.
-            This function will add bloq-key-to-bloq-key alias mappings when evaluating
+        qdefs: A registry mapping symbol_id to its un-evaluated qdef _or_ another symbol_id.
+            This function will add symbol_id-to-symbol_id alias mappings when evaluating
             AliasAssignmentNode statements.
-        bloqs: A registry mapping bloq key to previously-evaluated bloqs.
+        bloqs: A registry mapping symbol_id to previously-evaluated bloqs.
 
     Returns:
         An evaluated qualtran.Bloq. The *caller* of this function is responsible for updating
@@ -391,8 +487,10 @@ def _eval_qdef_impl_node(
     """
     logger.info("Evaluating qdef impl %s", qdef.bloq_key)
 
-    signature: Signature = eval_qsignature(qdef.qsignature)
-    qlocals: Mapping[str, Union['SoquetT', BloqKey]]
+    signature: Signature = eval_qsignature(
+        qdef.qsignature, safe=safe
+    )
+    qlocals: Dict[str, Union['SoquetT', SymbolID]]
     bb, qlocals = BloqBuilder.from_signature(signature)
     subbloq_aliases: Dict[Bloq, str] = {}
 
@@ -403,11 +501,15 @@ def _eval_qdef_impl_node(
 
         if isinstance(stmt, AliasAssignmentNode):
             qlocals[stmt.alias] = stmt.bloq_key  # type: ignore[assignment]
-            bloq = eval_bloq_maybe_aliased(stmt.bloq_key, qdefs, qlocals, bloqs)
+            bloq = eval_bloq_maybe_aliased(
+                stmt.bloq_key, qdefs, qlocals, bloqs, safe=safe,
+            )
             subbloq_aliases[bloq] = stmt.alias
 
         elif isinstance(stmt, QCallNode):
-            bloq = eval_bloq_maybe_aliased(stmt.bloq_key, qdefs, qlocals, bloqs)
+            bloq = eval_bloq_maybe_aliased(
+                stmt.bloq_key, qdefs, qlocals, bloqs, safe=safe,
+            )
             qkwargs = eval_qarg_nodes(stmt.qargs, qlocals)
             qrets = bb.add_t(bloq, **qkwargs)
             if len(qrets) != len(stmt.lvalues):
@@ -415,7 +517,7 @@ def _eval_qdef_impl_node(
                     f"Calling {stmt.bloq_key} gives {len(qrets)} return values, but {len(stmt.lvalues)} lvalues were written"
                 )
             for qret, lval in zip(qrets, stmt.lvalues):
-                qlocals[lval] = qret
+                qlocals[lval.name] = qret
 
         elif isinstance(stmt, QReturnNode):
             qkwargs = eval_qarg_nodes(stmt.ret_mapping, qlocals)
@@ -453,31 +555,34 @@ def _eval_qdef_impl_node(
 
 def eval_qdef_impl_node(
     qdef: QDefImplNode,
-    qdefs: Dict[BloqKey, QDefNode],
-    bloqs: Dict[BloqKey, Bloq],
+    qdefs: Dict[SymbolID, QDefNode],
+    bloqs: Dict[SymbolID, Bloq],
     *,
     safe: bool = True,
 ) -> 'qualtran.CompositeBloq':
     # Wrapper to un-roll error messages.
     # See `_eval_qdef_impl_node` for details about this function.
     try:
-        return _eval_qdef_impl_node(qdef=qdef, qdefs=qdefs, bloqs=bloqs, safe=safe)
+        return _eval_qdef_impl_node(
+            qdef=qdef, qdefs=qdefs, bloqs=bloqs, safe=safe,
+        )
     except Exception as e:
         logger.error("%s", e)
         logger.error("During evaluation of %s", qdef.bloq_key)
-        raise e
+        raise
 
 
-def eval_module(m: L1Module, *, safe: bool = True) -> Dict[BloqKey, 'qualtran.Bloq']:
+def eval_module(m: L1Module, *, safe: bool = True) -> Dict[SymbolID, 'qualtran.Bloq']:
     """Evaluate a parsed L1Module.
 
     This will call `eval_qdef_impl_node` or `eval_qdef_extern_node` on each qdef in the
     L1Module. Note that `eval_qdef_impl_node` is recursive, so bloqs will be evaluated
     in a depth-first traversal.
+
     """
 
-    qdefs: Dict[BloqKey, QDefNode] = {qdef.bloq_key: qdef for qdef in m.qdefs}
-    bloqs: Dict[BloqKey, Bloq] = {}
+    qdefs: Dict[SymbolID, QDefNode] = {qdef.bloq_key: qdef for qdef in m.qdefs}
+    bloqs: Dict[SymbolID, Bloq] = {}
     for qdef in m.qdefs:
         bk = qdef.bloq_key
 
@@ -492,6 +597,10 @@ def eval_module(m: L1Module, *, safe: bool = True) -> Dict[BloqKey, 'qualtran.Bl
 
         elif isinstance(qdef, QDefExternNode):
             bloq = eval_qdef_extern_node(qdef, safe=safe)
+            bloqs[bk] = bloq
+
+        elif isinstance(qdef, QCastNode):
+            bloq = eval_qcast_node(qdef, safe=safe)
             bloqs[bk] = bloq
 
         else:

--- a/qualtran/l1/_eval.py
+++ b/qualtran/l1/_eval.py
@@ -227,7 +227,7 @@ def eval_cvalue_node(node: CValueNode, *, safe: bool = True) -> Any:
             return cls(*args, **kwargs)
 
         # Allowlisted importable bloq classes
-        if '.' in node.name and node.name in _get_safe_import_names():
+        if safe and '.' in node.name and node.name in _get_safe_import_names():
             try:
                 return _eval_imported(node.name, args, kwargs)
             except (ImportError, AttributeError) as e:

--- a/qualtran/l1/_eval.py
+++ b/qualtran/l1/_eval.py
@@ -85,8 +85,9 @@ def _get_safe_loadables() -> Dict[str, type[Any]]:
 def _get_safe_import_names() -> frozenset[str]:
     """Return the set of fully-qualified names that are safe to import.
 
-    This is derived from `BLOQ_CLASS_NAMES` plus the module prefixes of the
-    safe-loadable types and builtin dtypes.
+    These are the entries in the bloq manifest (`BLOQ_CLASS_NAMES`), each of
+    the form `'qualtran.bloqs.module.ClassName'`. Only names present in
+    this set will be resolved via `importlib` when `safe=True`.
     """
     return frozenset(BLOQ_CLASS_NAMES)
 

--- a/qualtran/l1/_eval_test.py
+++ b/qualtran/l1/_eval_test.py
@@ -30,6 +30,8 @@ from qualtran.l1._eval import (
 )
 from qualtran.l1.nodes import CArgNode, CObjectNode, LiteralNode, TupleNode
 
+from qualtran.l1 import eval_module, parse_module
+
 
 def test_safe_eval_prevents_arbitrary_code():
     # Try to execute os.system('echo hacked')
@@ -225,15 +227,12 @@ def test_too_many_values():
 
 
 def test_safe_false_propagates_to_impl_qdefs():
-    """Verify that safe=False propagates through eval_module into impl qdefs.
+    # Verify that safe=False propagates through eval_module into impl qdefs.
 
-    Regression test: eval_bloq_maybe_aliased was not forwarding the `safe`
-    flag when calling eval_qdef_impl_node for QDefImplNode, causing the
-    `from` clause to silently default to safe=True and return
-    UnevaluatedCValue for non-manifest dotted names.
-    """
-    from qualtran.l1 import eval_module, parse_module
-    from qualtran.l1._eval import _eval_qdef_impl_node
+    # Regression test: eval_bloq_maybe_aliased was not forwarding the `safe`
+    # flag when calling eval_qdef_impl_node for QDefImplNode, causing the
+    # `from` clause to silently default to safe=True and return
+    # UnevaluatedCValue for non-manifest dotted names.
 
     # An impl qdef whose `from` clause uses a dotted name NOT in the bloq
     # manifest (collections.OrderedDict is a harmless stdlib class).
@@ -260,6 +259,9 @@ from collections.OrderedDict()
     # decomposed_from is None.
     result_safe = eval_module(mod, safe=True)
     safe_bloq = result_safe['MyBloq']
+    from qualtran import CompositeBloq
+
+    assert isinstance(safe_bloq, CompositeBloq)
     assert safe_bloq.decomposed_from is None
 
     # With safe=False, the `from` clause should fully resolve to an
@@ -268,6 +270,7 @@ from collections.OrderedDict()
     # but we can verify the resolution by calling eval_cvalue_node directly
     # on the impl qdef's cobject_from node.
     impl_qdef = [q for q in mod.qdefs if q.bloq_key == 'MyBloq'][0]
+    assert impl_qdef.cobject_from is not None
     result = eval_cvalue_node(impl_qdef.cobject_from, safe=False)
     import collections
 
@@ -276,18 +279,21 @@ from collections.OrderedDict()
     ), f"Expected OrderedDict, got {type(result).__name__}: {result!r}"
 
     # Verify that safe=True returns UnevaluatedCValue for the same node.
-    result_safe_direct = eval_cvalue_node(impl_qdef.cobject_from, safe=True)
+    result_safe_direct = eval_cvalue_node(
+        impl_qdef.cobject_from, safe=True
+    )  # cobject_from asserted not None above
     assert isinstance(result_safe_direct, UnevaluatedCValue)
 
 
 def test_eval_qcast_node():
+    from qualtran.bloqs.bookkeeping.qcast import QCast
     from qualtran.l1._eval import eval_qcast_node
     from qualtran.l1.nodes import CObjectNode, QCastNode, QDTypeNode, QSignatureEntry
 
-    from qualtran.bloqs.bookkeeping.qcast import QCast
-
     # Build a QCastNode for Split(QUInt(4)): reg: QUInt(4) -> QBit[4]
-    quint4 = QDTypeNode(dtype=CObjectNode(name='QUInt', cargs=[CArgNode(None, LiteralNode(4))]), shape=None)
+    quint4 = QDTypeNode(
+        dtype=CObjectNode(name='QUInt', cargs=[CArgNode(None, LiteralNode(4))]), shape=None
+    )
     qbit_arr = QDTypeNode(dtype=CObjectNode(name='QBit', cargs=[]), shape=[4])
     sig_entry = QSignatureEntry(name='reg', dtype=(quint4, qbit_arr))
     qcast_node = QCastNode(bloq_key='Split(QUInt(4))', qsignature=[sig_entry])
@@ -298,8 +304,8 @@ def test_eval_qcast_node():
 
 
 def test_qcast_roundtrip():
-    from qualtran.l1 import eval_module, parse_module
     from qualtran.bloqs.bookkeeping.qcast import QCast
+    from qualtran.l1 import eval_module, parse_module
 
     l1_code = """# Qualtran-L1
 # 1.0.0

--- a/qualtran/l1/_eval_test.py
+++ b/qualtran/l1/_eval_test.py
@@ -17,6 +17,7 @@ import pytest
 import sympy
 
 from qualtran import Register, Side
+from qualtran.l1 import eval_module, parse_module
 from qualtran.l1._eval import (
     _CVALUE_EVALUATORS,
     _eval_imported,
@@ -29,8 +30,6 @@ from qualtran.l1._eval import (
     UnevaluatedCValue,
 )
 from qualtran.l1.nodes import CArgNode, CObjectNode, LiteralNode, TupleNode
-
-from qualtran.l1 import eval_module, parse_module
 
 
 def test_safe_eval_prevents_arbitrary_code():

--- a/qualtran/l1/_eval_test.py
+++ b/qualtran/l1/_eval_test.py
@@ -222,3 +222,59 @@ def test_too_many_values():
 
     with pytest.raises(ValueError, match=r'Too many.*'):
         _ = eval_cvalue_node(node, safe=True)
+
+
+def test_safe_false_propagates_to_impl_qdefs():
+    """Verify that safe=False propagates through eval_module into impl qdefs.
+
+    Regression test: eval_bloq_maybe_aliased was not forwarding the `safe`
+    flag when calling eval_qdef_impl_node for QDefImplNode, causing the
+    `from` clause to silently default to safe=True and return
+    UnevaluatedCValue for non-manifest dotted names.
+    """
+    from qualtran.l1 import eval_module, parse_module
+    from qualtran.l1._eval import _eval_qdef_impl_node
+
+    # An impl qdef whose `from` clause uses a dotted name NOT in the bloq
+    # manifest (collections.OrderedDict is a harmless stdlib class).
+    l1_code = """\
+# Qualtran-L1
+# 1.0.0
+
+extern qdef XGate
+from qualtran.bloqs.basic_gates.XGate()
+[q: QBit()]
+
+qdef MyBloq
+from collections.OrderedDict()
+[q: QBit()] {
+    q = XGate [q=q]
+    return [q=q]
+}
+"""
+    mod = parse_module(l1_code)
+
+    # With safe=True, the `from` clause of the impl qdef should fail to
+    # resolve (OrderedDict is not on the manifest), producing an
+    # UnevaluatedCValue internally. The bloq still builds but
+    # decomposed_from is None.
+    result_safe = eval_module(mod, safe=True)
+    safe_bloq = result_safe['MyBloq']
+    assert safe_bloq.decomposed_from is None
+
+    # With safe=False, the `from` clause should fully resolve to an
+    # OrderedDict instance (not a Bloq, but not UnevaluatedCValue either).
+    # decomposed_from will still be None because OrderedDict isn't a Bloq,
+    # but we can verify the resolution by calling eval_cvalue_node directly
+    # on the impl qdef's cobject_from node.
+    impl_qdef = [q for q in mod.qdefs if q.bloq_key == 'MyBloq'][0]
+    result = eval_cvalue_node(impl_qdef.cobject_from, safe=False)
+    import collections
+
+    assert isinstance(
+        result, collections.OrderedDict
+    ), f"Expected OrderedDict, got {type(result).__name__}: {result!r}"
+
+    # Verify that safe=True returns UnevaluatedCValue for the same node.
+    result_safe_direct = eval_cvalue_node(impl_qdef.cobject_from, safe=True)
+    assert isinstance(result_safe_direct, UnevaluatedCValue)

--- a/qualtran/l1/_eval_test.py
+++ b/qualtran/l1/_eval_test.py
@@ -278,3 +278,37 @@ from collections.OrderedDict()
     # Verify that safe=True returns UnevaluatedCValue for the same node.
     result_safe_direct = eval_cvalue_node(impl_qdef.cobject_from, safe=True)
     assert isinstance(result_safe_direct, UnevaluatedCValue)
+
+
+def test_eval_qcast_node():
+    from qualtran.l1._eval import eval_qcast_node
+    from qualtran.l1.nodes import CObjectNode, QCastNode, QDTypeNode, QSignatureEntry
+
+    from qualtran.bloqs.bookkeeping.qcast import QCast
+
+    # Build a QCastNode for Split(QUInt(4)): reg: QUInt(4) -> QBit[4]
+    quint4 = QDTypeNode(dtype=CObjectNode(name='QUInt', cargs=[CArgNode(None, LiteralNode(4))]), shape=None)
+    qbit_arr = QDTypeNode(dtype=CObjectNode(name='QBit', cargs=[]), shape=[4])
+    sig_entry = QSignatureEntry(name='reg', dtype=(quint4, qbit_arr))
+    qcast_node = QCastNode(bloq_key='Split(QUInt(4))', qsignature=[sig_entry])
+
+    result = eval_qcast_node(qcast_node, safe=True)
+    assert isinstance(result, QCast)
+    assert len(result.signature) == 2  # LEFT reg and RIGHT reg
+
+
+def test_qcast_roundtrip():
+    from qualtran.l1 import eval_module, parse_module
+    from qualtran.bloqs.bookkeeping.qcast import QCast
+
+    l1_code = """# Qualtran-L1
+# 1.0.0
+
+qcast Split(QUInt(4))
+[reg: QUInt(4) -> QBit[4]]
+"""
+    mod = parse_module(l1_code)
+    bloqs = eval_module(mod, safe=True)
+    assert 'Split(QUInt(4))' in bloqs
+    bloq = bloqs['Split(QUInt(4))']
+    assert isinstance(bloq, QCast)

--- a/qualtran/l1/_parse.py
+++ b/qualtran/l1/_parse.py
@@ -417,7 +417,7 @@ class QualtranL1Parser:
         qargs = self.parse_qargs()
         return self.nodes.QReturnNode(qargs)
 
-    def parse_lvalues(self) -> List[str]:
+    def parse_lvalues(self) -> List[LValueNode]:
         """Parse a comma-separated list of l-values.
 
         L-values are the targets of an assignment statement, typically

--- a/qualtran/l1/_parse.py
+++ b/qualtran/l1/_parse.py
@@ -404,6 +404,10 @@ class QualtranL1Parser:
                 )
             if lvalues[0].annotation is not None:
                 raise ValueError("Syntax error: alias assignment lvalue cannot have an annotation")
+            if annotation is not None:
+                raise ValueError(
+                    "Syntax error: alias assignment bloq_key cannot have an annotation"
+                )
             alias = lvalues[0].name
             return self.nodes.AliasAssignmentNode(alias=alias, bloq_key=bloq_key)
 

--- a/qualtran/l1/_parse.py
+++ b/qualtran/l1/_parse.py
@@ -17,10 +17,11 @@
 import json
 import logging
 import re
-from typing import List
+from typing import List, Optional, Tuple
 
 import attrs
 
+from . import nodes as qualtran_l1_nodes
 from .nodes import (
     AliasAssignmentNode,
     CArgNode,
@@ -28,11 +29,14 @@ from .nodes import (
     CValueNode,
     L1ASTNode,
     L1Module,
+    L1Nodes,
     LiteralNode,
+    LValueNode,
     NestedQArgValue,
     QArgNode,
     QArgValueNode,
     QCallNode,
+    QCastNode,
     QDefExternNode,
     QDefImplNode,
     QDefNode,
@@ -73,6 +77,7 @@ def tokenize(code: str) -> List[Token]:
         ('DOT', r'\.'),
         ('COLON', r':'),
         ('PIPE', r'\|'),
+        ('AT', r'@'),
         ('NEWLINE', r'\n'),
         ('SKIP', r'[ \t]+'),
         ('MISMATCH', r'.'),
@@ -107,9 +112,10 @@ def tokenize(code: str) -> List[Token]:
 class QualtranL1Parser:
     """A recursive-descent parser for bloq strings."""
 
-    def __init__(self, tokens: List[Token]):
+    def __init__(self, tokens: List[Token], nodes: L1Nodes = qualtran_l1_nodes):
         self.tokens = tokens
         self.pos = 0
+        self.nodes = nodes
 
     def peek(self) -> Token:
         """Look at the next token without consuming it."""
@@ -165,6 +171,12 @@ class QualtranL1Parser:
             return True
         return False
 
+    def parse_annotation(self) -> Optional[CValueNode]:
+        if self.check('AT'):
+            self.advance()
+            return self.parse_cvalue()
+        return None
+
     def parse_module(self) -> L1Module:
         """Parse an L1 module consisting of multiple quantum definitions.
 
@@ -175,21 +187,21 @@ class QualtranL1Parser:
             An L1Module containing the parsed quantum definitions.
         """
         if self.check('EOF'):
-            return L1Module(qdefs=[])
+            return self.nodes.L1Module(qdefs=[])
 
         qdefs = self.parse_qdefs()
 
         self.consume('EOF', "Expected EOF")
-        return L1Module(qdefs=qdefs)
+        return self.nodes.L1Module(qdefs=qdefs)
 
     def parse_qdefs(self) -> List[QDefNode]:
-        """Parse a sequence of quantum definitions.
+        """Parse a sequence of quantum function, or cast definitions.
 
-        Reads zero or more `qdef` or `extern qdef` keywords and parses them
+        Reads zero or more `qcast`, `qdef` or `extern qdef` keywords and parses them
         into QDefNode instances.
 
         Returns:
-            A list of QDefNode blocks (either implementations or externs).
+            qdefs: A list of QDefNode (implementations, externs, or casts).
         """
         qdefs = []
         while True:
@@ -206,10 +218,34 @@ class QualtranL1Parser:
                     raise ValueError(f"Expected 'extern qdef', not 'extern {tok}'")
                 qdef = self.parse_qdef(extern=True)
                 qdefs.append(qdef)
+            elif tok.value == 'qcast':
+                qcast = self.parse_qcast()
+                qdefs.append(qcast)
+            else:
+                raise ValueError(f"Unexpected identifier {tok}")
+
         return qdefs
 
+    def parse_qcast(self) -> QCastNode:
+        """Parse a qcast (casting operation) definition.
+
+        A qcast consists of a bloq key and a quantum signature.
+        It has no ``from`` clause and no body.
+
+        ```qlt
+        qcast Split(QUInt(4))
+        [reg: QUInt(4) -> QBit[4]]
+        ```
+
+        Returns:
+            A QCastNode.
+        """
+        bloq_key = self.parse_bloq_key()
+        qsig = self.parse_qdef_signature()
+        return self.nodes.QCastNode(bloq_key=bloq_key, qsignature=qsig)
+
     def parse_qdef(self, extern: bool = False) -> QDefNode:
-        """Parse a single quantum definition.
+        """Parse a single quantum function definition.
 
         A qdef consists of a signature, an optional classical 'from' binding,
         and either a body (for implementations) or no body (for externs).
@@ -229,10 +265,12 @@ class QualtranL1Parser:
         qsig = self.parse_qdef_signature()
 
         if extern:
-            return QDefExternNode(bloq_key=bloq_key, qsignature=qsig, cobject_from=bobj_cval)
+            return self.nodes.QDefExternNode(
+                bloq_key=bloq_key, qsignature=qsig, cobject_from=bobj_cval
+            )
         else:
             statements = self.parse_qdef_body()
-            return QDefImplNode(
+            return self.nodes.QDefImplNode(
                 bloq_key=bloq_key, qsignature=qsig, body=statements, cobject_from=bobj_cval
             )
 
@@ -279,7 +317,10 @@ class QualtranL1Parser:
             self.advance()
             self.consume('RARROW', 'output-only datatypes must be formulated | -> t')
             dtype = self.parse_qsig_dtype()
-            return QSignatureEntry(name=name_tok.value, dtype=(None, dtype))
+            annotation = self.parse_annotation()
+            return self.nodes.QSignatureEntry(
+                name=name_tok.value, dtype=(None, dtype), annotation=annotation
+            )
 
         # Per docstring, there are 3 out of 4 possible formulations for the datatype portion of
         # the signature entry. 't', 't -> |', 't1 -> t2'. Each starts with a data type.
@@ -290,21 +331,28 @@ class QualtranL1Parser:
             if self.peek().type == 'PIPE':
                 # t -> |
                 self.advance()
-                return QSignatureEntry(name=name_tok.value, dtype=(t1, None))
+                annotation = self.parse_annotation()
+                return self.nodes.QSignatureEntry(
+                    name=name_tok.value, dtype=(t1, None), annotation=annotation
+                )
             # t1 -> t2
             t2 = self.parse_qsig_dtype()
-            return QSignatureEntry(name=name_tok.value, dtype=(t1, t2))
+            annotation = self.parse_annotation()
+            return self.nodes.QSignatureEntry(
+                name=name_tok.value, dtype=(t1, t2), annotation=annotation
+            )
 
         # We've eliminated all possibilities except the basic 't' syntax.
-        return QSignatureEntry(name=name_tok.value, dtype=t1)
+        annotation = self.parse_annotation()
+        return self.nodes.QSignatureEntry(name=name_tok.value, dtype=t1, annotation=annotation)
 
     def parse_qsig_dtype(self) -> QDTypeNode:
         """QDType(k=v)[2, 4]"""
         cls = self.parse_cobject_node()
         if self.check('LBRACK'):
             shape = self.parse_shape_list()
-            return QDTypeNode(dtype=cls, shape=shape)
-        return QDTypeNode(dtype=cls, shape=None)
+            return self.nodes.QDTypeNode(dtype=cls, shape=shape)
+        return self.nodes.QDTypeNode(dtype=cls, shape=None)
 
     def parse_shape_list(self) -> List[int]:
         """[1, 2, 3]"""
@@ -345,16 +393,21 @@ class QualtranL1Parser:
         lvalues = self.parse_lvalues()
         self.consume('EQUALS', "Assignment operator '=' expected")
         bloq_key = self.parse_bloq_key()
+        annotation = self.parse_annotation()
         if self.check('LBRACK'):
             qargs = self.parse_qargs()
-            return QCallNode(bloq_key=bloq_key, lvalues=lvalues, qargs=qargs)
+            return self.nodes.QCallNode(
+                bloq_key=bloq_key, lvalues=lvalues, qargs=qargs, annotation=annotation
+            )
         else:
             if len(lvalues) != 1:
                 raise ValueError(
                     f"Syntax error: during alias assignment, only one lvalue may be specified (at {self.peek()})"
                 )
-            alias = lvalues[0]
-            return AliasAssignmentNode(alias=alias, bloq_key=bloq_key)
+            if lvalues[0].annotation is not None:
+                raise ValueError(f"Syntax error: alias assignment lvalue cannot have an annotation")
+            alias = lvalues[0].name
+            return self.nodes.AliasAssignmentNode(alias=alias, bloq_key=bloq_key)
 
     def parse_return_statement(self) -> QReturnNode:
         ret_tok = self.consume('NAME', "return statement must start with 'return'")
@@ -362,7 +415,7 @@ class QualtranL1Parser:
             raise ValueError("return statement must start with 'return'")
 
         qargs = self.parse_qargs()
-        return QReturnNode(qargs)
+        return self.nodes.QReturnNode(qargs)
 
     def parse_lvalues(self) -> List[str]:
         """Parse a comma-separated list of l-values.
@@ -383,7 +436,8 @@ class QualtranL1Parser:
         lvalues = []
         while True:
             ident_tok = self.consume('NAME', 'Expected identifier for lvalue')
-            lvalues.append(ident_tok.value)
+            annotation = self.parse_annotation()
+            lvalues.append(self.nodes.LValueNode(name=ident_tok.value, annotation=annotation))
 
             done = self._advance_to_next_list_item(
                 'EQUALS', consume_rbrack=False, list_name='lvalues'
@@ -411,6 +465,14 @@ class QualtranL1Parser:
     def parse_qarg(self) -> QArgNode:
         """ctrl=[qvar[0], qvar[1]]"""
         key = self.consume('NAME', 'invalid qarg key').value
+
+        # Support array indexing on key e.g. reg[0]=...
+        if self.check('LBRACK'):
+            self.advance()
+            idx = self.parse_int_literal('qarg key index')
+            self.consume('RBRACK', 'missing closing bracket for qarg key index')
+            key = f"{key}[{idx}]"
+
         self.consume('EQUALS', 'invalid qargs k=v specification')
 
         val: NestedQArgValue
@@ -420,7 +482,8 @@ class QualtranL1Parser:
         else:
             val = self.parse_qarg_value()
 
-        return QArgNode(key=key, value=val)
+        annotation = self.parse_annotation()
+        return self.nodes.QArgNode(key=key, value=val, annotation=annotation)
 
     def parse_qarg_value_list(self) -> List[NestedQArgValue]:
         """[qvar[0], qvar[1]].
@@ -458,9 +521,9 @@ class QualtranL1Parser:
 
                 done = self._advance_to_next_list_item('RBRACK', list_name='qarg value index')
                 if done:
-                    return QArgValueNode(name=value_tok.value, idx=tuple(idx))
+                    return self.nodes.QArgValueNode(name=value_tok.value, idx=tuple(idx))
         else:
-            return QArgValueNode(name=value_tok.value, idx=tuple())
+            return self.nodes.QArgValueNode(name=value_tok.value, idx=tuple())
 
     def parse_cobject_only(self) -> CObjectNode:
         ret = self.parse_cobject_node()
@@ -482,13 +545,13 @@ class QualtranL1Parser:
         name = self.parse_qualified_identifier()
 
         if not self.check('LPAREN'):
-            return CObjectNode(name=name, cargs=())
+            return self.nodes.CObjectNode(name=name, cargs=())
         self.advance()  # LPAREN
 
         if self.check('RPAREN'):
             # Empty arg list
             self.advance()  # RPAREN
-            return CObjectNode(name=name, cargs=tuple())
+            return self.nodes.CObjectNode(name=name, cargs=tuple())
 
         cargs = []
         while True:
@@ -497,7 +560,7 @@ class QualtranL1Parser:
 
             done = self._advance_to_next_list_item('RPAREN', list_name='classical args')
             if done:
-                return CObjectNode(name=name, cargs=tuple(cargs))
+                return self.nodes.CObjectNode(name=name, cargs=tuple(cargs))
 
     def parse_qualified_identifier(self) -> str:
         """Parse a dot-separated identifier.
@@ -526,10 +589,10 @@ class QualtranL1Parser:
                 key = self.advance().value  # NAME
                 self.advance()  # EQUALS
                 value = self.parse_cvalue()
-                return CArgNode(key=key, value=value)
+                return self.nodes.CArgNode(key=key, value=value)
 
         value = self.parse_cvalue()
-        return CArgNode(key=None, value=value)
+        return self.nodes.CArgNode(key=None, value=value)
 
     def parse_int_literal(self, err_ctx: str = 'parsing') -> int:
         """Parse an integer literal.
@@ -577,7 +640,7 @@ class QualtranL1Parser:
             # Check for empty list
             if self.check('RPAREN'):
                 self.advance()  # RPAREN
-                return TupleNode(items=())
+                return self.nodes.TupleNode(items=())
 
             # Get values
             vals = []
@@ -586,18 +649,18 @@ class QualtranL1Parser:
                 vals.append(val)
                 done = self._advance_to_next_list_item('RPAREN', list_name='cvalue list')
                 if done:
-                    return TupleNode(items=tuple(vals))
+                    return self.nodes.TupleNode(items=tuple(vals))
 
         if token.type == 'NUMBER':
             # The cvalue is a number
             self.advance()  # NUMBER
             if '.' in token.value or 'e' in token.value:
-                return LiteralNode(value=float(token.value))
-            return LiteralNode(value=int(token.value))
+                return self.nodes.LiteralNode(value=float(token.value))
+            return self.nodes.LiteralNode(value=int(token.value))
         if token.type == 'STRING':
             # The cvalue is a string
             self.advance()  # STRING
-            return LiteralNode(value=str(token.value))
+            return self.nodes.LiteralNode(value=str(token.value))
         if token.type == 'NAME':
             # The cvalue is a cobject
             return self.parse_cobject_node()
@@ -605,32 +668,34 @@ class QualtranL1Parser:
         raise ValueError(f"Unexpected token {token} when parsing value")
 
 
-def parse_objectstring(objectstring: str) -> CObjectNode:
+def parse_objectstring(objectstring: str, *, nodes: L1Nodes = qualtran_l1_nodes) -> CObjectNode:
     """Parse a classical object string representing a Bloq instance.
 
     Args:
         objectstring: The string representation of the object, e.g., 'MyBloq(1)'.
+        nodes: The module providing the AST node constructors.
 
     Returns:
         A CObjectNode representing the parsed classical object.
     """
     tokens = tokenize(objectstring)
-    parser = QualtranL1Parser(tokens)
+    parser = QualtranL1Parser(tokens, nodes=nodes)
     cval_node: CObjectNode = parser.parse_cobject_only()
     return cval_node
 
 
-def parse_module(l1_code: str) -> L1Module:
+def parse_module(l1_code: str, *, nodes: L1Nodes = qualtran_l1_nodes) -> L1Module:
     """Parse an entire L1 code string into an L1Module.
 
     Args:
         l1_code: The Qualtran-L1 source code as a string.
+        nodes: The module providing the AST node constructors.
 
     Returns:
         An L1Module containing the root AST of the parsed code.
     """
     tokens = tokenize(l1_code)
-    parser = QualtranL1Parser(tokens)
+    parser = QualtranL1Parser(tokens, nodes=nodes)
     return parser.parse_module()
 
 

--- a/qualtran/l1/_parse.py
+++ b/qualtran/l1/_parse.py
@@ -14,38 +14,36 @@
 
 """A recursive-descent parser for bloq string representation."""
 
+from __future__ import annotations
+
 import json
 import logging
 import re
-from typing import List, Optional, Tuple
+from typing import List, Optional, TYPE_CHECKING
 
 import attrs
 
 from . import nodes as qualtran_l1_nodes
-from .nodes import (
-    AliasAssignmentNode,
-    CArgNode,
-    CObjectNode,
-    CValueNode,
-    L1ASTNode,
-    L1Module,
-    L1Nodes,
-    LiteralNode,
-    LValueNode,
-    NestedQArgValue,
-    QArgNode,
-    QArgValueNode,
-    QCallNode,
-    QCastNode,
-    QDefExternNode,
-    QDefImplNode,
-    QDefNode,
-    QDTypeNode,
-    QReturnNode,
-    QSignatureEntry,
-    StatementNode,
-    TupleNode,
-)
+from .nodes import L1Nodes
+
+if TYPE_CHECKING:
+    from .nodes import (
+        CArgNode,
+        CObjectNode,
+        CValueNode,
+        L1ASTNode,
+        L1Module,
+        LValueNode,
+        NestedQArgValue,
+        QArgNode,
+        QArgValueNode,
+        QCastNode,
+        QDefNode,
+        QDTypeNode,
+        QReturnNode,
+        QSignatureEntry,
+        StatementNode,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -405,7 +403,7 @@ class QualtranL1Parser:
                     f"Syntax error: during alias assignment, only one lvalue may be specified (at {self.peek()})"
                 )
             if lvalues[0].annotation is not None:
-                raise ValueError(f"Syntax error: alias assignment lvalue cannot have an annotation")
+                raise ValueError("Syntax error: alias assignment lvalue cannot have an annotation")
             alias = lvalues[0].name
             return self.nodes.AliasAssignmentNode(alias=alias, bloq_key=bloq_key)
 
@@ -708,6 +706,8 @@ def _l1_to_json_dict(self):
 
 
 def l1_ast_node_to_json(o: object):
+    from .nodes import L1ASTNode
+
     if isinstance(o, L1ASTNode):
         return _l1_to_json_dict(o)
     return o

--- a/qualtran/l1/_parse_eval.py
+++ b/qualtran/l1/_parse_eval.py
@@ -15,7 +15,7 @@ import logging
 from typing import Dict
 
 import qualtran as qlt
-from qualtran.l1._eval import BloqKey, eval_module
+from qualtran.l1._eval import eval_module, SymbolID
 from qualtran.l1._parse import parse_module
 
 from ._eval import eval_cvalue_node
@@ -29,7 +29,7 @@ def load_objectstring(objectstring: str, *, safe: bool = True) -> object:
     return eval_cvalue_node(cobject_node, safe=safe)
 
 
-def load_module(l1_code: str, *, safe: bool = True) -> Dict[BloqKey, 'qlt.Bloq']:
+def load_module(l1_code: str, *, safe: bool = True) -> Dict[SymbolID, 'qlt.Bloq']:
     m = parse_module(l1_code)
     return eval_module(m, safe=safe)
 

--- a/qualtran/l1/_parse_eval.py
+++ b/qualtran/l1/_parse_eval.py
@@ -15,7 +15,7 @@ import logging
 from typing import Dict
 
 import qualtran as qlt
-from qualtran.l1._eval import eval_module, SymbolID
+from qualtran.l1._eval import BloqKey, eval_module
 from qualtran.l1._parse import parse_module
 
 from ._eval import eval_cvalue_node
@@ -29,7 +29,7 @@ def load_objectstring(objectstring: str, *, safe: bool = True) -> object:
     return eval_cvalue_node(cobject_node, safe=safe)
 
 
-def load_module(l1_code: str, *, safe: bool = True) -> Dict[SymbolID, 'qlt.Bloq']:
+def load_module(l1_code: str, *, safe: bool = True) -> Dict[BloqKey, 'qlt.Bloq']:
     m = parse_module(l1_code)
     return eval_module(m, safe=safe)
 

--- a/qualtran/l1/_parse_eval_test.py
+++ b/qualtran/l1/_parse_eval_test.py
@@ -34,7 +34,6 @@ def test_issue_1713():
     assert bloq
 
 
-@pytest.mark.xfail(reason="Missing _pkg_")
 def test_load_bloq():
     s = "qualtran.bloqs.reflections.ReflectionUsingPrepare(qualtran.bloqs.chemistry.hubbard_model.qubitization.PrepareHubbard(5, 5, 2.0, 0.1), None, -1, 1e-11)"
     bloq = load_bloq(s)
@@ -62,8 +61,7 @@ def test_load_objectstring_unsafe_import():
 
 
 def test_load_negate():
-    module = load_module(
-        """
+    module = load_module("""
     # Qualtran-L1
     # 1.0.0
 
@@ -83,8 +81,7 @@ def test_load_negate():
 
     extern qdef AddK(k=1)
     from qualtran.bloqs.arithmetic.AddK(QUInt(8), 1)
-    [x: QUInt(8)]"""
-    )
+    [x: QUInt(8)]""")
 
     assert set(module.keys()) == {'Negate', 'BitwiseNot(8)', 'AddK(k=1)'}
     cbloq = cast(qlt.CompositeBloq, module['Negate'])

--- a/qualtran/l1/_parse_test.py
+++ b/qualtran/l1/_parse_test.py
@@ -280,9 +280,12 @@ qdef OtherBloq() from qualtran.bloqs.OtherBloq() [
     assert len(module.qdefs) == 2
     assert module.qdefs[0].bloq_key == "MyBloq"
     assert module.qdefs[0].qsignature[0].name == "q"
-    assert len(module.qdefs[1].body[0].lvalues) == 1
-    assert module.qdefs[1].body[0].lvalues[0].name == "q"
-    assert module.qdefs[1].body[0].bloq_key == "MyBloq"  # type: ignore
+    assert isinstance(module.qdefs[1], QDefImplNode)
+    stmt0 = module.qdefs[1].body[0]
+    assert isinstance(stmt0, QCallNode)
+    assert len(stmt0.lvalues) == 1
+    assert stmt0.lvalues[0].name == "q"
+    assert stmt0.bloq_key == "MyBloq"
 
 
 def test_parse_lvalues_pipe():
@@ -343,8 +346,6 @@ def test_parse_empty_brackets():
     assert module.qdefs[1].body[0].alias == "c"  # type: ignore[attr-defined]
 
 
-
-
 def test_parse_annotations():
     code = """# Qualtran-L1
 # 1.0.0
@@ -389,6 +390,7 @@ from qualtran.bloqs.bookkeeping.Join(QAny(4))
     assert len(sig.annotation.items) == 2
 
     # Check body statements
+    assert isinstance(qdef, QDefImplNode)
     assert len(qdef.body) == 7
 
     # Split call
@@ -436,8 +438,12 @@ def test_parse_lvalues_with_annotation():
     lvals = parser.parse_lvalues()
     assert len(lvals) == 2
     assert lvals[0].name == "a"
+    assert lvals[0].annotation is not None
+    assert isinstance(lvals[0].annotation, LiteralNode)
     assert lvals[0].annotation.value == 1
     assert lvals[1].name == "b"
+    assert lvals[1].annotation is not None
+    assert isinstance(lvals[1].annotation, LiteralNode)
     assert lvals[1].annotation.value == 2
 
 
@@ -445,12 +451,16 @@ def test_parse_qarg_with_annotation():
     parser = QualtranL1Parser(tokenize("ctrl=qvar @ 1"))
     qarg = parser.parse_qarg()
     assert qarg.key == "ctrl"
+    assert qarg.annotation is not None
+    assert isinstance(qarg.annotation, LiteralNode)
     assert qarg.annotation.value == 1
 
     # Test array indexing on key too
     parser = QualtranL1Parser(tokenize("reg[0]=qvar @ 2"))
     qarg = parser.parse_qarg()
     assert qarg.key == "reg[0]"
+    assert qarg.annotation is not None
+    assert isinstance(qarg.annotation, LiteralNode)
     assert qarg.annotation.value == 2
 
 
@@ -458,6 +468,8 @@ def test_parse_signature_with_annotation():
     code = "qdef Foo() [ a: t @ 1 ] {}"
     module = parse_module(code)
     qdef = module.qdefs[0]
+    assert qdef.qsignature[0].annotation is not None
+    assert isinstance(qdef.qsignature[0].annotation, LiteralNode)
     assert qdef.qsignature[0].annotation.value == 1
 
 

--- a/qualtran/l1/_parse_test.py
+++ b/qualtran/l1/_parse_test.py
@@ -32,8 +32,10 @@ from qualtran.l1.nodes import (
     CObjectNode,
     LiteralNode,
     QArgValueNode,
+    QCallNode,
     QDefImplNode,
     QDTypeNode,
+    QReturnNode,
     TupleNode,
 )
 
@@ -277,9 +279,8 @@ qdef OtherBloq() from qualtran.bloqs.OtherBloq() [
     assert len(module.qdefs) == 2
     assert module.qdefs[0].bloq_key == "MyBloq"
     assert module.qdefs[0].qsignature[0].name == "q"
-    assert module.qdefs[1].bloq_key == "OtherBloq"
-    assert isinstance(module.qdefs[1], QDefImplNode)
-    assert module.qdefs[1].body[0].lvalues == ("q",)  # type: ignore
+    assert len(module.qdefs[1].body[0].lvalues) == 1
+    assert module.qdefs[1].body[0].lvalues[0].name == "q"
     assert module.qdefs[1].body[0].bloq_key == "MyBloq"  # type: ignore
 
 
@@ -339,3 +340,121 @@ def test_parse_empty_brackets():
     assert module.qdefs[0].body[0].qargs == ()  # type: ignore
     assert module.qdefs[1].qsignature[0].dtype.shape == []  # type: ignore
     assert module.qdefs[1].body[0].alias == "c"  # type: ignore[attr-defined]
+
+
+
+
+def test_parse_annotations():
+    code = """# Qualtran-L1
+# 1.0.0
+
+qdef BitwiseNot(QAny(4))
+from BitwiseNot(QAny(4))
+[
+    x: QAny(4) @ (3, 0),
+] {
+    reg @ (1, 2, 3, 4, 2, 3, 4) = Split(QAny(4)) @ (5, 0) [reg=x]
+    q @ 1                       = X @ (8, 0, False)       [q=reg[0] @ 1]
+    q2 @ 2                      = X @ (9, 0, False)       [q=reg[1] @ 2]
+    q3 @ 3                      = X @ (8, 0, False)       [q=reg[2] @ 3]
+    q4 @ 4                      = X @ (9, 0, False)       [q=reg[3] @ 4]
+    reg @ 0                     = Join(QAny(4)) @ (12, 0) [reg=[q, q2, q3, q4] @ (1, 2, 3, 4)]
+                                  return                  [x=reg @ (16, 0)]
+}
+
+extern qdef Split(QAny(4))
+from qualtran.bloqs.bookkeeping.Split(QAny(4))
+[reg: QAny(4) -> QBit[4]]
+
+extern qdef X
+from qualtran.bloqs.basic_gates.XGate
+[q: QBit @ oplus]
+
+extern qdef Join(QAny(4))
+from qualtran.bloqs.bookkeeping.Join(QAny(4))
+[reg: QBit[4] -> QAny(4)]
+"""
+    module = parse_module(code)
+    assert len(module.qdefs) == 4
+
+    # Check BitwiseNot
+    qdef = module.qdefs[0]
+    assert qdef.bloq_key == "BitwiseNot(QAny(4))"
+    assert len(qdef.qsignature) == 1
+    sig = qdef.qsignature[0]
+    assert sig.name == "x"
+    assert sig.annotation is not None
+    assert isinstance(sig.annotation, TupleNode)
+    assert len(sig.annotation.items) == 2
+
+    # Check body statements
+    assert len(qdef.body) == 7
+
+    # Split call
+    stmt0 = qdef.body[0]
+    assert isinstance(stmt0, QCallNode)
+    assert stmt0.bloq_key == "Split(QAny(4))"
+    assert len(stmt0.lvalues) == 1
+    assert stmt0.lvalues[0].name == "reg"
+    assert stmt0.lvalues[0].annotation is not None
+    assert stmt0.annotation is not None
+
+    # X call
+    stmt1 = qdef.body[1]
+    assert isinstance(stmt1, QCallNode)
+    assert stmt1.bloq_key == "X"
+    assert stmt1.lvalues[0].name == "q"
+    assert stmt1.lvalues[0].annotation is not None
+    assert stmt1.annotation is not None
+    assert stmt1.qargs[0].annotation is not None
+
+    # Join call
+    stmt5 = qdef.body[5]
+    assert isinstance(stmt5, QCallNode)
+    assert stmt5.bloq_key == "Join(QAny(4))"
+
+    # Return
+    stmt6 = qdef.body[6]
+    assert isinstance(stmt6, QReturnNode)
+    assert stmt6.ret_mapping[0].annotation is not None
+
+
+def test_parse_annotation():
+    parser = QualtranL1Parser(tokenize("@ 123"))
+    annotation = parser.parse_annotation()
+    assert isinstance(annotation, LiteralNode)
+    assert annotation.value == 123
+
+    parser = QualtranL1Parser(tokenize("not_an_annotation"))
+    annotation = parser.parse_annotation()
+    assert annotation is None
+
+
+def test_parse_lvalues_with_annotation():
+    parser = QualtranL1Parser(tokenize("a @ 1, b @ 2 ="))
+    lvals = parser.parse_lvalues()
+    assert len(lvals) == 2
+    assert lvals[0].name == "a"
+    assert lvals[0].annotation.value == 1
+    assert lvals[1].name == "b"
+    assert lvals[1].annotation.value == 2
+
+
+def test_parse_qarg_with_annotation():
+    parser = QualtranL1Parser(tokenize("ctrl=qvar @ 1"))
+    qarg = parser.parse_qarg()
+    assert qarg.key == "ctrl"
+    assert qarg.annotation.value == 1
+
+    # Test array indexing on key too
+    parser = QualtranL1Parser(tokenize("reg[0]=qvar @ 2"))
+    qarg = parser.parse_qarg()
+    assert qarg.key == "reg[0]"
+    assert qarg.annotation.value == 2
+
+
+def test_parse_signature_with_annotation():
+    code = "qdef Foo() [ a: t @ 1 ] {}"
+    module = parse_module(code)
+    qdef = module.qdefs[0]
+    assert qdef.qsignature[0].annotation.value == 1

--- a/qualtran/l1/_parse_test.py
+++ b/qualtran/l1/_parse_test.py
@@ -33,6 +33,7 @@ from qualtran.l1.nodes import (
     LiteralNode,
     QArgValueNode,
     QCallNode,
+    QCastNode,
     QDefImplNode,
     QDTypeNode,
     QReturnNode,
@@ -458,3 +459,26 @@ def test_parse_signature_with_annotation():
     module = parse_module(code)
     qdef = module.qdefs[0]
     assert qdef.qsignature[0].annotation.value == 1
+
+
+def test_parse_qcast():
+    code = """# Qualtran-L1
+# 1.0.0
+
+qcast Split(QUInt(4))
+[reg: QUInt(4) -> QBit[4]]
+"""
+    module = parse_module(code)
+    assert len(module.qdefs) == 1
+    qdef = module.qdefs[0]
+    assert isinstance(qdef, QCastNode)
+    assert qdef.bloq_key == "Split(QUInt(4))"
+    assert len(qdef.qsignature) == 1
+    assert qdef.cobject_from is None
+
+    # Check the signature entry
+    sig = qdef.qsignature[0]
+    assert sig.name == "reg"
+    # It's a casting register: t1 -> t2
+    assert isinstance(sig.dtype, tuple)
+    assert len(sig.dtype) == 2

--- a/qualtran/l1/_roudtrip_test.py
+++ b/qualtran/l1/_roudtrip_test.py
@@ -49,10 +49,17 @@ def check_signatures(original, loaded):
 
 
 def check_bloq_object_roundtrip(original, loaded) -> list[str]:
+    from qualtran.bloqs.bookkeeping.qcast import QCast
+
     problems = []
     for bloq_key in original.keys():
         ref = original[bloq_key]
         tst = loaded[bloq_key]
+
+        # QCast bloqs intentionally lose object identity; signature
+        # equality (checked separately) is the right invariant for them.
+        if isinstance(tst, QCast):
+            continue
 
         if isinstance(tst, qlt.CompositeBloq):
 

--- a/qualtran/l1/_to_cobject_node.py
+++ b/qualtran/l1/_to_cobject_node.py
@@ -19,8 +19,9 @@ import sympy
 
 from qualtran import CtrlSpec, QDType, Side
 
+from . import nodes as qualtran_l1_nodes
 from ._dtypes import get_builtin_qdtypes
-from .nodes import CArgNode, CObjectNode, CValueNode, LiteralNode, TupleNode
+from .nodes import CArgNode, CObjectNode, CValueNode, L1Nodes, LiteralNode, TupleNode
 
 
 def _get_pkg(cls) -> str:
@@ -31,7 +32,11 @@ def _get_pkg(cls) -> str:
 
 
 def object_to_object_node(
-    o: object, *, fieldnames: Optional[Sequence[str]] = None, pkg: Optional[str] = None
+    o: object,
+    *,
+    fieldnames: Optional[Sequence[str]] = None,
+    pkg: Optional[str] = None,
+    nodes: L1Nodes = qualtran_l1_nodes,
 ) -> CObjectNode:
     """Convert an object to a CObjectNode.
 
@@ -54,6 +59,7 @@ def object_to_object_node(
             classmethod on the object, if present or 2) the class's `__module__` parts,
             excluding the final name. This matches the Qualtran convention of re-exporting
             bloq classes one level up.
+        nodes: The module providing the AST node constructors.
 
     Returns:
         A CObjectNode representing the object.
@@ -75,52 +81,58 @@ def object_to_object_node(
     kwargs: List[CArgNode] = []
     for fieldname, kwonly in zip(fieldnames, kwonlys):
         v = getattr(o, fieldname)
-        v = to_cobject_node(v)
+        v = to_cobject_node(v, nodes=nodes)
         if kwonly:
             pos = False
 
         if pos:
-            args.append(CArgNode(None, v))
+            args.append(nodes.CArgNode(None, v))
         else:
-            kwargs.append(CArgNode(fieldname, v))
+            kwargs.append(nodes.CArgNode(fieldname, v))
 
     pkg = _get_pkg(o.__class__) if pkg is None else str(pkg)
     name = o.__class__.__name__
     qualname = f'{pkg}.{name}' if pkg else name
-    return CObjectNode(name=f'{qualname}', cargs=args + kwargs)
+    return nodes.CObjectNode(name=f'{qualname}', cargs=args + kwargs)
 
 
-def unserializable_object(name: str) -> CObjectNode:
+def unserializable_object(name: str, *, nodes: L1Nodes = qualtran_l1_nodes) -> CObjectNode:
     """Create a CObjectNode representing an unserializable object.
 
     Args:
         name: The name or description of the unserializable object.
+        nodes: The module providing the AST node constructors.
 
     Returns:
         A CObjectNode with name 'Unserializable' and the given name as an argument.
     """
-    return CObjectNode(name='Unserializable', cargs=[CArgNode(None, LiteralNode(name))])
+    return nodes.CObjectNode(
+        name='Unserializable', cargs=[nodes.CArgNode(None, nodes.LiteralNode(name))]
+    )
 
 
-def tuple_to_tuplenode(t: tuple) -> TupleNode:
+def tuple_to_tuplenode(t: tuple, *, nodes: L1Nodes = qualtran_l1_nodes) -> TupleNode:
     """Convert a Python tuple to a TupleNode.
 
     Recursively converts each element of the tuple.
 
     Args:
         t: The tuple to convert.
+        nodes: The module providing the AST node constructors.
 
     Returns:
         A TupleNode containing the converted elements.
     """
     vals = []
     for v in t:
-        v = to_cobject_node(v)
+        v = to_cobject_node(v, nodes=nodes)
         vals.append(v)
-    return TupleNode(items=vals)
+    return nodes.TupleNode(items=vals)
 
 
-def ndarray_to_ndarr_objectnode(a: np.ndarray, max_size: int = 100) -> CObjectNode:
+def ndarray_to_ndarr_objectnode(
+    a: np.ndarray, max_size: int = 100, *, nodes: L1Nodes = qualtran_l1_nodes
+) -> CObjectNode:
     """Convert a numpy array to a CObjectNode representing an NDArr.
 
     If the array is too large (> `max_size` elements), it returns an unserializable object node.
@@ -128,19 +140,22 @@ def ndarray_to_ndarr_objectnode(a: np.ndarray, max_size: int = 100) -> CObjectNo
     Args:
         a: The numpy array to convert.
         max_size: The maximum number of elements before we give up on serialization.
+        nodes: The module providing the AST node constructors.
 
     Returns:
         A CObjectNode "NDArry" node representing the array (or an unserializable object).
     """
     if a.size > max_size:
-        return unserializable_object('ndarray_too_large')
+        return unserializable_object('ndarray_too_large', nodes=nodes)
 
-    shape = tuple_to_tuplenode(a.shape)
-    data = to_cobject_node(tuple(a.reshape(-1).tolist()))
-    return CObjectNode(name='NDArr', cargs=[CArgNode('shape', shape), CArgNode('data', data)])
+    shape = tuple_to_tuplenode(a.shape, nodes=nodes)
+    data = to_cobject_node(tuple(a.reshape(-1).tolist()), nodes=nodes)
+    return nodes.CObjectNode(
+        name='NDArr', cargs=[nodes.CArgNode('shape', shape), nodes.CArgNode('data', data)]
+    )
 
 
-def to_cobject_node(x: Any) -> CValueNode:
+def to_cobject_node(x: Any, *, nodes: L1Nodes = qualtran_l1_nodes) -> CValueNode:
     """Convert any supported Python value to a CValueNode.
 
     Include support for `None`, `True`, `False`, integers, strings, floats, tuples, and
@@ -153,47 +168,52 @@ def to_cobject_node(x: Any) -> CValueNode:
 
     Args:
         x: The value to convert.
+        nodes: The module providing the AST node constructors.
 
     Returns:
         A CValueNode representing the value.
     """
     if x is None:
-        return CObjectNode(name='None', cargs=[])
+        return nodes.CObjectNode(name='None', cargs=[])
 
     if isinstance(x, bool):
         if x:
-            return CObjectNode(name='True', cargs=[])
+            return nodes.CObjectNode(name='True', cargs=[])
         else:
-            return CObjectNode(name='False', cargs=[])
+            return nodes.CObjectNode(name='False', cargs=[])
 
     if isinstance(x, (str, int, float)):
-        return LiteralNode(value=x)
+        return nodes.LiteralNode(value=x)
 
     if isinstance(x, tuple):
-        return tuple_to_tuplenode(x)
+        return tuple_to_tuplenode(x, nodes=nodes)
 
     if isinstance(x, np.ndarray):
-        return ndarray_to_ndarr_objectnode(x)
+        return ndarray_to_ndarr_objectnode(x, nodes=nodes)
 
     if isinstance(x, CtrlSpec):
-        return object_to_object_node(x, fieldnames=['qdtypes', 'cvs'])
+        return object_to_object_node(x, fieldnames=['qdtypes', 'cvs'], nodes=nodes)
 
     if isinstance(x, sympy.Symbol):
         assert isinstance(x.name, str)
-        return CObjectNode(name='Symbol', cargs=[CArgNode(None, LiteralNode(x.name))])
+        return nodes.CObjectNode(
+            name='Symbol', cargs=[nodes.CArgNode(None, nodes.LiteralNode(x.name))]
+        )
 
     if isinstance(x, Side):
         assert isinstance(x.name, str)
-        return CObjectNode(name='Side', cargs=[CArgNode(None, LiteralNode(x.name))])
+        return nodes.CObjectNode(
+            name='Side', cargs=[nodes.CArgNode(None, nodes.LiteralNode(x.name))]
+        )
 
     if isinstance(x, QDType) and isinstance(x, get_builtin_qdtypes()):
-        return object_to_object_node(x, pkg='')
+        return object_to_object_node(x, pkg='', nodes=nodes)
 
     if attrs.has(x):
-        return object_to_object_node(x)
+        return object_to_object_node(x, nodes=nodes)
 
-    return unserializable_object(x.__class__.__name__)
+    return unserializable_object(x.__class__.__name__, nodes=nodes)
 
 
-def dump_objectstring(x: Any) -> str:
-    return to_cobject_node(x).canonical_str()
+def dump_objectstring(x: Any, *, nodes: L1Nodes = qualtran_l1_nodes) -> str:
+    return to_cobject_node(x, nodes=nodes).canonical_str()

--- a/qualtran/l1/_to_cobject_node.py
+++ b/qualtran/l1/_to_cobject_node.py
@@ -21,7 +21,7 @@ from qualtran import CtrlSpec, QDType, Side
 
 from . import nodes as qualtran_l1_nodes
 from ._dtypes import get_builtin_qdtypes
-from .nodes import CArgNode, CObjectNode, CValueNode, L1Nodes, LiteralNode, TupleNode
+from .nodes import CArgNode, CObjectNode, CValueNode, L1Nodes, TupleNode
 
 
 def _get_pkg(cls) -> str:

--- a/qualtran/l1/_to_l1.py
+++ b/qualtran/l1/_to_l1.py
@@ -11,6 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from __future__ import annotations
+
 import io
 import itertools
 import logging
@@ -26,6 +28,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    TYPE_CHECKING,
     TypeAlias,
     Union,
 )
@@ -34,32 +37,25 @@ import attrs
 import numpy as np
 
 import qualtran as qlt
-import qualtran.dtype as qdt
 from qualtran._infra.binst_graph_iterators import greedy_topological_sort
 from qualtran._infra.composite_bloq import _binst_to_cxns, _cxns_to_soq_dict
 from qualtran._infra.quantum_graph import _Soquet
 
 from . import nodes as qualtran_l1_nodes
-from ._dtypes import reg_to_qdtype_node, to_qdtype_node
+from ._dtypes import reg_to_qdtype_node
 from ._to_cobject_node import to_cobject_node, unserializable_object
-from .nodes import (
-    AliasAssignmentNode,
-    CObjectNode,
-    L1Module,
-    L1Nodes,
-    LValueNode,
-    QArgNode,
-    QArgValueNode,
-    QCallNode,
-    QCastNode,
-    QDefExternNode,
-    QDefImplNode,
-    QDefNode,
-    QDTypeNode,
-    QReturnNode,
-    QSignatureEntry,
-    StatementNode,
-)
+from .nodes import L1Nodes
+
+if TYPE_CHECKING:
+    from .nodes import (
+        CObjectNode,
+        L1Module,
+        QArgNode,
+        QArgValueNode,
+        QDefNode,
+        QSignatureEntry,
+        StatementNode,
+    )
 
 BloqKey: TypeAlias = str
 
@@ -116,10 +112,7 @@ class Locals:
 
 
 def regs_to_sig_entry(
-    reg_name: str,
-    regs: Sequence['qlt.Register'],
-    *,
-    nodes: L1Nodes = qualtran_l1_nodes,
+    reg_name: str, regs: Sequence['qlt.Register'], *, nodes: L1Nodes = qualtran_l1_nodes
 ) -> QSignatureEntry:
     """Convert a register group (from `Signature.groups()`) to a `QSignatureEntry`.
 
@@ -138,53 +131,34 @@ def regs_to_sig_entry(
         r1, r2 = regs
         if r1.side is qlt.Side.LEFT and r2.side is qlt.Side.RIGHT:
             return nodes.QSignatureEntry(
-                reg_name,
-                (
-                    reg_to_qdtype_node(r1, nodes=nodes),
-                    reg_to_qdtype_node(r2, nodes=nodes),
-                ),
+                reg_name, (reg_to_qdtype_node(r1, nodes=nodes), reg_to_qdtype_node(r2, nodes=nodes))
             )
         elif r2.side is qlt.Side.LEFT and r1.side is qlt.Side.RIGHT:
             return nodes.QSignatureEntry(
-                reg_name,
-                (
-                    reg_to_qdtype_node(r2, nodes=nodes),
-                    reg_to_qdtype_node(r1, nodes=nodes),
-                ),
+                reg_name, (reg_to_qdtype_node(r2, nodes=nodes), reg_to_qdtype_node(r1, nodes=nodes))
             )
         raise ValueError(f'Bad register sides for {reg_name}: {regs}')
 
     (r,) = regs
     if r.side is qlt.Side.THRU:
-        return nodes.QSignatureEntry(
-            reg_name, reg_to_qdtype_node(r, nodes=nodes)
-        )
+        return nodes.QSignatureEntry(reg_name, reg_to_qdtype_node(r, nodes=nodes))
     elif r.side is qlt.Side.RIGHT:
-        return nodes.QSignatureEntry(
-            reg_name, (None, reg_to_qdtype_node(r, nodes=nodes))
-        )
+        return nodes.QSignatureEntry(reg_name, (None, reg_to_qdtype_node(r, nodes=nodes)))
     elif r.side is qlt.Side.LEFT:
-        return nodes.QSignatureEntry(
-            reg_name, (reg_to_qdtype_node(r, nodes=nodes), None)
-        )
+        return nodes.QSignatureEntry(reg_name, (reg_to_qdtype_node(r, nodes=nodes), None))
     else:
         raise ValueError(f'Bad side for {r}')
 
 
 def signature_to_l1_entries(
-    signature: 'qlt.Signature',
-    *,
-    nodes: L1Nodes = qualtran_l1_nodes,
+    signature: 'qlt.Signature', *, nodes: L1Nodes = qualtran_l1_nodes
 ) -> List[QSignatureEntry]:
     """Convert a `qualtran.Signature` to a list of `QSignatureEntry` AST nodes.
 
     This is a convenience wrapper around `regs_to_sig_entry` for all register
     groups in the signature.
     """
-    return [
-        regs_to_sig_entry(reg_name, regs, nodes=nodes)
-        for reg_name, regs in signature.groups()
-    ]
+    return [regs_to_sig_entry(reg_name, regs, nodes=nodes) for reg_name, regs in signature.groups()]
 
 
 @attrs.mutable
@@ -243,12 +217,12 @@ class QDefBuilder:
             self._sig_entries.append(entry)
 
     def finalize_extern(self, reason: str = ''):
+        cobject_from: CObjectNode
         if isinstance(self.bloq, qlt.CompositeBloq):
             warnings.warn("Tried to `extern` a CompositeBloq. You will not be able to load this.")
-            cobject_from_val = unserializable_object('CompositeBloq', nodes=self.nodes)
+            cobject_from = unserializable_object('CompositeBloq', nodes=self.nodes)
         else:
-            cobject_from_val = to_cobject_node(self.bloq, nodes=self.nodes)
-        cobject_from = cobject_from_val
+            cobject_from = to_cobject_node(self.bloq, nodes=self.nodes)  # type: ignore[assignment]
         return QDefWithContext(
             qdef=self.nodes.QDefExternNode(
                 bloq_key=self.bloq_key, qsignature=self._sig_entries, cobject_from=cobject_from
@@ -394,8 +368,7 @@ class QDefBuilder:
         elif isinstance(self.bloq, qlt.CompositeBloq):
             cobject_from = None
         else:
-            cobject_from_val = to_cobject_node(self.bloq, nodes=self.nodes)
-            cobject_from = cobject_from_val
+            cobject_from = to_cobject_node(self.bloq, nodes=self.nodes)  # type: ignore[assignment]
 
         return QDefWithContext(
             qdef=self.nodes.QDefImplNode(
@@ -483,8 +456,6 @@ def bloq_to_ast(
     return qdb.finalize(extern_only_from=extern_only_from), list(qdb.qlocals.bloqvars.keys())
 
 
-
-
 @attrs.mutable(kw_only=True)
 class L1ModuleBuilder:
     """Format and export a Qualtran-L1 'module': a collection of 'qdef' bloq definitions."""
@@ -495,7 +466,6 @@ class L1ModuleBuilder:
     extern_qdefs: List[QDefWithContext] = attrs.field(factory=list)
     nodes: L1Nodes = attrs.field(default=qualtran_l1_nodes)
     # all_costs: Dict['CostKey', Dict] = attrs.field(factory=dict)
-
 
     def add_bloqs(
         self,
@@ -544,9 +514,7 @@ class L1ModuleBuilder:
         return self.qglobals[root]
 
     def finalize(self) -> L1Module:
-        return self.nodes.L1Module(
-            qdefs=tuple(qdef_with_ctx.qdef for qdef_with_ctx in self.qdefs),
-        )
+        return self.nodes.L1Module(qdefs=tuple(qdef_with_ctx.qdef for qdef_with_ctx in self.qdefs))
 
     def pretty_print_qdef(self, bloq_or_bloq_key: Union[qlt.Bloq, BloqKey], f=None) -> None:
         from qualtran.l1 import L1ASTPrinter

--- a/qualtran/l1/_to_l1.py
+++ b/qualtran/l1/_to_l1.py
@@ -248,7 +248,6 @@ class QDefBuilder:
             cobject_from_val = unserializable_object('CompositeBloq', nodes=self.nodes)
         else:
             cobject_from_val = to_cobject_node(self.bloq, nodes=self.nodes)
-        assert isinstance(cobject_from_val, self.nodes.CObjectNode)
         cobject_from = cobject_from_val
         return QDefWithContext(
             qdef=self.nodes.QDefExternNode(
@@ -396,7 +395,6 @@ class QDefBuilder:
             cobject_from = None
         else:
             cobject_from_val = to_cobject_node(self.bloq, nodes=self.nodes)
-            assert isinstance(cobject_from_val, self.nodes.CObjectNode)
             cobject_from = cobject_from_val
 
         return QDefWithContext(

--- a/qualtran/l1/_to_l1.py
+++ b/qualtran/l1/_to_l1.py
@@ -15,6 +15,7 @@ import io
 import itertools
 import logging
 import uuid
+import warnings
 from typing import (
     Callable,
     cast,
@@ -33,22 +34,28 @@ import attrs
 import numpy as np
 
 import qualtran as qlt
+import qualtran.dtype as qdt
 from qualtran._infra.binst_graph_iterators import greedy_topological_sort
 from qualtran._infra.composite_bloq import _binst_to_cxns, _cxns_to_soq_dict
+from qualtran._infra.quantum_graph import _Soquet
 
-from .._infra.quantum_graph import _Soquet
-from ._dtypes import reg_to_qdtype_node
-from ._to_cobject_node import to_cobject_node
+from . import nodes as qualtran_l1_nodes
+from ._dtypes import reg_to_qdtype_node, to_qdtype_node
+from ._to_cobject_node import to_cobject_node, unserializable_object
 from .nodes import (
     AliasAssignmentNode,
     CObjectNode,
     L1Module,
+    L1Nodes,
+    LValueNode,
     QArgNode,
     QArgValueNode,
     QCallNode,
+    QCastNode,
     QDefExternNode,
     QDefImplNode,
     QDefNode,
+    QDTypeNode,
     QReturnNode,
     QSignatureEntry,
     StatementNode,
@@ -78,6 +85,7 @@ class Locals:
     soqvars: Dict[_Soquet, QArgValueNode] = attrs.field(factory=dict)
     bloqvars: Dict[qlt.Bloq, BloqKey] = attrs.field(factory=dict)
     varnames: Set[str] = attrs.field(factory=set)
+    nodes: L1Nodes = attrs.field(default=qualtran_l1_nodes)
 
     def get_unique_name(self, prefix: str) -> str:
         """Get and register a unique name."""
@@ -98,7 +106,7 @@ class Locals:
 
     def assign_soq(self, soq: _Soquet, prefix: str) -> str:
         name = self.get_unique_name(prefix)
-        self.soqvars[soq] = QArgValueNode(name, ())
+        self.soqvars[soq] = self.nodes.QArgValueNode(name, ())
         return name
 
     def assign_bloq(self, bloq: qlt.Bloq, prefix: str) -> str:
@@ -107,40 +115,127 @@ class Locals:
         return name
 
 
+def regs_to_sig_entry(
+    reg_name: str,
+    regs: Sequence['qlt.Register'],
+    *,
+    nodes: L1Nodes = qualtran_l1_nodes,
+) -> QSignatureEntry:
+    """Convert a register group (from `Signature.groups()`) to a `QSignatureEntry`.
+
+    This is the pure conversion logic without any side effects such as
+    annotation or local-variable registration.
+
+    Args:
+        reg_name: The register group name.
+        regs: The 1- or 2-element sequence of registers for this group.
+        nodes: The module providing the AST node constructors.
+    """
+    if len(regs) not in [1, 2]:
+        raise ValueError(f'Bad regs for {reg_name}')
+
+    if len(regs) == 2:
+        r1, r2 = regs
+        if r1.side is qlt.Side.LEFT and r2.side is qlt.Side.RIGHT:
+            return nodes.QSignatureEntry(
+                reg_name,
+                (
+                    reg_to_qdtype_node(r1, nodes=nodes),
+                    reg_to_qdtype_node(r2, nodes=nodes),
+                ),
+            )
+        elif r2.side is qlt.Side.LEFT and r1.side is qlt.Side.RIGHT:
+            return nodes.QSignatureEntry(
+                reg_name,
+                (
+                    reg_to_qdtype_node(r2, nodes=nodes),
+                    reg_to_qdtype_node(r1, nodes=nodes),
+                ),
+            )
+        raise ValueError(f'Bad register sides for {reg_name}: {regs}')
+
+    (r,) = regs
+    if r.side is qlt.Side.THRU:
+        return nodes.QSignatureEntry(
+            reg_name, reg_to_qdtype_node(r, nodes=nodes)
+        )
+    elif r.side is qlt.Side.RIGHT:
+        return nodes.QSignatureEntry(
+            reg_name, (None, reg_to_qdtype_node(r, nodes=nodes))
+        )
+    elif r.side is qlt.Side.LEFT:
+        return nodes.QSignatureEntry(
+            reg_name, (reg_to_qdtype_node(r, nodes=nodes), None)
+        )
+    else:
+        raise ValueError(f'Bad side for {r}')
+
+
+def signature_to_l1_entries(
+    signature: 'qlt.Signature',
+    *,
+    nodes: L1Nodes = qualtran_l1_nodes,
+) -> List[QSignatureEntry]:
+    """Convert a `qualtran.Signature` to a list of `QSignatureEntry` AST nodes.
+
+    This is a convenience wrapper around `regs_to_sig_entry` for all register
+    groups in the signature.
+    """
+    return [
+        regs_to_sig_entry(reg_name, regs, nodes=nodes)
+        for reg_name, regs in signature.groups()
+    ]
+
+
 @attrs.mutable
 class QDefBuilder:
     bloq: qlt.Bloq
     bloq_key: str
     qglobals: Dict[qlt.Bloq, str]
+    nodes: L1Nodes = attrs.field(default=qualtran_l1_nodes)
     qlocals: Locals = attrs.field(factory=Locals)
 
     _sig_entries: List[QSignatureEntry] = attrs.field(factory=list)
     _stmnts: List[StatementNode] = attrs.field(factory=list)
 
+    def __attrs_post_init__(self):
+        if self.qlocals.nodes is qualtran_l1_nodes and self.nodes is not qualtran_l1_nodes:
+            self.qlocals.nodes = self.nodes
+
+    def _get_sig_entry_annotation(self, reg: 'qlt.Register') -> Optional[CObjectNode]:
+        """Determine annotation based on wire symbol."""
+        from qualtran.drawing import Circle, ModPlus
+
+        if reg.shape:
+            # TODO: Support for shaped registers.
+            return None
+
+        annotation: Optional[CObjectNode] = None
+        symbol = self.bloq.wire_symbol(reg)
+        if isinstance(symbol, Circle):
+            if symbol.filled:
+                annotation = self.nodes.CObjectNode('dot', cargs=())
+            else:
+                annotation = self.nodes.CObjectNode('circle', cargs=())
+        elif isinstance(symbol, ModPlus):
+            annotation = self.nodes.CObjectNode('oplus', cargs=())
+        return annotation
+
     def _get_sig_entry(self, reg_name: str, regs: Sequence['qlt.Register']) -> QSignatureEntry:
-        if len(regs) not in [1, 2]:
-            raise ValueError(f'Bad regs for {reg_name}')
+        entry = regs_to_sig_entry(reg_name, regs, nodes=self.nodes)
 
-        if len(regs) == 2:
-            r1, r2 = regs
-            if r1.side is qlt.Side.LEFT and r2.side is qlt.Side.RIGHT:
-                self.qlocals.register_name(r1.name)
-                return QSignatureEntry(reg_name, (reg_to_qdtype_node(r1), reg_to_qdtype_node(r2)))
-            elif r2.side is qlt.Side.LEFT and r1.side is qlt.Side.RIGHT:
-                self.qlocals.register_name(r2.name)
-                return QSignatureEntry(reg_name, (reg_to_qdtype_node(r2), reg_to_qdtype_node(r1)))
+        # Layer on annotation from wire symbols
+        # TODO: Handle the case for different r1 vs r2
+        annotation = self._get_sig_entry_annotation(regs[0])
+        if annotation is not None:
+            entry = attrs.evolve(entry, annotation=annotation)
 
-        (r,) = regs
-        if r.side is qlt.Side.THRU:
-            self.qlocals.register_name(r.name)
-            return QSignatureEntry(reg_name, reg_to_qdtype_node(r))
-        elif r.side is qlt.Side.RIGHT:
-            return QSignatureEntry(reg_name, (None, reg_to_qdtype_node(r)))
-        elif r.side is qlt.Side.LEFT:
-            self.qlocals.register_name(r.name)
-            return QSignatureEntry(reg_name, (reg_to_qdtype_node(r), None))
-        else:
-            raise ValueError(f'Bad side for {r}')
+        # Register local variable names for LEFT/THRU registers
+        for r in regs:
+            if r.side in (qlt.Side.LEFT, qlt.Side.THRU):
+                self.qlocals.register_name(r.name)
+
+        return entry
 
     def add_signature(self, signature: 'qlt.Signature') -> None:
         for reg_name, regs in signature.groups():
@@ -148,11 +243,15 @@ class QDefBuilder:
             self._sig_entries.append(entry)
 
     def finalize_extern(self, reason: str = ''):
-        cobject_from_val = to_cobject_node(self.bloq)
-        assert isinstance(cobject_from_val, CObjectNode)
+        if isinstance(self.bloq, qlt.CompositeBloq):
+            warnings.warn("Tried to `extern` a CompositeBloq. You will not be able to load this.")
+            cobject_from_val = unserializable_object('CompositeBloq', nodes=self.nodes)
+        else:
+            cobject_from_val = to_cobject_node(self.bloq, nodes=self.nodes)
+        assert isinstance(cobject_from_val, self.nodes.CObjectNode)
         cobject_from = cobject_from_val
         return QDefWithContext(
-            qdef=QDefExternNode(
+            qdef=self.nodes.QDefExternNode(
                 bloq_key=self.bloq_key, qsignature=self._sig_entries, cobject_from=cobject_from
             ),
             bloq=self.bloq,
@@ -160,10 +259,19 @@ class QDefBuilder:
             extern_reason=reason,
         )
 
+    def finalize_qcast(self) -> QDefWithContext:
+        """Finalize as a qcast (casting operation) definition."""
+        return QDefWithContext(
+            qdef=self.nodes.QCastNode(bloq_key=self.bloq_key, qsignature=self._sig_entries),
+            bloq=self.bloq,
+            implemented=False,
+            extern_reason='qcast',
+        )
+
     def add_alias_assignment_heuristically(self, bloq: qlt.Bloq) -> None:
 
         if bloq not in self.qglobals:
-            bloq_key = _get_unique_bloq_key(bloq, self.qglobals.values())
+            bloq_key = _get_unique_bloq_key(bloq, self.qglobals.values(), nodes=self.nodes)
             self.qglobals[bloq] = bloq_key
         else:
             bloq_key = self.qglobals[bloq]
@@ -175,9 +283,9 @@ class QDefBuilder:
         # If it's longer than 20 characters, make an alias.
         should_alias = len(bloq_key) > 20
         if should_alias:
-            prefix = _guess_good_alias_prefix(bloq)
+            prefix = _guess_good_alias_prefix(bloq, nodes=self.nodes)
             alias_str = self.qlocals.assign_bloq(bloq, prefix=prefix)
-            self._stmnts.append(AliasAssignmentNode(alias=alias_str, bloq_key=bloq_key))
+            self._stmnts.append(self.nodes.AliasAssignmentNode(alias=alias_str, bloq_key=bloq_key))
         else:
             self.qlocals.bloqvars[bloq] = bloq_key
 
@@ -194,10 +302,10 @@ class QDefBuilder:
             for suc in succs:
                 reg = suc.left.reg
                 if reg.shape:
-                    v = QArgValueNode(reg.name, suc.left.idx)
+                    v = self.nodes.QArgValueNode(reg.name, suc.left.idx)
                     self.qlocals.soqvars[suc.left] = v
                 else:
-                    v = QArgValueNode(reg.name, ())
+                    v = self.nodes.QArgValueNode(reg.name, ())
                     self.qlocals.soqvars[suc.left] = v
             return
 
@@ -219,11 +327,13 @@ class QDefBuilder:
                     arr = np.empty(soqs.shape, dtype=object)
                     for idx in itertools.product(*[range(sh) for sh in soqs.shape]):
                         arr[idx] = self.qlocals.soqvars[soqs[idx]]
-                    kwargs.append(QArgNode(regname, arr.tolist()))
+                    kwargs.append(self.nodes.QArgNode(regname, arr.tolist()))
                 else:
-                    kwargs.append(QArgNode(regname, self.qlocals.soqvars[cast(_Soquet, soqs)]))
+                    kwargs.append(
+                        self.nodes.QArgNode(regname, self.qlocals.soqvars[cast(_Soquet, soqs)])
+                    )
 
-            self._stmnts.append(QReturnNode(ret_mapping=kwargs))
+            self._stmnts.append(self.nodes.QReturnNode(ret_mapping=kwargs))
             return
 
         # Otherwise, this is a qcall to a sub-bloq.
@@ -241,9 +351,11 @@ class QDefBuilder:
                 arr = np.empty(soqs.shape, dtype=object)
                 for idx in itertools.product(*[range(sh) for sh in soqs.shape]):
                     arr[idx] = self.qlocals.soqvars[soqs[idx]]
-                kwargs.append(QArgNode(regname, arr.tolist()))
+                kwargs.append(self.nodes.QArgNode(regname, arr.tolist()))
             else:
-                kwargs.append(QArgNode(regname, self.qlocals.soqvars[cast(_Soquet, soqs)]))
+                kwargs.append(
+                    self.nodes.QArgNode(regname, self.qlocals.soqvars[cast(_Soquet, soqs)])
+                )
 
         # B: Handle output variables from the subbloq
         retsoqs = _cxns_to_soq_dict(
@@ -261,30 +373,34 @@ class QDefBuilder:
             if qlt.BloqBuilder.is_ndarray(soqs):
                 for idx in itertools.product(*[range(sh) for sh in soqs.shape]):
                     # Track indexed soquets as independent local variables
-                    self.qlocals.soqvars[soqs[idx]] = QArgValueNode(basename, idx)
+                    self.qlocals.soqvars[soqs[idx]] = self.nodes.QArgValueNode(basename, idx)
                 # But syntactically, we assign to an indexless basename.
                 rets.append(basename)
             else:
-                self.qlocals.soqvars[cast(_Soquet, soqs)] = QArgValueNode(basename, ())
+                self.qlocals.soqvars[cast(_Soquet, soqs)] = self.nodes.QArgValueNode(basename, ())
                 rets.append(basename)
 
         # C. Record the call itself to `binst.bloq`.
         self._stmnts.append(
-            QCallNode(bloq_key=self.qlocals.bloqvars[binst.bloq], lvalues=rets, qargs=kwargs)
+            self.nodes.QCallNode(
+                bloq_key=self.qlocals.bloqvars[binst.bloq],
+                lvalues=[self.nodes.LValueNode(r) for r in rets],
+                qargs=kwargs,
+            )
         )
 
-    def finalize(self, extern_only_from: bool):
+    def finalize(self, extern_only_from: bool) -> QDefWithContext:
         if extern_only_from:
             cobject_from = None
         elif isinstance(self.bloq, qlt.CompositeBloq):
             cobject_from = None
         else:
-            cobject_from_val = to_cobject_node(self.bloq)
-            assert isinstance(cobject_from_val, CObjectNode)
+            cobject_from_val = to_cobject_node(self.bloq, nodes=self.nodes)
+            assert isinstance(cobject_from_val, self.nodes.CObjectNode)
             cobject_from = cobject_from_val
 
         return QDefWithContext(
-            qdef=QDefImplNode(
+            qdef=self.nodes.QDefImplNode(
                 bloq_key=self.bloq_key,
                 qsignature=self._sig_entries,
                 body=self._stmnts,
@@ -294,20 +410,15 @@ class QDefBuilder:
             implemented=True,
         )
 
-    # qlocals: Locals = attrs.field(factory=Locals)
-    # calls: List[FormattedCall] = attrs.field(factory=list)
-    # aliases: List[Alias] = attrs.field(factory=list)
-    # ret_qargs: str = ''
-    # implemented: bool = True
-    # extern_only_from: bool = False
 
-
-def bloq_to_code(
+def bloq_to_ast(
     bloq: qlt.Bloq,
     qglobals: Dict[qlt.Bloq, BloqKey],
     *,
     extern_only_from: bool,
     force_extern: bool = False,
+    level: int = 0,
+    nodes: L1Nodes = qualtran_l1_nodes,
 ) -> Tuple[QDefWithContext, List['qlt.Bloq']]:
     """Turn a bloq into Qualtran-L1 code.
 
@@ -321,11 +432,14 @@ def bloq_to_code(
     if bloq in qglobals:
         bloq_key = qglobals[bloq]
     else:
-        bloq_key = _get_unique_bloq_key(bloq, qglobals.values())
+        bloq_key = _get_unique_bloq_key(bloq, qglobals.values(), nodes=nodes)
         qglobals[bloq] = bloq_key
 
-    qdb = QDefBuilder(bloq=bloq, bloq_key=bloq_key, qglobals=qglobals)
-    log.info("Compiling %s -> %s", repr(bloq), bloq_key)
+    qdb = QDefBuilder(
+        bloq=bloq, bloq_key=bloq_key, qglobals=qglobals, nodes=nodes, qlocals=Locals(nodes=nodes)
+    )
+    indent = ' ' * level
+    log.info("%sCompiling %s -> %s", indent, repr(bloq), bloq_key)
 
     # Signature
     qdb.add_signature(bloq.signature)
@@ -333,6 +447,17 @@ def bloq_to_code(
     if force_extern:
         return qdb.finalize_extern(reason='force_extern'), []
 
+    # Detect bookkeeping / casting bloqs and emit as qcast.
+    # Alloc and Free are _BookkeepingBloqs but are *not* casts.
+    from qualtran.bloqs.bookkeeping._bookkeeping_bloq import _BookkeepingBloq
+    from qualtran.bloqs.bookkeeping.allocate import Allocate
+    from qualtran.bloqs.bookkeeping.free import Free
+    from qualtran.bloqs.bookkeeping.qcast import QCast
+
+    if isinstance(bloq, (Allocate, Free)):
+        return qdb.finalize_extern(reason='alloc/free'), []
+    if isinstance(bloq, (_BookkeepingBloq, QCast)):
+        return qdb.finalize_qcast(), []
     if isinstance(bloq, qlt.CompositeBloq):
         cbloq = bloq
     else:
@@ -360,6 +485,8 @@ def bloq_to_code(
     return qdb.finalize(extern_only_from=extern_only_from), list(qdb.qlocals.bloqvars.keys())
 
 
+
+
 @attrs.mutable(kw_only=True)
 class L1ModuleBuilder:
     """Format and export a Qualtran-L1 'module': a collection of 'qdef' bloq definitions."""
@@ -368,7 +495,9 @@ class L1ModuleBuilder:
     done: Set[qlt.Bloq] = attrs.field(factory=set)
     qdefs: List[QDefWithContext] = attrs.field(factory=list)
     extern_qdefs: List[QDefWithContext] = attrs.field(factory=list)
+    nodes: L1Nodes = attrs.field(default=qualtran_l1_nodes)
     # all_costs: Dict['CostKey', Dict] = attrs.field(factory=dict)
+
 
     def add_bloqs(
         self,
@@ -378,27 +507,30 @@ class L1ModuleBuilder:
         extern_only_from: bool = True,
         force_extern_pred: Callable[['qlt.Bloq'], bool] = lambda b: False,
     ) -> BloqKey:
-        # returns the bloq key of the root bloq
-        subbloqs = [root]
+
+        # Stack of (Bloq, level) indices where `level` is the level of recursion
+        subbloqs: List[Tuple[qlt.Bloq, int]] = [(root, 0)]
 
         # cks = [QECGatesCost(), QubitCount()]
         # if not self.all_costs:
         #     self.all_costs = {ck: {} for ck in cks}
 
         while subbloqs:
-            bloq: qlt.Bloq = subbloqs.pop(0)
+            bloq, level = subbloqs.pop(0)
             if bloq in self.done:
                 continue
 
             force_extern = force_extern_pred(bloq)
 
-            qdef, new_subbloqs = bloq_to_code(
+            qdef, new_subbloqs = bloq_to_ast(
                 bloq=bloq,
                 qglobals=self.qglobals,
                 extern_only_from=extern_only_from,
                 force_extern=force_extern,
+                level=level,
+                nodes=self.nodes,
             )
-            subbloqs += new_subbloqs
+            subbloqs += [(nsb, level + 1) for nsb in new_subbloqs]
 
             # if annotate_costs:
             #     lines = get_cost_lines(bloq, cks, self.all_costs)
@@ -414,7 +546,9 @@ class L1ModuleBuilder:
         return self.qglobals[root]
 
     def finalize(self) -> L1Module:
-        return L1Module(qdefs=tuple(qdef_with_ctx.qdef for qdef_with_ctx in self.qdefs))
+        return self.nodes.L1Module(
+            qdefs=tuple(qdef_with_ctx.qdef for qdef_with_ctx in self.qdefs),
+        )
 
     def pretty_print_qdef(self, bloq_or_bloq_key: Union[qlt.Bloq, BloqKey], f=None) -> None:
         from qualtran.l1 import L1ASTPrinter
@@ -449,10 +583,11 @@ def dump_l1(
     annotate_costs: bool = False,
     extern_only_from: bool = False,
     force_extern_pred: Callable[['qlt.Bloq'], bool] = lambda b: False,
+    nodes: L1Nodes = qualtran_l1_nodes,
 ) -> Optional[str]:
     from qualtran.l1 import L1ASTPrinter
 
-    l1_mb = L1ModuleBuilder()
+    l1_mb = L1ModuleBuilder(nodes=nodes)
     root_bloq_key = l1_mb.add_bloqs(
         root=bloq,
         annotate_costs=annotate_costs,
@@ -469,7 +604,7 @@ def dump_l1(
     return root_bloq_key
 
 
-def dump_root_l1(bloq: qlt.Bloq) -> str:
+def dump_root_l1(bloq: qlt.Bloq, *, nodes: L1Nodes = qualtran_l1_nodes) -> str:
     from qualtran.l1 import L1ASTPrinter
 
     def extern_all_but_root(b: qlt.Bloq) -> bool:
@@ -477,7 +612,7 @@ def dump_root_l1(bloq: qlt.Bloq) -> str:
             return False
         return True
 
-    l1_mb = L1ModuleBuilder()
+    l1_mb = L1ModuleBuilder(nodes=nodes)
     _root_bloq_key = l1_mb.add_bloqs(
         root=bloq, extern_only_from=True, force_extern_pred=extern_all_but_root
     )
@@ -487,14 +622,15 @@ def dump_root_l1(bloq: qlt.Bloq) -> str:
     return l1_txt
 
 
-def _get_unique_bloq_key(bloq: qlt.Bloq, bloq_keys: Container[str]) -> str:
+def _get_unique_bloq_key(
+    bloq: qlt.Bloq, bloq_keys: Container[str], *, nodes: L1Nodes = qualtran_l1_nodes
+) -> str:
     """Heuristic for writing a human-readable bloq key"""
     from qualtran.l1 import parse_objectstring
-    from qualtran.l1.nodes import CArgNode, LiteralNode
 
     key = str(bloq).replace('†', '_dag')
     try:
-        structured_key = parse_objectstring(key)
+        structured_key = parse_objectstring(key, nodes=nodes)
         key = structured_key.canonical_str()
         if key not in bloq_keys:
             log.debug("Using structured __str__ for %s", bloq)
@@ -502,7 +638,7 @@ def _get_unique_bloq_key(bloq: qlt.Bloq, bloq_keys: Container[str]) -> str:
         i = 1
         while True:
             new_cargs = tuple(structured_key.cargs) + (
-                CArgNode(key='variant', value=LiteralNode(value=i)),
+                nodes.CArgNode(key='variant', value=nodes.LiteralNode(value=i)),
             )
             key = attrs.evolve(structured_key, cargs=new_cargs).canonical_str()
             if key not in bloq_keys:
@@ -516,14 +652,14 @@ def _get_unique_bloq_key(bloq: qlt.Bloq, bloq_keys: Container[str]) -> str:
         return f'bloq{uuid.uuid4().hex}'
 
 
-def _guess_good_alias_prefix(bloq: qlt.Bloq):
+def _guess_good_alias_prefix(bloq: qlt.Bloq, *, nodes: L1Nodes = qualtran_l1_nodes):
     """Heuristic for coming up with a good bloq object alias name"""
 
     from qualtran.l1 import parse_objectstring
 
     key = str(bloq).replace('†', '_dag')
     try:
-        structured_key = parse_objectstring(key)
+        structured_key = parse_objectstring(key, nodes=nodes)
         name = structured_key.name
     except ValueError:
         name = bloq.__class__.__name__

--- a/qualtran/l1/_to_l1_test.py
+++ b/qualtran/l1/_to_l1_test.py
@@ -1,0 +1,74 @@
+#  Copyright 2026 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import qualtran as qlt
+import qualtran.dtype as qdt
+from qualtran.drawing import Circle
+from qualtran.l1 import L1ASTPrinter, L1ModuleBuilder
+
+
+class MyBloq(qlt.Bloq):
+    @property
+    def signature(self) -> qlt.Signature:
+        return qlt.Signature(
+            [qlt.Register('ctrl', qdt.QBit()), qlt.Register('neg_ctrl', qdt.QBit())]
+        )
+
+    def wire_symbol(self, reg: qlt.Register):
+        if reg.name == 'ctrl':
+            return Circle(filled=False)
+        elif reg.name == 'neg_ctrl':
+            return Circle(filled=True)
+        return super().wire_symbol(reg)
+
+
+def test_wire_symbol_annotations():
+    bloq = MyBloq()
+    l1_mb = L1ModuleBuilder()
+    l1_mb.add_bloqs(bloq, force_extern_pred=lambda b: True)
+    l1_mod = l1_mb.finalize()
+    l1_txt = L1ASTPrinter().visit(l1_mod)
+
+    assert "ctrl: QBit @ circle" in l1_txt
+    assert "neg_ctrl: QBit @ dot" in l1_txt
+
+
+def test_alloc_free_are_extern_not_qcast():
+    """Allocate and Free are _BookkeepingBloqs but should be extern qdef, not qcast."""
+    from qualtran.bloqs.bookkeeping.allocate import Allocate
+    from qualtran.bloqs.bookkeeping.cast import Cast
+    from qualtran.bloqs.bookkeeping.free import Free
+    from qualtran.bloqs.bookkeeping.join import Join
+    from qualtran.bloqs.bookkeeping.split import Split
+    from qualtran.l1._to_l1 import bloq_to_ast
+    from qualtran.l1.nodes import QCastNode, QDefExternNode
+
+    # Allocate and Free should produce QDefExternNode
+    for bloq in [
+        Allocate(qdt.QBit()),
+        Free(qdt.QBit()),
+        Allocate(qdt.QUInt(4)),
+        Free(qdt.QUInt(4)),
+    ]:
+        qdef_ctx, _ = bloq_to_ast(bloq, {}, extern_only_from=False)
+        assert isinstance(
+            qdef_ctx.qdef, QDefExternNode
+        ), f'{bloq} should be QDefExternNode, got {type(qdef_ctx.qdef).__name__}'
+
+    # True casting bloqs should still produce QCastNode
+    for bloq in [Cast(qdt.QUInt(4), qdt.QUInt(4)), Split(qdt.QUInt(4)), Join(qdt.QUInt(4))]:
+        qdef_ctx, _ = bloq_to_ast(bloq, {}, extern_only_from=False)
+        assert isinstance(
+            qdef_ctx.qdef, QCastNode
+        ), f'{bloq} should be QCastNode, got {type(qdef_ctx.qdef).__name__}'

--- a/qualtran/l1/nodes.py
+++ b/qualtran/l1/nodes.py
@@ -114,8 +114,6 @@ class QSignatureEntry(L1ASTNode):
     annotation: Optional[CValueNode] = None
 
 
-
-
 @attrs.frozen
 class LValueNode(L1ASTNode):
     """An l-value with an optional annotation."""
@@ -287,8 +285,6 @@ class QCastNode(QDefNode):
     @property
     def cobject_from(self) -> Optional[CObjectNode]:
         return None
-
-
 
 
 @attrs.frozen

--- a/qualtran/l1/nodes.py
+++ b/qualtran/l1/nodes.py
@@ -14,7 +14,7 @@
 """The Qualtran-L1 AST Nodes."""
 
 import abc
-from typing import Optional, Sequence, Tuple, TypeAlias, Union
+from typing import Any, Optional, Protocol, Sequence, Tuple, TypeAlias, Union
 
 import attrs
 
@@ -111,6 +111,22 @@ class QSignatureEntry(L1ASTNode):
 
     name: str
     dtype: Union[QDTypeNode, Tuple[Optional[QDTypeNode], Optional[QDTypeNode]]]
+    annotation: Optional[CValueNode] = None
+
+
+
+
+@attrs.frozen
+class LValueNode(L1ASTNode):
+    """An l-value with an optional annotation."""
+
+    name: str
+    annotation: Optional[CValueNode] = None
+
+    def __str__(self):
+        if self.annotation:
+            return f'{self.name} @ {self.annotation.canonical_str()}'
+        return self.name
 
 
 class StatementNode(L1ASTNode, metaclass=abc.ABCMeta):
@@ -160,6 +176,7 @@ class QArgNode(L1ASTNode):
 
     key: str
     value: NestedQArgValue  # TODO: turn all to tuple
+    annotation: Optional[CValueNode] = None
 
 
 @attrs.frozen
@@ -167,8 +184,9 @@ class QCallNode(StatementNode):
     """A statement that calls a quantum subroutine."""
 
     bloq_key: str
-    lvalues: Sequence[str] = attrs.field(converter=tuple[str])
+    lvalues: Sequence[LValueNode] = attrs.field(converter=tuple[LValueNode])
     qargs: Sequence[QArgNode] = attrs.field(converter=tuple[QArgNode])
+    annotation: Optional[CValueNode] = None
 
 
 @attrs.frozen
@@ -245,6 +263,35 @@ class QDefExternNode(QDefNode):
 
 
 @attrs.frozen
+class QCastNode(QDefNode):
+    """A qcast declaring a casting (bookkeeping) operation.
+
+    A ``qcast`` is syntactic sugar for bookkeeping bloqs such as Split, Join,
+    Partition, Destructure, and Restructure. Unlike ``extern qdef``, it does
+    *not* have a ``from`` clause — the casting is fully determined by the
+    quantum signature.
+
+    Args:
+        bloq_key: The symbol id for this casting operation.
+        qsignature: The quantum signature describing the cast.
+
+    ```qlt
+    qcast Split(QUInt(4))
+    [reg: QUInt(4) -> QBit[4]]
+    ```
+    """
+
+    bloq_key: str
+    qsignature: Sequence[QSignatureEntry] = attrs.field(converter=tuple[QSignatureEntry])
+
+    @property
+    def cobject_from(self) -> Optional[CObjectNode]:
+        return None
+
+
+
+
+@attrs.frozen
 class L1Module(L1ASTNode):
     """A module consisting of a sequence of qdefs.
 
@@ -265,3 +312,36 @@ class L1Module(L1ASTNode):
     """
 
     qdefs: Sequence[QDefNode] = attrs.field(converter=tuple[QDefNode])
+
+
+class L1Nodes(Protocol):
+    def LiteralNode(self, value: Union[int, float, str]) -> Any: ...
+    def TupleNode(self, items: Sequence[Any]) -> Any: ...
+    def CArgNode(self, key: Optional[str], value: Any) -> Any: ...
+    def CObjectNode(self, name: str, cargs: Sequence[Any]) -> Any: ...
+    def QDTypeNode(self, dtype: Any, shape: Optional[Sequence[int]]) -> Any: ...
+    def QSignatureEntry(self, name: str, dtype: Any, annotation: Optional[Any] = None) -> Any: ...
+    def LValueNode(self, name: str, annotation: Optional[Any] = None) -> Any: ...
+    def AliasAssignmentNode(self, alias: str, bloq_key: str) -> Any: ...
+    def QArgValueNode(self, name: str, idx: Sequence[int]) -> Any: ...
+    def QArgNode(self, key: str, value: Any, annotation: Optional[Any] = None) -> Any: ...
+    def QCallNode(
+        self,
+        bloq_key: str,
+        lvalues: Sequence[Any],
+        qargs: Sequence[Any],
+        annotation: Optional[Any] = None,
+    ) -> Any: ...
+    def QReturnNode(self, ret_mapping: Sequence[Any]) -> Any: ...
+    def QDefImplNode(
+        self,
+        bloq_key: str,
+        qsignature: Sequence[Any],
+        body: Sequence[Any],
+        cobject_from: Optional[Any],
+    ) -> Any: ...
+    def QDefExternNode(
+        self, bloq_key: str, qsignature: Sequence[Any], cobject_from: Optional[Any]
+    ) -> Any: ...
+    def QCastNode(self, bloq_key: str, qsignature: Sequence[Any]) -> Any: ...
+    def L1Module(self, qdefs: Sequence[Any]) -> Any: ...


### PR DESCRIPTION

### 1. `qcast` for bookkeeping bloqs

A new `QCastNode` AST node and `qcast` keyword represent bookkeeping operations (Split, Join, Partition, Cast, etc.) that are fully determined by their quantum signature. Unlike `extern qdef`, a `qcast` has no `from` clause — the casting is inferred from the signature alone. This is to prep for forthcoming quantum structs, who we don't want to have to load from a `from` clause.

```qlt
qcast Split(QUInt(4))
[reg: QUInt(4) -> QBit[4]]
```

### 2. `@` annotations 

For attaching arbitrary classical data to components of the quantum program. We emit some layout and drawing info from bloqs.

- Signature entries: `x: QBit @ oplus` — wire‐symbol metadata (dot, circle, oplus)
- L-values: `reg @ (1, 2, 3)` — position/layout hints
- QArgs: `q=reg[0] @ 1` — per-argument metadata
- QCalls: `= X @ (8, 0, False) [...]` — call-level metadata

### 3.  pluggable AST node constructors

A new `L1Nodes` `Protocol` class defines the factory interface for all AST node types. The parser, serializer, and helper functions now accept a `nodes: L1Nodes` parameter (defaulting to the concrete `qualtran.l1.nodes` module), enabling extensions to supply alternative node implementations without duplicating the parsing and serializing logic.

### Misc

- `eval_qdef_extern_node` now warns instead of raising on link failures and falls back to a `_PlaceholderBloq`.
- `safe` parameter threaded consistently through all eval/parse functions.
- The parser now supports `reg[0]=...` syntax for indexed qarg keys.
- `regs_to_sig_entry` / `signature_to_l1_entries` extracted as public helpers for converting `Signature` to AST without side effects.
