### PR TITLE
Framework for automated classical testing

### DIFF
--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -21,7 +21,7 @@ follow_imports = silent
 ignore_missing_imports = true
 
 # Non-Google
-[mypy-sympy.*,matplotlib.*,proto.*,pandas.*,scipy.*,freezegun.*,mpl_toolkits.*,networkx.*,ply.*,astroid.*,pytest.*,_pytest.*,pylint.*,setuptools.*,qiskit.*,quimb.*,pylatex.*,filelock.*,sortedcontainers.*,tqdm.*,plotly.*,dash.*,tensorflow_docs.*,fxpmath.*,ipywidgets.*,cachetools.*,pydot.*,nbformat.*,nbconvert.*,openfermion.*,pennylane.*,mpmath.*]
+[mypy-sympy.*,matplotlib.*,proto.*,pandas.*,scipy.*,freezegun.*,mpl_toolkits.*,networkx.*,ply.*,astroid.*,pytest.*,_pytest.*,pylint.*,setuptools.*,qiskit.*,quimb.*,pylatex.*,filelock.*,sortedcontainers.*,tqdm.*,plotly.*,dash.*,tensorflow_docs.*,fxpmath.*,ipywidgets.*,cachetools.*,pydot.*,nbformat.*,nbconvert.*,openfermion.*,pennylane.*,mpmath.*,rsqualtran.*]
 follow_imports = silent
 ignore_missing_imports = true
 

--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -526,3 +526,31 @@ def _add_k_large() -> AddK:
 
 
 _ADD_K_DOC = BloqDocSpec(bloq_cls=AddK, examples=[_add_k, _add_k_small, _add_k_large])
+
+
+
+def _get_add_k_classical_sim_test_cases() -> list['ClassicalSimTestCase']:
+    """Test cases for the `AddK` bloq.
+
+    These specify concrete (non-symbolic) bloq instances with specific
+    compile-time parameter combinations. Runtime quantum inputs are
+    generated automatically by the verification framework.
+    """
+    from qualtran.simulation.verification import ClassicalSimTestCase
+
+    cases: list[ClassicalSimTestCase] = []
+    # Unsigned.
+    for bs, k in itertools.product([3, 4, 5], [1, 3, 7]):
+        cases.append(
+            ClassicalSimTestCase(
+                bloq=AddK(QUInt(bs), k=k), name=f"AddK(QUInt({bs}), k={k})"
+            )
+        )
+    # Signed.
+    for bs, k in itertools.product([4, 5], [-3, 2]):
+        cases.append(
+            ClassicalSimTestCase(
+                bloq=AddK(QInt(bs), k=k), name=f"AddK(QInt({bs}), k={k})"
+            )
+        )
+    return cases

--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -530,7 +530,6 @@ def _add_k_large() -> AddK:
 _ADD_K_DOC = BloqDocSpec(bloq_cls=AddK, examples=[_add_k, _add_k_small, _add_k_large])
 
 
-
 def _get_add_k_classical_sim_test_cases() -> list['ClassicalSimTestCase']:
     """Test cases for the `AddK` bloq.
 
@@ -544,15 +543,11 @@ def _get_add_k_classical_sim_test_cases() -> list['ClassicalSimTestCase']:
     # Unsigned.
     for bs, k in itertools.product([3, 4, 5], [1, 3, 7]):
         cases.append(
-            ClassicalSimTestCase(
-                bloq=AddK(QUInt(bs), k=k), name=f"AddK(QUInt({bs}), k={k})"
-            )
+            ClassicalSimTestCase(bloq=AddK(QUInt(bs), k=k), name=f"AddK(QUInt({bs}), k={k})")
         )
     # Signed.
     for bs, k in itertools.product([4, 5], [-3, 2]):
         cases.append(
-            ClassicalSimTestCase(
-                bloq=AddK(QInt(bs), k=k), name=f"AddK(QInt({bs}), k={k})"
-            )
+            ClassicalSimTestCase(bloq=AddK(QInt(bs), k=k), name=f"AddK(QInt({bs}), k={k})")
         )
     return cases

--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import itertools
 from collections import Counter
 from functools import cached_property
 from typing import Dict, Iterator, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union

--- a/qualtran/bloqs/arithmetic/addition.py
+++ b/qualtran/bloqs/arithmetic/addition.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from qualtran.drawing import WireSymbol
     from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
     from qualtran.simulation.classical_sim import ClassicalValT
+    from qualtran.simulation.verification import ClassicalSimTestCase
 
 
 @frozen

--- a/qualtran/bloqs/arithmetic/negate.ipynb
+++ b/qualtran/bloqs/arithmetic/negate.ipynb
@@ -107,7 +107,6 @@
    },
    "outputs": [],
    "source": [
-    "import sympy\n",
     "\n",
     "n = sympy.Symbol(\"n\")\n",
     "negate_symb = Negate(QInt(n))"

--- a/qualtran/bloqs/arithmetic/negate.py
+++ b/qualtran/bloqs/arithmetic/negate.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import Tuple, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union
 
 import sympy
 from attrs import frozen
@@ -29,11 +29,11 @@ from qualtran import (
 )
 from qualtran.bloqs.arithmetic import AddK
 from qualtran.bloqs.arithmetic.bitwise import BitwiseNot
-from qualtran.resource_counting import GateCounts
-from qualtran.simulation.classical_sim import ClassicalValT
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, SoquetT
+    from qualtran.simulation.classical_sim import ClassicalValT
+    from qualtran.simulation.verification import ClassicalSimTestCase
 
 
 @frozen
@@ -106,7 +106,6 @@ def _negate() -> Negate:
 
 @bloq_example
 def _negate_symb() -> Negate:
-    import sympy
 
     n = sympy.Symbol("n")
     negate_symb = Negate(QInt(n))

--- a/qualtran/bloqs/arithmetic/negate.py
+++ b/qualtran/bloqs/arithmetic/negate.py
@@ -12,13 +12,25 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from functools import cached_property
-from typing import TYPE_CHECKING, Union
+from typing import Tuple, TYPE_CHECKING, Union
 
+import sympy
 from attrs import frozen
 
-from qualtran import Bloq, bloq_example, BloqDocSpec, QInt, QMontgomeryUInt, QUInt, Signature
+from qualtran import (
+    Bloq,
+    bloq_example,
+    BloqDocSpec,
+    QInt,
+    QMontgomeryUInt,
+    QUInt,
+    Register,
+    Signature,
+)
 from qualtran.bloqs.arithmetic import AddK
 from qualtran.bloqs.arithmetic.bitwise import BitwiseNot
+from qualtran.resource_counting import GateCounts
+from qualtran.simulation.classical_sim import ClassicalValT
 
 if TYPE_CHECKING:
     from qualtran import BloqBuilder, SoquetT
@@ -59,7 +71,26 @@ class Negate(Bloq):
 
     @cached_property
     def signature(self) -> 'Signature':
-        return Signature.build_from_dtypes(x=self.dtype)
+        return Signature([Register('x', self.dtype)])
+
+    def on_classical_vals(self, x: 'ClassicalValT') -> dict[str, 'ClassicalValT']:
+        n = self.dtype.num_qubits
+        # Two's complement negation: -x == (~x + 1) mod 2^n
+        # Work in unsigned space, then re-interpret in the dtype.
+        unsigned_x = int(x) % (1 << n)
+        result_unsigned = (unsigned_x ^ ((1 << n) - 1)) + 1  # ~x + 1
+        result_unsigned %= 1 << n
+
+        if isinstance(self.dtype, QInt):
+            # Re-interpret as signed.
+            if result_unsigned >= (1 << (n - 1)):
+                result = result_unsigned - (1 << n)
+            else:
+                result = result_unsigned
+        else:
+            result = result_unsigned
+
+        return {'x': result}
 
     def build_composite_bloq(self, bb: 'BloqBuilder', x: 'SoquetT') -> dict[str, 'SoquetT']:
         x = bb.add(BitwiseNot(self.dtype), x=x)  # ~x
@@ -83,3 +114,31 @@ def _negate_symb() -> Negate:
 
 
 _NEGATE_DOC = BloqDocSpec(bloq_cls=Negate, examples=[_negate, _negate_symb])
+
+
+def _get_negate_classical_sim_test_cases() -> list['ClassicalSimTestCase']:
+    """Test cases for the `Negate` bloq.
+
+    These specify concrete (non-symbolic) bloq instances with specific
+    compile-time parameter combinations. Runtime quantum inputs are
+    generated automatically by the verification framework.
+    """
+    from qualtran.simulation.verification import ClassicalSimTestCase
+
+    cases: list[ClassicalSimTestCase] = []
+    for bitsize in [1, 2, 3, 4]:
+        cases.append(
+            ClassicalSimTestCase(
+                bloq=Negate(QUInt(bitsize)),
+                name=f"Negate(QUInt({bitsize}))",
+            )
+        )
+    for bitsize in [2, 3, 4]:
+        cases.append(
+            ClassicalSimTestCase(
+                bloq=Negate(QInt(bitsize)),
+                name=f"Negate(QInt({bitsize}))",
+            )
+        )
+    return cases
+

--- a/qualtran/bloqs/arithmetic/negate.py
+++ b/qualtran/bloqs/arithmetic/negate.py
@@ -127,17 +127,10 @@ def _get_negate_classical_sim_test_cases() -> list['ClassicalSimTestCase']:
     cases: list[ClassicalSimTestCase] = []
     for bitsize in [1, 2, 3, 4]:
         cases.append(
-            ClassicalSimTestCase(
-                bloq=Negate(QUInt(bitsize)),
-                name=f"Negate(QUInt({bitsize}))",
-            )
+            ClassicalSimTestCase(bloq=Negate(QUInt(bitsize)), name=f"Negate(QUInt({bitsize}))")
         )
     for bitsize in [2, 3, 4]:
         cases.append(
-            ClassicalSimTestCase(
-                bloq=Negate(QInt(bitsize)),
-                name=f"Negate(QInt({bitsize}))",
-            )
+            ClassicalSimTestCase(bloq=Negate(QInt(bitsize)), name=f"Negate(QInt({bitsize}))")
         )
     return cases
-

--- a/qualtran/bloqs/arithmetic/negate.py
+++ b/qualtran/bloqs/arithmetic/negate.py
@@ -106,7 +106,6 @@ def _negate() -> Negate:
 
 @bloq_example
 def _negate_symb() -> Negate:
-    import sympy
 
     n = sympy.Symbol("n")
     negate_symb = Negate(QInt(n))

--- a/qualtran/bloqs/arithmetic/negate.py
+++ b/qualtran/bloqs/arithmetic/negate.py
@@ -106,6 +106,7 @@ def _negate() -> Negate:
 
 @bloq_example
 def _negate_symb() -> Negate:
+    import sympy
 
     n = sympy.Symbol("n")
     negate_symb = Negate(QInt(n))

--- a/qualtran/bloqs/arithmetic/negate.py
+++ b/qualtran/bloqs/arithmetic/negate.py
@@ -75,6 +75,8 @@ class Negate(Bloq):
 
     def on_classical_vals(self, x: 'ClassicalValT') -> dict[str, 'ClassicalValT']:
         n = self.dtype.num_qubits
+        if isinstance(n, sympy.Expr):
+            raise ValueError(f'Cannot simulate symbolic bloq {self}')
         # Two's complement negation: -x == (~x + 1) mod 2^n
         # Work in unsigned space, then re-interpret in the dtype.
         unsigned_x = int(x) % (1 << n)

--- a/qualtran/bloqs/arithmetic/negate_test.py
+++ b/qualtran/bloqs/arithmetic/negate_test.py
@@ -54,3 +54,9 @@ def test_negate_unsigned_classical_sim(bitsize: int):
             assert x_out == 0
         else:
             assert x_out == 2**bitsize - x_in
+
+
+def test_negate_symbolic_classical_sim():
+    bloq = _negate_symb()
+    with pytest.raises(ValueError, match="Cannot simulate symbolic bloq"):
+        bloq.on_classical_vals(x=1)

--- a/qualtran/bloqs/basic_gates/on_each.py
+++ b/qualtran/bloqs/basic_gates/on_each.py
@@ -137,10 +137,7 @@ def _get_on_each_classical_sim_test_cases() -> list['ClassicalSimTestCase']:
     for n in [2, 3, 4]:
         # Default dtype (QAny)
         cases.append(
-            ClassicalSimTestCase(
-                bloq=OnEach(n=n, gate=XGate()),
-                name=f"OnEach(XGate, n={n})",
-            )
+            ClassicalSimTestCase(bloq=OnEach(n=n, gate=XGate()), name=f"OnEach(XGate, n={n})")
         )
         # Unsigned
         cases.append(

--- a/qualtran/bloqs/basic_gates/on_each.py
+++ b/qualtran/bloqs/basic_gates/on_each.py
@@ -39,6 +39,7 @@ from qualtran.symbolics import SymbolicInt
 
 if TYPE_CHECKING:
     from qualtran.simulation.classical_sim import ClassicalValT
+    from qualtran.simulation.verification import ClassicalSimTestCase
 
 
 @attrs.frozen

--- a/qualtran/bloqs/basic_gates/on_each.py
+++ b/qualtran/bloqs/basic_gates/on_each.py
@@ -15,7 +15,7 @@
 """Classes to apply single qubit bloq to multiple qubits."""
 
 from functools import cached_property
-from typing import Dict, Optional, Tuple, TYPE_CHECKING
+from typing import cast, Dict, Optional, Tuple, TYPE_CHECKING
 
 import attrs
 import sympy
@@ -89,14 +89,17 @@ class OnEach(Bloq):
         return {'q': bb.join(qs, self.target_dtype)}
 
     def on_classical_vals(self, q: int) -> Dict[str, 'ClassicalValT']:
+        n = self.n
+        if isinstance(n, sympy.Expr):
+            raise ValueError(f'Cannot simulate symbolic bloq {self}')
         dtype = self.signature[0].dtype
         bits = dtype.to_bits(q)
         out_bits = list(bits)
-        for i in range(self.n):
+        for i in range(n):
             out = self.gate.on_classical_vals(q=bits[i])
             if out is NotImplemented:
                 return NotImplemented
-            out_bits[i] = out['q']
+            out_bits[i] = int(cast(int, out['q']))
         return {'q': dtype.from_bits(out_bits)}
 
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':

--- a/qualtran/bloqs/basic_gates/on_each.py
+++ b/qualtran/bloqs/basic_gates/on_each.py
@@ -15,7 +15,7 @@
 """Classes to apply single qubit bloq to multiple qubits."""
 
 from functools import cached_property
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 import attrs
 import sympy
@@ -36,6 +36,9 @@ from qualtran.drawing import Text, WireSymbol
 from qualtran.drawing.musical_score import TextBox
 from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 from qualtran.symbolics import SymbolicInt
+
+if TYPE_CHECKING:
+    from qualtran.simulation.classical_sim import ClassicalValT
 
 
 @attrs.frozen
@@ -84,6 +87,17 @@ class OnEach(Bloq):
             qs[i] = bb.add(self.gate, q=qs[i])
         return {'q': bb.join(qs, self.target_dtype)}
 
+    def on_classical_vals(self, q: int) -> Dict[str, 'ClassicalValT']:
+        dtype = self.signature[0].dtype
+        bits = dtype.to_bits(q)
+        out_bits = list(bits)
+        for i in range(self.n):
+            out = self.gate.on_classical_vals(q=bits[i])
+            if out is NotImplemented:
+                return NotImplemented
+            out_bits[i] = out['q']
+        return {'q': dtype.from_bits(out_bits)}
+
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         return {self.gate: self.n}
 
@@ -102,3 +116,40 @@ class OnEach(Bloq):
 
     def __str__(self):
         return f'{self.gate}(oneach={self.n})'
+
+
+def _get_on_each_classical_sim_test_cases() -> list['ClassicalSimTestCase']:
+    """Test cases for the `OnEach` bloq.
+
+    These specify concrete (non-symbolic) bloq instances with specific
+    compile-time parameter combinations. Runtime quantum inputs are
+    generated automatically by the verification framework.
+    """
+    from qualtran import QInt, QUInt
+    from qualtran.bloqs.basic_gates import XGate
+    from qualtran.simulation.verification import ClassicalSimTestCase
+
+    cases: list[ClassicalSimTestCase] = []
+    for n in [2, 3, 4]:
+        # Default dtype (QAny)
+        cases.append(
+            ClassicalSimTestCase(
+                bloq=OnEach(n=n, gate=XGate()),
+                name=f"OnEach(XGate, n={n})",
+            )
+        )
+        # Unsigned
+        cases.append(
+            ClassicalSimTestCase(
+                bloq=OnEach(n=n, gate=XGate(), target_dtype=QUInt(n)),
+                name=f"OnEach(XGate, n={n}, QUInt)",
+            )
+        )
+        # Signed
+        cases.append(
+            ClassicalSimTestCase(
+                bloq=OnEach(n=n, gate=XGate(), target_dtype=QInt(n)),
+                name=f"OnEach(XGate, n={n}, QInt)",
+            )
+        )
+    return cases

--- a/qualtran/bloqs/basic_gates/on_each_test.py
+++ b/qualtran/bloqs/basic_gates/on_each_test.py
@@ -47,6 +47,18 @@ def test_classical_simulation():
         h_on_each.call_classically(q=0)
 
 
+def test_classical_simulation_signed_dtype():
+    """on_classical_vals must respect the register's dtype signedness."""
+    from qualtran import QInt
+
+    bloq = OnEach(n=2, gate=XGate(), target_dtype=QInt(2))
+    # QInt(2) domain: {-2, -1, 0, 1}. Flipping all bits of 0 → -1, not 3.
+    assert bloq.on_classical_vals(q=0) == {'q': -1}
+    assert bloq.on_classical_vals(q=-1) == {'q': 0}
+    assert bloq.on_classical_vals(q=1) == {'q': -2}
+    assert bloq.on_classical_vals(q=-2) == {'q': 1}
+
+
 def test_call_graph():
     x_on_each = OnEach(10, XGate())
     g, sigma = x_on_each.call_graph()

--- a/qualtran/bloqs/bookkeeping/free.py
+++ b/qualtran/bloqs/bookkeeping/free.py
@@ -33,6 +33,7 @@ from qualtran import (
 )
 from qualtran.bloqs.bookkeeping._bookkeeping_bloq import _BookkeepingBloq
 from qualtran.drawing import directional_text_box, Text, WireSymbol
+from qualtran.simulation.classical_sim import QCDTypeDomainError
 
 if TYPE_CHECKING:
     import cirq
@@ -79,7 +80,7 @@ class Free(_BookkeepingBloq):
 
     def on_classical_vals(self, reg: int) -> Dict[str, 'ClassicalValT']:
         if reg != 0 and not self.dirty:
-            raise ValueError(f"Tried to free a non-zero register: {reg} with {self.dirty=}")
+            raise QCDTypeDomainError(f"Tried to free a non-zero register: {reg} with {self.dirty=}")
         return {}
 
     def my_tensors(
@@ -108,6 +109,9 @@ class Free(_BookkeepingBloq):
 
     def as_pl_op(self, wires: 'Wires') -> 'Operation':
         return None
+
+    def __str__(self):
+        return f'Free({self.dtype})'
 
 
 @bloq_example

--- a/qualtran/bloqs/mcmt/and_bloq.py
+++ b/qualtran/bloqs/mcmt/and_bloq.py
@@ -66,7 +66,7 @@ from qualtran.cirq_interop import decompose_from_cirq_style_method
 from qualtran.drawing import Circle, directional_text_box, Text, WireSymbol
 from qualtran.resource_counting import BloqCountDictT, MutableBloqCountDictT, SympySymbolAllocator
 from qualtran.resource_counting.generalizers import generalize_cvs, ignore_cliffords
-from qualtran.simulation.classical_sim import ClassicalValT
+from qualtran.simulation.classical_sim import ClassicalValT, QCDTypeDomainError
 from qualtran.symbolics import HasLength, is_symbolic, SymbolicInt
 
 if TYPE_CHECKING:
@@ -138,7 +138,7 @@ class And(GateWithRegisters):
 
         # Uncompute
         if target != out:
-            raise ValueError(
+            raise QCDTypeDomainError(
                 f"Inconsistent `target` found for uncomputing `And`: {ctrl=}, {target=}. Expected target={out}"
             )
         return {'ctrl': ctrl}

--- a/qualtran/simulation/classical_sim.py
+++ b/qualtran/simulation/classical_sim.py
@@ -58,6 +58,27 @@ ClassicalValT = Union[int, np.integer, NDArray[np.integer]]
 ClassicalValRetT = Union[int, np.integer, NDArray[np.integer], 'ClassicalValDistribution']
 
 
+class QCDTypeDomainError(ValueError):
+    """Raised by `on_classical_vals` when an input is outside the bloq's valid domain.
+
+    Bloqs should raise this (instead of bare ``ValueError`` or ``AssertionError``)
+    to signal that the input is invalid for *this* bloq but not indicative of a
+    programming error. The verification framework catches only this type when
+    skipping domain-constrained inputs, so genuine bugs (``TypeError``,
+    ``KeyError``, etc.) propagate immediately.
+
+    Subclasses ``ValueError`` for backward compatibility with existing code that
+    catches ``ValueError``.
+
+    Example usage in a bloq::
+
+        def on_classical_vals(self, x):
+            if x % 2 != 0:
+                raise QCDTypeDomainError(f"Only even inputs allowed, got {x}")
+            return {'x': x}
+    """
+
+
 def _numpy_dtype_from_qlt_dtype(dtype: 'QCDType') -> Type:
     # TODO: Move to a method on QCDType. https://github.com/quantumlib/Qualtran/issues/1437.
     from qualtran._infra.data_types import CBit, QAny, QBit, QInt, QUInt

--- a/qualtran/simulation/classical_sim.py
+++ b/qualtran/simulation/classical_sim.py
@@ -168,7 +168,7 @@ class _RandomClassicalValHandler(_ClassicalValHandler):
         self._gen = rng
 
     def get(self, binst, distribution: ClassicalValDistribution):
-        return self._gen.choice(distribution.a, p=distribution.p)  # type:ignore[arg-type]
+        return self._gen.choice(distribution.a, p=distribution.p)  # type: ignore[arg-type]
 
 
 class _FixedClassicalValHandler(_ClassicalValHandler):

--- a/qualtran/simulation/do-classical-verification.py
+++ b/qualtran/simulation/do-classical-verification.py
@@ -49,13 +49,11 @@ import numpy as np
 from qualtran.simulation.verification import (
     _should_use_fastsim,
     ClassicalSimTestCase,
-    TestCaseProvider,
     print_verification_summary,
+    TestCaseProvider,
     validate_test_cases,
     verify_structural_induction,
 )
-
-
 
 # ---------------------------------------------------------------------------
 # Registry: maps short lowercase names to test-case provider functions.
@@ -66,15 +64,9 @@ from qualtran.simulation.verification import (
 
 def _build_registry() -> dict[str, TestCaseProvider]:
     """Build the registry of test-case providers."""
-    from qualtran.bloqs.arithmetic.addition import (
-        _get_add_k_classical_sim_test_cases,
-    )
-    from qualtran.bloqs.basic_gates.on_each import (
-        _get_on_each_classical_sim_test_cases,
-    )
-    from qualtran.bloqs.arithmetic.negate import (
-        _get_negate_classical_sim_test_cases,
-    )
+    from qualtran.bloqs.arithmetic.addition import _get_add_k_classical_sim_test_cases
+    from qualtran.bloqs.arithmetic.negate import _get_negate_classical_sim_test_cases
+    from qualtran.bloqs.basic_gates.on_each import _get_on_each_classical_sim_test_cases
 
     return {
         'add_k': _get_add_k_classical_sim_test_cases,

--- a/qualtran/simulation/do-classical-verification.py
+++ b/qualtran/simulation/do-classical-verification.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+#  Copyright 2025 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Structural induction verification for arithmetic and modular bloqs.
+
+Verifies bloqs by cross-checking each bloq's reference implementation
+(`on_classical_vals`) against recursive decomposition simulation.
+The BFS traversal automatically discovers and verifies all sub-bloqs in the
+decomposition tree.
+
+Test cases are registered per bloq class and collected into a registry with
+short, friendly names. The CLI supports selecting specific bloqs by name,
+or using `--all` with optional `--exclude`.
+
+Environment Variables:
+    QLT_USE_FASTSIM: Controls the classical simulation engine:
+        - Set to '1', 'true', or 'yes' to explicitly use the Rust `rsqualtran` fastsim engine.
+        - Set to '0', 'false', or 'no' to explicitly use Python simulation (`simulate_via_subbloq_classical_vals`).
+        - If unset, fastsim is used automatically when `rsqualtran` is installed, falling back to Python otherwise.
+
+Usage:
+    # Verify specific bloqs:
+    python -m qualtran.simulation.do-classical-verification product square
+
+    # Verify all registered bloqs using Python simulation engine explicitly:
+    QLT_USE_FASTSIM=0 python -m qualtran.simulation.do-classical-verification --all
+
+    # Verify all except one:
+    python -m qualtran.simulation.do-classical-verification --all --exclude square
+"""
+
+import argparse
+import sys
+
+import numpy as np
+
+from qualtran.simulation.verification import (
+    _should_use_fastsim,
+    ClassicalSimTestCase,
+    TestCaseProvider,
+    print_verification_summary,
+    validate_test_cases,
+    verify_structural_induction,
+)
+
+
+
+# ---------------------------------------------------------------------------
+# Registry: maps short lowercase names to test-case provider functions.
+#
+# To add a new bloq, import its provider function and add an entry here.
+# ---------------------------------------------------------------------------
+
+
+def _build_registry() -> dict[str, TestCaseProvider]:
+    """Build the registry of test-case providers."""
+    from qualtran.bloqs.arithmetic.addition import (
+        _get_add_k_classical_sim_test_cases,
+    )
+    from qualtran.bloqs.basic_gates.on_each import (
+        _get_on_each_classical_sim_test_cases,
+    )
+    from qualtran.bloqs.arithmetic.negate import (
+        _get_negate_classical_sim_test_cases,
+    )
+
+    return {
+        'add_k': _get_add_k_classical_sim_test_cases,
+        'negate': _get_negate_classical_sim_test_cases,
+        'on_each': _get_on_each_classical_sim_test_cases,
+    }
+
+
+def main() -> None:
+    registry = _build_registry()
+    available = sorted(registry)
+
+    epilog = (
+        "environment variables:\n"
+        "  QLT_USE_FASTSIM    '1' to force Rust fastsim, '0' to force Python simulation.\n"
+        "                     If unset, uses fastsim when available (`rsqualtran` installed).\n\n"
+        "available bloqs:\n  " + "\n  ".join(available)
+    )
+    parser = argparse.ArgumentParser(
+        description="Verify bloqs via structural induction.\n\n"
+        "Simulation behavior can be controlled via the QLT_USE_FASTSIM environment variable.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=epilog,
+    )
+    parser.add_argument(
+        "names", nargs="*", metavar="NAME", help="Bloq names to verify (e.g. 'product', 'square')."
+    )
+    parser.add_argument(
+        "--all", action="store_true", dest="run_all", help="Verify all registered bloqs."
+    )
+    parser.add_argument(
+        "--exclude",
+        nargs="*",
+        default=[],
+        metavar="NAME",
+        help="Bloq names to exclude (only meaningful with --all).",
+    )
+    parser.add_argument(
+        "--n-samples",
+        type=int,
+        default=1_000,
+        help="Number of random quantum input samples per bloq. "
+        "If this exceeds the total domain size, exhaustive enumeration is used.",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducibility.")
+    args = parser.parse_args()
+
+    # --- Resolve which bloqs to verify. ---
+    if args.run_all:
+        selected = [n for n in available if n not in args.exclude]
+        # Validate --exclude names.
+        bad_excludes = [n for n in args.exclude if n not in registry]
+        if bad_excludes:
+            parser.error(
+                f"Unknown bloq name(s) in --exclude: {bad_excludes}. " f"Available: {available}"
+            )
+    elif args.names:
+        selected = args.names
+        # Validate positional names.
+        bad_names = [n for n in selected if n not in registry]
+        if bad_names:
+            parser.error(f"Unknown bloq name(s): {bad_names}. " f"Available: {available}")
+        if args.exclude:
+            parser.error("--exclude can only be used with --all.")
+    else:
+        parser.error("Specify bloq names to verify, or use --all. " f"Available: {available}")
+
+    if not selected:
+        print("Nothing to verify (all bloqs excluded).", file=sys.stderr)
+        return
+
+    # --- Collect and validate test cases. ---
+    all_test_cases: list[ClassicalSimTestCase] = []
+    for name in selected:
+        provider = registry[name]
+        cases = provider()
+        validate_test_cases(name, cases)
+        all_test_cases.extend(cases)
+
+    # --- Run verification. ---
+    print("=" * 70)
+    print("Structural Induction Verification")
+    print("=" * 70)
+    print(f"  bloqs:     {', '.join(selected)}")
+    print(f"  engine:    {'QLTFastsim (Rust)' if _should_use_fastsim() else 'Python'}")
+    print(f"  n_samples: {args.n_samples}")
+    print(f"  seed:      {args.seed}")
+    print()
+
+    print(f"Loaded {len(all_test_cases)} root test cases:")
+    for tc in all_test_cases:
+        print(f"  - {tc.name}")
+    print()
+
+    rng = np.random.default_rng(args.seed)
+    results = verify_structural_induction(
+        root_cases=all_test_cases, n_samples=args.n_samples, rng=rng
+    )
+
+    print_verification_summary(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/qualtran/simulation/do-classical-verification.py
+++ b/qualtran/simulation/do-classical-verification.py
@@ -64,9 +64,19 @@ from qualtran.simulation.verification import (
 
 def _build_registry() -> dict[str, TestCaseProvider]:
     """Build the registry of test-case providers."""
-    from qualtran.bloqs.arithmetic.addition import _get_add_k_classical_sim_test_cases
-    from qualtran.bloqs.arithmetic.negate import _get_negate_classical_sim_test_cases
-    from qualtran.bloqs.basic_gates.on_each import _get_on_each_classical_sim_test_cases
+    # fmt: off
+    # isort: off
+    from qualtran.bloqs.arithmetic.addition import (
+        _get_add_k_classical_sim_test_cases,
+    )
+    from qualtran.bloqs.arithmetic.negate import (
+        _get_negate_classical_sim_test_cases,
+    )
+    from qualtran.bloqs.basic_gates.on_each import (
+        _get_on_each_classical_sim_test_cases,
+    )
+    # isort: on
+    # fmt: on
 
     return {
         'add_k': _get_add_k_classical_sim_test_cases,

--- a/qualtran/simulation/verification.py
+++ b/qualtran/simulation/verification.py
@@ -434,7 +434,7 @@ logger = logging.getLogger(__name__)
 def _get_qlt_fastsim_cls() -> Any | None:
     """Memoize attempting to import `rsqualtran.QLTFastsim` to avoid repetitive `sys.path` searches."""
     try:
-        from rsqualtran import QLTFastsim  # type: ignore[import-untyped]
+        from rsqualtran import QLTFastsim  # type: ignore[import-untyped,import-not-found]
 
         return QLTFastsim
     except ImportError:

--- a/qualtran/simulation/verification.py
+++ b/qualtran/simulation/verification.py
@@ -51,7 +51,7 @@ import logging
 import math
 import os
 import sys
-from collections import Counter, OrderedDict, deque
+from collections import Counter, deque, OrderedDict
 from typing import Any, Callable, IO, Sequence
 
 import attrs
@@ -315,8 +315,6 @@ BFS, so every subbloq is also verified.
     keyed by a test suite alias and run with
     `python do-classical-verification.py --[your testsuite alias]`.
 """
-
-
 
 
 def validate_test_cases(name: str, cases: list[ClassicalSimTestCase]) -> None:
@@ -606,7 +604,9 @@ def verify_structural_induction(
         rng = np.random.default_rng(42)
 
     use_fastsim = _should_use_fastsim()
-    sim_style = "QLTFastsim (Rust)" if use_fastsim else "Python (simulate_via_subbloq_classical_vals)"
+    sim_style = (
+        "QLTFastsim (Rust)" if use_fastsim else "Python (simulate_via_subbloq_classical_vals)"
+    )
     sys.stderr.write(f"[verify_structural_induction] Simulation style: {sim_style}\n")
     logger.info("[verify_structural_induction] Simulation style: %s", sim_style)
 

--- a/qualtran/simulation/verification.py
+++ b/qualtran/simulation/verification.py
@@ -489,11 +489,7 @@ def _verify_decomposable_bloq(
     if use_fastsim:
         fastsim_cls = _get_qlt_fastsim_cls()
         if fastsim_cls is not None:
-            try:
-                sim = fastsim_cls.from_bloq(bloq)
-            except Exception:  # pylint: disable=broad-exception-caught
-                # Fall back to Python simulation for mock or custom test bloqs.
-                sim = None
+            sim = fastsim_cls.from_bloq(bloq)
 
     try:
         n_checked = 0

--- a/qualtran/simulation/verification.py
+++ b/qualtran/simulation/verification.py
@@ -421,7 +421,7 @@ def _verify_leaf_bloq(
 
         return VerificationResult(bloq, VerificationStatus.LEAF_VERIFIED, n_inputs_checked=n_ok)
 
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         return VerificationResult(
             bloq, VerificationStatus.ERROR, error_message=f"Leaf verification failed: {e}"
         )
@@ -491,7 +491,7 @@ def _verify_decomposable_bloq(
         if fastsim_cls is not None:
             try:
                 sim = fastsim_cls.from_bloq(bloq)
-            except Exception:
+            except Exception:  # pylint: disable=broad-exception-caught
                 # Fall back to Python simulation for mock or custom test bloqs.
                 sim = None
 
@@ -556,7 +556,7 @@ def _verify_decomposable_bloq(
             bloq, VerificationStatus.FAILED, error_message=str(e), children=child_bloqs
         )
 
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         return VerificationResult(
             bloq,
             VerificationStatus.ERROR,
@@ -629,7 +629,7 @@ def verify_structural_induction(
         # Generate input values.
         try:
             input_vals_list = generate_input_vals(bloq, n_samples, rng)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             result = VerificationResult(
                 bloq, VerificationStatus.ERROR, error_message=f"Input generation failed: {e}"
             )

--- a/qualtran/simulation/verification.py
+++ b/qualtran/simulation/verification.py
@@ -52,7 +52,7 @@ import math
 import os
 import sys
 from collections import Counter, OrderedDict, deque
-from typing import IO, Callable, Sequence
+from typing import Any, Callable, IO, Sequence
 
 import attrs
 import numpy as np
@@ -223,16 +223,16 @@ def generate_input_vals(
         # Random sampling.
         results = []
         for _ in range(n_samples):
-            vals: dict[str, ClassicalValT] = {}
+            sampled_vals: dict[str, ClassicalValT] = {}
             for reg in left_regs:
                 if reg.shape:
                     n_elems = int(np.prod(reg.shape))
-                    vals[reg.name] = np.array(
+                    sampled_vals[reg.name] = np.array(
                         [_sample_from_register(reg, rng) for _ in range(n_elems)]
                     ).reshape(reg.shape)
                 else:
-                    vals[reg.name] = _sample_from_register(reg, rng)
-            results.append(vals)
+                    sampled_vals[reg.name] = _sample_from_register(reg, rng)
+            results.append(sampled_vals)
         return results
 
 
@@ -433,10 +433,10 @@ logger = logging.getLogger(__name__)
 
 
 @functools.lru_cache(maxsize=1)
-def _get_qlt_fastsim_cls() -> type | None:
+def _get_qlt_fastsim_cls() -> Any | None:
     """Memoize attempting to import `rsqualtran.QLTFastsim` to avoid repetitive `sys.path` searches."""
     try:
-        from rsqualtran import QLTFastsim
+        from rsqualtran import QLTFastsim  # type: ignore[import-untyped]
 
         return QLTFastsim
     except ImportError:
@@ -824,7 +824,7 @@ def print_verification_summary(
             _write()
 
     # Status totals.
-    status_counts: Counter[str] = Counter(r.status for r in results)
+    status_counts: Counter[VerificationStatus] = Counter(r.status for r in results)
     _write('-' * 70)
     for status, count in sorted(status_counts.items()):
         icon = _STATUS_ICONS.get(status, '?')

--- a/qualtran/simulation/verification.py
+++ b/qualtran/simulation/verification.py
@@ -1,0 +1,833 @@
+#  Copyright 2025 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Functional verification of bloqs via classical simulation cross-checks.
+
+This module verifies that a bloq's decomposition is functionally equivalent
+to its hand-written `on_classical_vals`.
+
+The key problem: `Bloq.call_classically()` silently falls back to recursive
+decomposition when `on_classical_vals` is not implemented.  Comparing
+`bloq.call_classically()` vs `bloq.decompose_bloq().call_classically()`
+can therefore be tautological — both sides may execute the exact same code
+path.
+
+To avoid this, we provide:
+
+- `StrictClassicalSimState`: a `ClassicalSimState` subclass that raises
+  `MissingClassicalValsError` instead of recursing when
+  `on_classical_vals` returns `NotImplemented`.
+
+- `simulate_via_subbloq_classical_vals`: decomposes a bloq once, then
+  simulates using each sub-bloq's `on_classical_vals`.  Used by
+  `verify_structural_induction` as one side of the cross-check (the other
+  side being the parent bloq's own `on_classical_vals`).
+
+- `generate_input_vals`: automatic generation of classical input values
+  from `QDType.get_classical_domain()`, with random sampling or exhaustive
+  enumeration.
+
+- `verify_structural_induction`: BFS over the decomposition tree, verifying
+  each bloq encountered via structural induction.
+"""
+
+from __future__ import annotations
+
+import enum
+import functools
+import itertools
+import logging
+import math
+import os
+import sys
+from collections import Counter, OrderedDict, deque
+from typing import IO, Callable, Sequence
+
+import attrs
+import numpy as np
+
+from qualtran import Bloq, DecomposeNotImplementedError, DecomposeTypeError, Register
+from qualtran.l1 import dump_objectstring, StandardQualtranArchitectureAgnosticVirtualMachine
+from qualtran.simulation.classical_sim import ClassicalSimState, ClassicalValT, QCDTypeDomainError
+
+
+class MissingClassicalValsError(Exception):
+    """Raised when a bloq does not implement `on_classical_vals`.
+
+    This means there is no hand-written classical simulation to compare
+    against, so the verification cannot proceed for this bloq.
+    """
+
+
+class VerificationStatus(enum.StrEnum):
+    """Status of a single bloq verification.
+
+    Using `StrEnum` so members are valid strings — backward-compatible
+    with code that compares against plain string literals.
+    """
+
+    PASSED = 'passed'
+    FAILED = 'failed'
+    MISSING_DECOMPOSITION = 'missing_decomposition'
+    LEAF_VERIFIED = 'leaf_verified'
+    LEAF_NO_CLASSICAL_VALS = 'leaf_no_classical_vals'
+    MISSING_CLASSICAL_VALS = 'missing_classical_vals'
+    NO_VALID_INPUTS = 'no_valid_inputs'
+    ERROR = 'error'
+
+
+class StrictClassicalSimState(ClassicalSimState):
+    """A `ClassicalSimState` that requires `on_classical_vals` on every bloq.
+
+    Unlike the standard `ClassicalSimState` which silently falls back to
+    recursive decomposition when `on_classical_vals` returns `NotImplemented`,
+    this subclass raises `MissingClassicalValsError`. This guarantees that every
+    sub-bloq in the simulation has a hand-written `on_classical_vals`, and
+    we are never accidentally comparing simulation against itself.
+
+    Implementation: overrides `_recurse` (the fallback called from `step()`
+    when `on_classical_vals` returns `NotImplemented`). The base class's
+    `step()` method — including `basis_state_phase` handling — is inherited
+    unchanged.
+    """
+
+    def _recurse(self, binst, in_vals):
+        """Raise instead of recursing into decomposition."""
+        bloq = binst.bloq
+        raise MissingClassicalValsError(
+            f"{bloq.__class__.__name__} (instance: {bloq}) does not implement "
+            f"on_classical_vals."
+        )
+
+
+def simulate_via_subbloq_classical_vals(bloq: Bloq, **vals: ClassicalValT) -> tuple:
+    """Decompose `bloq` once, then simulate using each sub-bloq's `on_classical_vals`.
+
+    Every sub-bloq in the decomposition must implement `on_classical_vals`;
+    if any is missing, raises `MissingClassicalValsError`.
+
+    Args:
+        bloq: The bloq to decompose. Must have a decomposition.
+        **vals: Classical input values keyed by LEFT register names.
+
+    Returns:
+        A tuple of output classical values, ordered by RIGHT registers.
+
+    Raises:
+        MissingClassicalValsError: If any sub-bloq lacks `on_classical_vals`.
+        DecomposeNotImplementedError: If the bloq has no decomposition.
+    """
+    cbloq = bloq.decompose_bloq()
+    sim = StrictClassicalSimState.from_cbloq(cbloq, vals=vals)
+    final_vals = sim.simulate()
+    return tuple(final_vals[reg.name] for reg in bloq.signature.rights())
+
+
+_MAX_DOMAIN_MATERIALIZE = 2**16  # Don't materialize domains larger than this.
+
+
+def _domain_size_for_register(reg: Register) -> int:
+    """Get the size of the classical domain for a register's dtype."""
+    # TODO: consider adding get_classical_domain_size() to QDType
+    # so this doesn't have to assume 2**num_qubits.
+    return 2**reg.dtype.num_qubits
+
+
+def _sample_from_register(reg: Register, rng: np.random.Generator) -> ClassicalValT:
+    """Sample a single random classical value for a register.
+
+    Avoids materializing the full domain for large types by sampling an
+    integer index directly.
+    """
+    domain_size = _domain_size_for_register(reg)
+
+    if domain_size <= _MAX_DOMAIN_MATERIALIZE:
+        # Small domain: materialize and index.
+        try:
+            domain = list(reg.dtype.get_classical_domain())
+        except TypeError:  # dtype doesn't support get_classical_domain
+            domain = list(range(domain_size))
+        return domain[rng.integers(0, len(domain))]
+    else:
+        # Large domain: sample directly as an integer.
+        # This works for QUInt, QInt, QAny — the most common large types.
+        return int(rng.integers(0, domain_size))
+
+
+def generate_input_vals(
+    bloq: Bloq, n_samples: int, rng: np.random.Generator
+) -> list[dict[str, ClassicalValT]]:
+    """Generate classical input values for a bloq's LEFT registers.
+
+    Uses `QDType.get_classical_domain()` to determine valid value ranges for
+    each input register. If `n_samples` is >= the total domain size (product
+    of all register domain sizes), switches to exhaustive enumeration.
+
+    For registers with `shape` (multi-dimensional), each element is sampled
+    independently from the domain.
+
+    Args:
+        bloq: The bloq whose signature determines the input types.
+        n_samples: Number of random input samples to generate. If this exceeds
+            the total domain size, exhaustive enumeration is used instead.
+        rng: NumPy random generator for reproducible sampling.
+
+    Returns:
+        A list of dicts, each mapping LEFT register names to classical values.
+    """
+    left_regs = list(bloq.signature.lefts())
+
+    if not left_regs:
+        # No inputs — return a single empty dict.
+        return [{}]
+
+    # Compute per-register domain size (without materializing).
+    domain_sizes: dict[str, int] = {}
+    total_size: float = 1.0
+    has_shaped = False
+
+    for reg in left_regs:
+        domain_sizes[reg.name] = _domain_size_for_register(reg)
+        if reg.shape:
+            has_shaped = True
+            total_size = math.inf
+        else:
+            total_size *= domain_sizes[reg.name]
+
+    if not has_shaped and n_samples >= total_size and math.isfinite(total_size):
+        # Exhaustive enumeration: only when all registers are scalar and
+        # total domain is small enough.
+        domains = []
+        for reg in left_regs:
+            try:
+                domains.append(list(reg.dtype.get_classical_domain()))
+            except TypeError:  # dtype doesn't support get_classical_domain
+                domains.append(list(range(domain_sizes[reg.name])))
+        results = []
+        for combo in itertools.product(*domains):
+            vals = {r.name: v for r, v in zip(left_regs, combo)}
+            results.append(vals)
+        return results
+    else:
+        # Random sampling.
+        results = []
+        for _ in range(n_samples):
+            vals: dict[str, ClassicalValT] = {}
+            for reg in left_regs:
+                if reg.shape:
+                    n_elems = int(np.prod(reg.shape))
+                    vals[reg.name] = np.array(
+                        [_sample_from_register(reg, rng) for _ in range(n_elems)]
+                    ).reshape(reg.shape)
+                else:
+                    vals[reg.name] = _sample_from_register(reg, rng)
+            results.append(vals)
+        return results
+
+
+def _assert_results_equal(result_a: tuple, result_b: tuple, bloq: Bloq, input_vals: dict) -> None:
+    """Assert two simulation results are equal, with informative error messages."""
+    if len(result_a) != len(result_b):
+        raise AssertionError(
+            f"Result length mismatch for {bloq}: "
+            f"on_classical_vals has {len(result_a)} outputs, "
+            f"decomposition has {len(result_b)} outputs."
+        )
+    for i, (a, b) in enumerate(zip(result_a, result_b)):
+        if isinstance(a, np.ndarray) or isinstance(b, np.ndarray):
+            if not np.array_equal(a, b):
+                raise AssertionError(
+                    f"Mismatch for {bloq}, output index {i}.\n"
+                    f"  Input: {input_vals}\n"
+                    f"  on_classical_vals: {a}\n"
+                    f"  decomposition:     {b}"
+                )
+        elif a != b:
+            raise AssertionError(
+                f"Mismatch for {bloq}, output index {i}.\n"
+                f"  Input: {input_vals}\n"
+                f"  on_classical_vals: {a}\n"
+                f"  decomposition:     {b}"
+            )
+
+
+@attrs.frozen
+class ClassicalSimTestCase:
+    """A test case specification for classical simulation verification.
+
+    Specifies a concrete bloq instance (with specific compile-time parameters
+    like bitsizes) to be verified. Classical input values are generated
+    automatically from the bloq's signature and QDType domains.
+
+    Attributes:
+        bloq: A concrete (non-symbolic) Bloq instance.
+        name: Human-readable name for this test case.
+    """
+
+    bloq: Bloq
+    name: str
+
+
+TestCaseProvider = Callable[[], list[ClassicalSimTestCase]]
+"""A zero-argument callable returning `list[ClassicalSimTestCase]` for one bloq class.
+
+Classical verification works by cross-checking two independent computations of the same
+function: a bloq's hand-written `on_classical_vals` (the reference) and the
+result of decomposing the bloq and running each subbloq's `on_classical_vals`
+(structural induction). If both sides agree on all inputs, the decomposition
+is functionally correct. The structural induction framework walks the full decomposition tree via
+BFS, so every subbloq is also verified.
+
+## How to add verification for a bloq
+
+1. **Implement `on_classical_vals`** on your bloq class. This is the reference
+   implementation that the decomposition is checked against. It must be a
+   direct, independent computation.
+
+2. **Provide a decomposition** via `build_composite_bloq`.
+
+3. **Write a `TestCaseProvider`** in the bloq's module that returns
+   `ClassicalSimTestCase` instances for desired parameter
+   combinations. Example:
+
+       def _get_add_classical_sim_test_cases() -> list['ClassicalSimTestCase']:
+           from qualtran.simulation.verification import ClassicalSimTestCase
+           return [
+               ClassicalSimTestCase(
+                   bloq=Add(a_bitsize=a, b_bitsize=b),
+                   name=f"Add(a={a}, b={b})",
+               )
+               for a, b in itertools.product([2, 3, 4], repeat=2)
+           ]
+
+4. **Register** the provider in the `qualtran/simulation/do-classical-verification.py` script
+    keyed by a test suite alias and run with
+    `python do-classical-verification.py --[your testsuite alias]`.
+"""
+
+
+
+
+def validate_test_cases(name: str, cases: list[ClassicalSimTestCase]) -> None:
+    """Validate that all test cases from a provider target the same bloq class.
+
+    Call this after invoking a :data:`TestCaseProvider` to verify the
+    structural invariant: each provider must return test cases for exactly
+    one bloq class.
+
+    Args:
+        name: The registry name of the provider (used in error messages).
+        cases: The test cases returned by a provider function.
+
+    Raises:
+        ValueError: If ``cases`` contains bloqs from more than one class.
+    """
+    if not cases:
+        return
+
+    class_names = {tc.bloq.__class__.__name__ for tc in cases}
+    if len(class_names) > 1:
+        raise ValueError(
+            f"Test case provider '{name}' returned test cases for multiple bloq "
+            f"classes: {sorted(class_names)}. Each provider function must return "
+            f"test cases for exactly one bloq class."
+        )
+
+
+@attrs.frozen
+class VerificationResult:
+    """The result of verifying one bloq.
+
+    Attributes:
+        bloq: The bloq that was verified.
+        status: The verification outcome.
+        n_inputs_checked: Number of input values tested.
+        error_message: Description of the failure, if any.
+        children: Bloqs discovered by decomposing this bloq.
+    """
+
+    bloq: Bloq
+    status: VerificationStatus
+    n_inputs_checked: int = 0
+    error_message: str | None = None
+    children: tuple[Bloq, ...] = ()
+
+
+def _log_result(bloq: Bloq, result: VerificationResult, log: IO[str] | None) -> None:
+    """Write a single tab-separated log record for a verification result.
+
+    Columns: objectstring \t status \t n_inputs_checked \t error_message
+    """
+    if log is None:
+        return
+    objectstring = dump_objectstring(bloq)
+    detail = result.error_message or ''
+    log.write(f"{objectstring}\t{result.status}\t{result.n_inputs_checked}\t{detail}\n")
+    log.flush()
+
+
+def _verify_leaf_bloq(
+    bloq: Bloq, input_vals_list: list[dict[str, ClassicalValT]]
+) -> VerificationResult:
+    """Verify a leaf bloq (no decomposition) by exercising `on_classical_vals`.
+
+    Since there is no decomposition to cross-check against, we verify that
+    `on_classical_vals` is implemented and does not crash on any generated
+    input.
+    """
+    if not input_vals_list:
+        return VerificationResult(bloq, VerificationStatus.LEAF_VERIFIED, n_inputs_checked=0)
+
+    n_ok = 0
+    implemented: bool | None = None  # None = not yet determined
+    try:
+        for input_vals in input_vals_list:
+            try:
+                out = bloq.on_classical_vals(**input_vals)
+            except QCDTypeDomainError:
+                # Domain-constrained input; skip but keep trying others.
+                continue
+
+            if out is NotImplemented:
+                if n_ok > 0:
+                    # Inconsistent: returned real values for earlier inputs.
+                    raise MissingClassicalValsError(
+                        f"on_classical_vals returned NotImplemented for "
+                        f"inputs {input_vals} after succeeding on earlier inputs"
+                    )
+                implemented = False
+                break
+
+            implemented = True
+            if not isinstance(out, dict):
+                raise TypeError(f"on_classical_vals returned {type(out).__name__}, expected dict")
+            n_ok += 1
+
+        if implemented is False:
+            return VerificationResult(
+                bloq,
+                VerificationStatus.LEAF_NO_CLASSICAL_VALS,
+                error_message="Leaf bloq does not implement on_classical_vals.",
+            )
+
+        return VerificationResult(bloq, VerificationStatus.LEAF_VERIFIED, n_inputs_checked=n_ok)
+
+    except Exception as e:
+        return VerificationResult(
+            bloq, VerificationStatus.ERROR, error_message=f"Leaf verification failed: {e}"
+        )
+
+
+logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def _get_qlt_fastsim_cls() -> type | None:
+    """Memoize attempting to import `rsqualtran.QLTFastsim` to avoid repetitive `sys.path` searches."""
+    try:
+        from rsqualtran import QLTFastsim
+
+        return QLTFastsim
+    except ImportError:
+        return None
+
+
+def _should_use_fastsim() -> bool:
+    """Determine whether to use the Rust fastsim engine for classical verification.
+
+    Checks the `QLT_USE_FASTSIM` environment variable first (`1`/`true` or
+    `0`/`false`). If not set, checks whether `rsqualtran` can be imported and
+    uses fastsim if available, otherwise falls back to Python.
+    """
+    env_val = os.environ.get('QLT_USE_FASTSIM')
+    if env_val is not None:
+        val = env_val.strip().lower()
+        if val in ('1', 'true', 'yes', 'on'):
+            cls = _get_qlt_fastsim_cls()
+            if cls is not None:
+                return True
+            raise ImportError(
+                "QLT_USE_FASTSIM is explicitly enabled in environment variables, "
+                "but `rsqualtran` (`QLTFastsim`) could not be imported."
+            )
+        elif val in ('0', 'false', 'no', 'off'):
+            return False
+        else:
+            raise ValueError(
+                f"Invalid value for QLT_USE_FASTSIM environment variable: '{env_val}'. "
+                f"Expected '1'/'0', 'true'/'false', or similar boolean string."
+            )
+
+    return _get_qlt_fastsim_cls() is not None
+
+
+def _verify_decomposable_bloq(
+    bloq: Bloq, input_vals_list: list[dict[str, ClassicalValT]], child_bloqs: tuple[Bloq, ...]
+) -> VerificationResult:
+    """Verify a decomposable bloq via structural induction.
+
+    Cross-checks the parent bloq's `on_classical_vals` against
+    `simulate_via_subbloq_classical_vals` (decompose the parent once, then
+    run each sub-bloq's `on_classical_vals`).  If the parent does not
+    implement `on_classical_vals`, reports `MISSING_CLASSICAL_VALS`.
+
+    We call `on_classical_vals` directly, never `call_classically` or any
+    method that falls back to recursive decomposition to avoid tautological
+    comparisons.
+    """
+    use_fastsim = _should_use_fastsim()
+    sim = None
+    if use_fastsim:
+        fastsim_cls = _get_qlt_fastsim_cls()
+        if fastsim_cls is not None:
+            try:
+                sim = fastsim_cls.from_bloq(bloq)
+            except Exception:
+                # Fall back to Python simulation for mock or custom test bloqs.
+                sim = None
+
+    try:
+        n_checked = 0
+        parent_has_classical_vals = True
+
+        for input_vals in input_vals_list:
+            # Try on_classical_vals on auto-generated inputs.
+            # QCDTypeDomainError indicates an out-of-domain input and is skipped.
+            # All non-domain errors propagate immediately as verification bugs.
+            try:
+                parent_out = bloq.on_classical_vals(**input_vals)
+            except QCDTypeDomainError:
+                continue
+
+            if parent_out is NotImplemented:
+                parent_has_classical_vals = False
+                break
+
+            if sim is not None:
+                decomp_result = sim.call_classically(**input_vals)
+            else:
+                decomp_result = simulate_via_subbloq_classical_vals(bloq, **input_vals)
+
+            right_regs = list(bloq.signature.rights())
+            parent_tuple = tuple(parent_out[reg.name] for reg in right_regs)
+            _assert_results_equal(parent_tuple, decomp_result, bloq, input_vals)
+            n_checked += 1
+
+        if not parent_has_classical_vals:
+            return VerificationResult(
+                bloq,
+                VerificationStatus.MISSING_CLASSICAL_VALS,
+                error_message='Bloq does not implement on_classical_vals.',
+                children=child_bloqs,
+            )
+        elif n_checked == 0:
+            return VerificationResult(
+                bloq,
+                VerificationStatus.NO_VALID_INPUTS,
+                n_inputs_checked=0,
+                error_message='on_classical_vals raised on all inputs; '
+                'nothing was actually verified.',
+                children=child_bloqs,
+            )
+        else:
+            return VerificationResult(
+                bloq, VerificationStatus.PASSED, n_inputs_checked=n_checked, children=child_bloqs
+            )
+
+    except MissingClassicalValsError as e:
+        return VerificationResult(
+            bloq,
+            VerificationStatus.MISSING_CLASSICAL_VALS,
+            error_message=str(e),
+            children=child_bloqs,
+        )
+
+    except AssertionError as e:
+        return VerificationResult(
+            bloq, VerificationStatus.FAILED, error_message=str(e), children=child_bloqs
+        )
+
+    except Exception as e:
+        return VerificationResult(
+            bloq,
+            VerificationStatus.ERROR,
+            error_message=f"{type(e).__name__}: {e}",
+            children=child_bloqs,
+        )
+
+
+def verify_structural_induction(
+    root_cases: Sequence[ClassicalSimTestCase],
+    n_samples: int = 100,
+    rng: np.random.Generator | None = None,
+    log: IO[str] | None = sys.stdout,
+) -> list[VerificationResult]:
+    """BFS over the decomposition tree, verifying each bloq encountered.
+
+    For each bloq in the traversal:
+
+    1. Attempt to decompose it. If it can't decompose, it's a leaf node —
+       verify that `on_classical_vals` can at least be called.
+    2. Enqueue its sub-bloqs (callees) for subsequent verification.
+    3. Generate input values (random or exhaustive).
+    4. Cross-check: the parent bloq's `on_classical_vals` (its declared
+       behavior) must agree with `simulate_via_subbloq_classical_vals`
+       (decompose once, run each sub-bloq's `on_classical_vals`).
+
+    This implements structural induction: if every bloq's `on_classical_vals`
+    agrees with its decomposition, then the entire computation tree is
+    functionally correct.
+
+    Args:
+        root_cases: Test cases specifying the root bloq(s) to start from.
+        n_samples: Number of random input samples per bloq. If this exceeds
+            the total domain size, exhaustive enumeration is used.
+        rng: NumPy random generator. Defaults to a seeded generator for
+            reproducibility.
+        log: Writable text stream for the complete verification log.
+            Defaults to `sys.stdout`. Pass an open file to capture
+            the log, or `open(os.devnull, 'w')` to suppress output.
+
+    Returns:
+        A list of `VerificationResult` for every bloq encountered.
+    """
+    if rng is None:
+        rng = np.random.default_rng(42)
+
+    use_fastsim = _should_use_fastsim()
+    sim_style = "QLTFastsim (Rust)" if use_fastsim else "Python (simulate_via_subbloq_classical_vals)"
+    sys.stderr.write(f"[verify_structural_induction] Simulation style: {sim_style}\n")
+    logger.info("[verify_structural_induction] Simulation style: %s", sim_style)
+
+    queue: deque[Bloq] = deque()
+    visited: set[Bloq] = set()
+    results: list[VerificationResult] = []
+    vm = StandardQualtranArchitectureAgnosticVirtualMachine()
+
+    for tc in root_cases:
+        queue.append(tc.bloq)
+
+    while queue:
+        bloq = queue.popleft()
+
+        # attrs @frozen classes have __eq__ and __hash__, so deduplication works.
+        if bloq in visited:
+            continue
+        visited.add(bloq)
+
+        # Generate input values.
+        try:
+            input_vals_list = generate_input_vals(bloq, n_samples, rng)
+        except Exception as e:
+            result = VerificationResult(
+                bloq, VerificationStatus.ERROR, error_message=f"Input generation failed: {e}"
+            )
+            _log_result(bloq, result, log)
+            results.append(result)
+            continue
+
+        # Try to decompose.
+        try:
+            cbloq = bloq.decompose_bloq()
+        except (DecomposeNotImplementedError, DecomposeTypeError):
+            if vm.bloq_in_isa(bloq):
+                # Valid leaf node: in the ISA, no decomposition needed.
+                # Verify on_classical_vals is at least implemented and callable.
+                result = _verify_leaf_bloq(bloq, input_vals_list)
+            else:
+                # Not in the ISA and no decomposition — this bloq should
+                # decompose but doesn't. Flag it as a warning.
+                result = VerificationResult(
+                    bloq,
+                    VerificationStatus.MISSING_DECOMPOSITION,
+                    error_message="Bloq has no decomposition and is not in the ISA.",
+                )
+            _log_result(bloq, result, log)
+            results.append(result)
+            continue
+
+        # Collect unique child bloqs from the decomposition.
+        seen_children: set[Bloq] = set()
+        child_bloqs_list: list[Bloq] = []
+        for binst in cbloq.bloq_instances:
+            if binst.bloq not in seen_children:
+                seen_children.add(binst.bloq)
+                child_bloqs_list.append(binst.bloq)
+        child_bloqs = tuple(child_bloqs_list)
+
+        # Enqueue callees (sub-bloqs from the decomposition) for BFS.
+        for child_bloq in child_bloqs:
+            if child_bloq not in visited:
+                queue.append(child_bloq)
+
+        result = _verify_decomposable_bloq(bloq, input_vals_list, child_bloqs)
+        _log_result(bloq, result, log)
+        results.append(result)
+
+    return results
+
+
+_STATUS_ICONS: dict[VerificationStatus, str] = {
+    VerificationStatus.PASSED: '✓',
+    VerificationStatus.FAILED: '✗',
+    VerificationStatus.MISSING_DECOMPOSITION: '⊘',
+    VerificationStatus.LEAF_VERIFIED: '●',
+    VerificationStatus.LEAF_NO_CLASSICAL_VALS: '○',
+    VerificationStatus.MISSING_CLASSICAL_VALS: '⚠',
+    VerificationStatus.NO_VALID_INPUTS: '◇',
+    VerificationStatus.ERROR: '⚡',
+}
+
+_STATUS_RANK: dict[VerificationStatus, int] = {
+    VerificationStatus.PASSED: 0,
+    VerificationStatus.LEAF_VERIFIED: 1,
+    VerificationStatus.LEAF_NO_CLASSICAL_VALS: 2,
+    VerificationStatus.MISSING_CLASSICAL_VALS: 3,
+    VerificationStatus.NO_VALID_INPUTS: 4,
+    VerificationStatus.MISSING_DECOMPOSITION: 5,
+    VerificationStatus.ERROR: 6,
+    VerificationStatus.FAILED: 7,
+}
+
+
+@attrs.frozen
+class _TreeNode:
+    """A node in the verification summary tree.
+
+    Represents a single bloq class with aggregated verification results
+    from all instances of that class.
+    """
+
+    class_name: str
+    status: VerificationStatus
+    n_inputs_checked: int
+    error_message: str | None
+    child_class_names: tuple[str, ...]
+
+
+def print_verification_summary(
+    results: list[VerificationResult], file: IO[str] = sys.stdout
+) -> None:
+    """Print a tree-view summary of the verification results.
+
+    The decomposition DAG is displayed as a tree with increasing indentation
+    for children. Since the decomposition graph is a DAG (not a tree), each
+    bloq class is assigned to one parent for its primary display. If the same
+    class appears as a descendant of another node, it is shown in parentheses
+    indicating that its analysis is summarized elsewhere.
+
+    Nodes are de-duplicated by bloq class name: multiple instances of the same
+    class are collapsed into a single tree node.
+
+    Args:
+        results: The list of `VerificationResult` from
+            `verify_structural_induction`.
+        file: Writable text stream for the summary. Defaults to stdout.
+    """
+
+    def _write(msg: str = '') -> None:
+        file.write(msg + '\n')
+
+    # --- De-duplicate results by class name. ---------------------------------
+    # For each class name, merge all VerificationResult instances into one
+    # representative entry: aggregate n_inputs_checked, collect unique child
+    # class names, pick the worst status, and keep the first error message.
+    groups: OrderedDict[str, list[VerificationResult]] = OrderedDict()
+    for r in results:
+        cls_name = r.bloq.__class__.__name__
+        groups.setdefault(cls_name, []).append(r)
+
+    nodes: dict[str, _TreeNode] = {}
+    for cls_name, group in groups.items():
+        total_inputs = sum(r.n_inputs_checked for r in group)
+        worst = max(group, key=lambda r: _STATUS_RANK.get(r.status, 99))
+        # Collect unique child class names, preserving first-seen order.
+        seen_child_names: dict[str, None] = {}
+        for r in group:
+            for child in r.children:
+                child_cls = child.__class__.__name__
+                if child_cls not in seen_child_names:
+                    seen_child_names[child_cls] = None
+        nodes[cls_name] = _TreeNode(
+            class_name=cls_name,
+            status=worst.status,
+            n_inputs_checked=total_inputs,
+            error_message=worst.error_message,
+            child_class_names=tuple(seen_child_names),
+        )
+
+    # --- Build tree structure. -----------------------------------------------
+    # Identify root class names: those not appearing as a child of any node.
+    all_child_names: set[str] = set()
+    for node in nodes.values():
+        all_child_names.update(node.child_class_names)
+    root_names = [name for name in nodes if name not in all_child_names]
+
+    # Track which class names have been fully printed.
+    printed: set[str] = set()
+
+    def _node_line(node: _TreeNode) -> str:
+        icon = _STATUS_ICONS.get(node.status, '?')
+        parts = [f"{icon} {node.class_name} [{node.status}]"]
+        if node.n_inputs_checked:
+            parts.append(f"({node.n_inputs_checked} inputs)")
+        if node.error_message:
+            parts.append(f"-- {node.error_message}")
+        return ' '.join(parts)
+
+    def _print_tree(name: str, prefix: str, connector: str) -> None:
+        node = nodes.get(name)
+
+        if name in printed:
+            # Omit leaf-verified nodes entirely — they are typically low-level
+            # primitives that appear many times and add noise to the summary.
+            if node is not None and node.status == VerificationStatus.LEAF_VERIFIED:
+                return
+            icon = _STATUS_ICONS.get(node.status, '?') if node else '?'
+            _write(f"{prefix}{connector}({name}) [{icon} see above]")
+            return
+
+        printed.add(name)
+
+        if node is not None:
+            _write(f"{prefix}{connector}{_node_line(node)}")
+            children = node.child_class_names
+        else:
+            _write(f"{prefix}{connector}{name} [no result]")
+            children = ()
+
+        for i, child_name in enumerate(children):
+            is_last = i == len(children) - 1
+            child_connector = '└── ' if is_last else '├── '
+            child_prefix = prefix + ('    ' if connector in ('└── ', '') else '│   ')
+            _print_tree(child_name, child_prefix, child_connector)
+
+    _write()
+    _write('=' * 70)
+    _write('VERIFICATION SUMMARY (tree view)')
+    _write('=' * 70)
+
+    for i, root_name in enumerate(root_names):
+        _print_tree(root_name, '', '')
+        if i < len(root_names) - 1:
+            _write()
+
+    # Status totals.
+    status_counts: Counter[str] = Counter(r.status for r in results)
+    _write('-' * 70)
+    for status, count in sorted(status_counts.items()):
+        icon = _STATUS_ICONS.get(status, '?')
+        _write(f"  {icon} {status}: {count}")
+    _write(f"  Total: {len(results)}")
+    _write('=' * 70)

--- a/qualtran/simulation/verification_test.py
+++ b/qualtran/simulation/verification_test.py
@@ -488,7 +488,7 @@ class _KeyErrorInOnClassicalVals(Bloq):
         return Signature([Register('q', QBit())])
 
     def on_classical_vals(self, q):
-        d = {}
+        d: dict[str, int] = {}
         return {'q': d['missing_key']}  # Bug: KeyError
 
     def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
@@ -707,6 +707,7 @@ def test_generate_shaped_register_values_in_domain():
     vals = generate_input_vals(bloq, n_samples=10, rng=rng)
     for v in vals:
         arr = v['arr']
+        assert isinstance(arr, np.ndarray)
         for elem in arr.flat:
             assert elem in (0, 1), f"QBit element {elem} not in {{0, 1}}"
 
@@ -1747,7 +1748,8 @@ def test_should_use_fastsim_env_var(monkeypatch):
     # Test unset variable falls back to testing import rsqualtran
     monkeypatch.delenv('QLT_USE_FASTSIM', raising=False)
     try:
-        import rsqualtran  # noqa: F401
+        import rsqualtran  # type: ignore[import-untyped] # noqa: F401
+
         assert _should_use_fastsim() is True
     except ImportError:
         assert _should_use_fastsim() is False
@@ -1763,7 +1765,7 @@ def test_verify_structural_induction_engine_code_paths(qlt_use_fastsim, capsys):
     """
     if qlt_use_fastsim == '1':
         try:
-            import rsqualtran  # noqa: F401
+            import rsqualtran  # type: ignore[import-untyped] # noqa: F401
         except ImportError:
             pytest.skip("rsqualtran (`QLTFastsim`) is not installed in this environment.")
 

--- a/qualtran/simulation/verification_test.py
+++ b/qualtran/simulation/verification_test.py
@@ -40,11 +40,11 @@ from qualtran.simulation.classical_sim import QCDTypeDomainError
 from qualtran.simulation.verification import (
     _assert_results_equal,
     _should_use_fastsim,
-    simulate_via_subbloq_classical_vals,
     ClassicalSimTestCase,
     generate_input_vals,
     MissingClassicalValsError,
     print_verification_summary,
+    simulate_via_subbloq_classical_vals,
     VerificationResult,
     VerificationStatus,
     verify_structural_induction,
@@ -71,6 +71,8 @@ def default_python_verification_engine(monkeypatch, request):
 def qlt_use_fastsim(request, monkeypatch):
     monkeypatch.setenv('QLT_USE_FASTSIM', request.param)
     return request.param
+
+
 #
 # These are organised by role:
 #
@@ -607,7 +609,6 @@ def test_call_no_decomposition_raises():
     bloq = _IdentityBloq()
     with pytest.raises(DecomposeNotImplementedError):
         simulate_via_subbloq_classical_vals(bloq, q=0)
-
 
 
 # ===========================================================================
@@ -1780,6 +1781,8 @@ def test_verify_structural_induction_engine_code_paths(qlt_use_fastsim, capsys):
 
     captured = capsys.readouterr()
     expected_style = (
-        "QLTFastsim (Rust)" if qlt_use_fastsim == '1' else "Python (simulate_via_subbloq_classical_vals)"
+        "QLTFastsim (Rust)"
+        if qlt_use_fastsim == '1'
+        else "Python (simulate_via_subbloq_classical_vals)"
     )
     assert f"[verify_structural_induction] Simulation style: {expected_style}" in captured.err

--- a/qualtran/simulation/verification_test.py
+++ b/qualtran/simulation/verification_test.py
@@ -1749,7 +1749,7 @@ def test_should_use_fastsim_env_var(monkeypatch):
     # Test unset variable falls back to testing import rsqualtran
     monkeypatch.delenv('QLT_USE_FASTSIM', raising=False)
     try:
-        import rsqualtran  # type: ignore[import-untyped] # noqa: F401
+        import rsqualtran  # type: ignore[import-untyped,import-not-found] # noqa: F401
 
         assert _should_use_fastsim() is True
     except ImportError:
@@ -1766,7 +1766,7 @@ def test_verify_structural_induction_engine_code_paths(qlt_use_fastsim, capsys):
     """
     if qlt_use_fastsim == '1':
         try:
-            import rsqualtran  # type: ignore[import-untyped] # noqa: F401
+            import rsqualtran  # type: ignore[import-untyped,import-not-found] # noqa: F401
         except ImportError:
             pytest.skip("rsqualtran (`QLTFastsim`) is not installed in this environment.")
 

--- a/qualtran/simulation/verification_test.py
+++ b/qualtran/simulation/verification_test.py
@@ -1749,7 +1749,7 @@ def test_should_use_fastsim_env_var(monkeypatch):
     # Test unset variable falls back to testing import rsqualtran
     monkeypatch.delenv('QLT_USE_FASTSIM', raising=False)
     try:
-        import rsqualtran  # type: ignore[import-untyped,import-not-found] # noqa: F401
+        import rsqualtran  # type: ignore[import-untyped,import-not-found] # noqa: F401 # pylint: disable=unused-import
 
         assert _should_use_fastsim() is True
     except ImportError:
@@ -1766,7 +1766,7 @@ def test_verify_structural_induction_engine_code_paths(qlt_use_fastsim, capsys):
     """
     if qlt_use_fastsim == '1':
         try:
-            import rsqualtran  # type: ignore[import-untyped,import-not-found] # noqa: F401
+            import rsqualtran  # type: ignore[import-untyped,import-not-found] # noqa: F401 # pylint: disable=unused-import
         except ImportError:
             pytest.skip("rsqualtran (`QLTFastsim`) is not installed in this environment.")
 

--- a/qualtran/simulation/verification_test.py
+++ b/qualtran/simulation/verification_test.py
@@ -1,0 +1,1783 @@
+#  Copyright 2025 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for qualtran.simulation.verification."""
+
+from __future__ import annotations
+
+import io
+from functools import cached_property
+
+import attrs
+import numpy as np
+import pytest
+
+from qualtran import (
+    Bloq,
+    BloqBuilder,
+    DecomposeNotImplementedError,
+    DecomposeTypeError,
+    QBit,
+    QUInt,
+    Register,
+    Side,
+    Signature,
+    SoquetT,
+)
+from qualtran.bloqs.basic_gates import CNOT, XGate
+from qualtran.simulation.classical_sim import QCDTypeDomainError
+from qualtran.simulation.verification import (
+    _assert_results_equal,
+    _should_use_fastsim,
+    simulate_via_subbloq_classical_vals,
+    ClassicalSimTestCase,
+    generate_input_vals,
+    MissingClassicalValsError,
+    print_verification_summary,
+    VerificationResult,
+    VerificationStatus,
+    verify_structural_induction,
+)
+
+# ===========================================================================
+# Test fixtures: small custom bloqs with controlled behaviour
+# ===========================================================================
+
+
+@pytest.fixture(autouse=True)
+def default_python_verification_engine(monkeypatch, request):
+    """By default, run verification tests with Python engine (`QLT_USE_FASTSIM=0`).
+
+    Mock verification bloqs (`_AtomicNot`, `_DomainConstrainedBloq`, etc.) are not
+    supported by the `rsqualtran` compiled L1 engine. Tests that explicitly exercise
+    the Rust fastsim engine bypass this via `qlt_use_fastsim` parameterization or fixture.
+    """
+    if 'qlt_use_fastsim' not in request.fixturenames:
+        monkeypatch.setenv('QLT_USE_FASTSIM', '0')
+
+
+@pytest.fixture
+def qlt_use_fastsim(request, monkeypatch):
+    monkeypatch.setenv('QLT_USE_FASTSIM', request.param)
+    return request.param
+#
+# These are organised by role:
+#
+# 1. Basic building blocks (identity, NOT, double-NOT variants)
+# 2. Atomic leaf bloqs (raise DecomposeTypeError — can't decompose further)
+# 3. Composite bloqs for structural-induction tests (diamonds, 3-level trees)
+# 4. Domain-constrained / edge-case bloqs
+# 5. Shaped- and large-register bloqs for input-generation tests
+
+
+# --- 1. Basic building blocks ------------------------------------------------
+
+
+@attrs.frozen
+class _IdentityBloq(Bloq):
+    """Single-qubit identity: has on_classical_vals, no decomposition."""
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        return {'q': q}
+
+
+@attrs.frozen
+class _NotGate(Bloq):
+    """Single-qubit NOT: has on_classical_vals, no decomposition."""
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        return {'q': (q + 1) % 2}
+
+
+@attrs.frozen
+class _DoubleNot(Bloq):
+    """Applies NOT twice (identity). Has both reference and decomposition."""
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        return {'q': q}
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        q = bb.add(XGate(), q=q)
+        q = bb.add(XGate(), q=q)
+        return {'q': q}
+
+
+@attrs.frozen
+class _BuggyDoubleNot(Bloq):
+    """Correct decomposition (XX = identity), but WRONG on_classical_vals (NOT).
+
+    A tautological verifier using call_classically() on both sides would
+    silently fall back to decomposition for the parent too, comparing
+    decomposition-vs-decomposition and never noticing the bug. The real
+    verifier must call on_classical_vals DIRECTLY and catch the mismatch.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        # WRONG: claims to be NOT.
+        return {'q': (q + 1) % 2}
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        # CORRECT: XX = identity.
+        q = bb.add(XGate(), q=q)
+        q = bb.add(XGate(), q=q)
+        return {'q': q}
+
+
+@attrs.frozen
+class _PartiallyWrongBloq(Bloq):
+    """on_classical_vals is CORRECT for input 0 but WRONG for input 1.
+
+    A verifier that only tests input 0 (or stops after the first success)
+    would miss the bug. The verifier must test both inputs for QBit
+    (exhaustive enumeration) and detect the failure on input 1.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        if q == 0:
+            return {'q': 0}  # CORRECT: identity on 0
+        return {'q': 0}  # WRONG: should return 1 for identity
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        # Decomposition: identity (no gates).
+        return {'q': q}
+
+
+@attrs.frozen
+class _NoClassicalValsBloq(Bloq):
+    """Leaf bloq with no on_classical_vals and no decomposition."""
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    # on_classical_vals not overridden → returns NotImplemented.
+
+
+@attrs.frozen
+class _NoReferenceBloq(Bloq):
+    """Has a decomposition but a sub-bloq lacks on_classical_vals."""
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        q = bb.add(_NoClassicalValsBloq(), q=q)
+        return {'q': q}
+
+
+@attrs.frozen
+class _DecomposableNoReference(Bloq):
+    """Has a decomposition (into _DoubleNot) but no on_classical_vals.
+
+    The parent-reference check must be skipped for this bloq. If the verifier
+    accidentally used call_classically (which falls back to decomposition),
+    it would be comparing the decomposition against itself — tautological.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    # No on_classical_vals — returns NotImplemented by default.
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        q = bb.add(_DoubleNot(), q=q)
+        return {'q': q}
+
+
+# --- 2. Atomic leaf bloqs ----------------------------------------------------
+# These raise DecomposeTypeError to signal they are primitive operations.
+
+
+@attrs.frozen
+class _AtomicNot(Bloq):
+    """Atomic NOT gate (leaf node). Correct on_classical_vals."""
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        return {'q': (q + 1) % 2}
+
+    def decompose_bloq(self):
+        raise DecomposeTypeError(f"{self} is atomic")
+
+
+@attrs.frozen
+class _AtomicBuggyIdentity(Bloq):
+    """Atomic leaf whose on_classical_vals is WRONG: claims identity
+    instead of NOT.
+
+    Used to inject bugs deep in decomposition trees. A parent that expects
+    two NOTs (= identity) will get NOT + identity = NOT, causing a mismatch.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        # WRONG: claims identity instead of NOT.
+        return {'q': q}
+
+    def decompose_bloq(self):
+        raise DecomposeTypeError(f"{self} is atomic")
+
+
+# --- 3. Composite bloqs for structural-induction tests -----------------------
+
+
+@attrs.frozen
+class _ParentBloq(Bloq):
+    """Decomposes into two _DoubleNot instances (shared child class)."""
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('x', QBit()), Register('y', QBit())])
+
+    def on_classical_vals(self, x, y):
+        return {'x': x, 'y': y}
+
+    def build_composite_bloq(self, bb: BloqBuilder, x: SoquetT, y: SoquetT) -> dict[str, SoquetT]:
+        x = bb.add(_DoubleNot(), q=x)
+        y = bb.add(_DoubleNot(), q=y)
+        return {'x': x, 'y': y}
+
+
+@attrs.frozen
+class _ParentWithBuggySubBloqs(Bloq):
+    """Parent is correct (identity), decomposition uses two _AtomicBuggyIdentity.
+
+    Each sub-bloq claims identity (wrong — should be NOT), so two
+    "identities" = identity, matching the parent's reference. The parent
+    passes, but _AtomicBuggyIdentity would fail its own leaf verification
+    if it had a decomposition to cross-check against.
+
+    This demonstrates that consistently-wrong sub-bloqs can mask each other.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        return {'q': q}
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        q = bb.add(_AtomicBuggyIdentity(), q=q)
+        q = bb.add(_AtomicBuggyIdentity(), q=q)
+        return {'q': q}
+
+
+@attrs.frozen
+class _ParentWithOneBuggySubBloq(Bloq):
+    """Parent is correct (identity via NOT + NOT). Decomposition uses one
+    correct _AtomicNot and one buggy _AtomicBuggyIdentity.
+
+    simulate_via_subbloq_classical_vals computes: NOT(input) via _AtomicNot, then identity
+    via _AtomicBuggyIdentity = NOT(input). Parent says identity = input.
+    MISMATCH — sub-bloq bugs propagate to the parent.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        return {'q': q}
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        q = bb.add(_AtomicNot(), q=q)
+        q = bb.add(_AtomicBuggyIdentity(), q=q)
+        return {'q': q}
+
+
+@attrs.frozen
+class _DiamondMid(Bloq):
+    """Middle node in a diamond-shaped DAG. Decomposes into one correct
+    _AtomicNot and one buggy _AtomicBuggyIdentity.
+
+    on_classical_vals: identity (two NOTs should cancel).
+    simulate_via_subbloq_classical_vals: NOT + identity = NOT. MISMATCH.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        return {'q': q}
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        q = bb.add(_AtomicNot(), q=q)
+        q = bb.add(_AtomicBuggyIdentity(), q=q)
+        return {'q': q}
+
+
+@attrs.frozen
+class _DiamondTopBloq(Bloq):
+    """Diamond DAG top node. Decomposes into two _DiamondMid instances
+    on separate registers, creating a diamond-shaped dependency graph.
+
+    BFS must discover _DiamondMid and its leaves. The bug in
+    _AtomicBuggyIdentity causes _DiamondMid to fail.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('x', QBit()), Register('y', QBit())])
+
+    def on_classical_vals(self, x, y):
+        return {'x': x, 'y': y}
+
+    def build_composite_bloq(self, bb: BloqBuilder, x: SoquetT, y: SoquetT) -> dict[str, SoquetT]:
+        x = bb.add(_DiamondMid(), q=x)
+        y = bb.add(_DiamondMid(), q=y)
+        return {'x': x, 'y': y}
+
+
+@attrs.frozen
+class _Level1Mid(Bloq):
+    """Level 1 in a 3-level hierarchy. Decomposes into _AtomicNot +
+    _AtomicBuggyIdentity. on_classical_vals says identity (two NOTs
+    should cancel) but the buggy leaf causes a mismatch.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        return {'q': q}
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        q = bb.add(_AtomicNot(), q=q)
+        q = bb.add(_AtomicBuggyIdentity(), q=q)
+        return {'q': q}
+
+
+@attrs.frozen
+class _Level2Top(Bloq):
+    """3-level hierarchy top. Decomposes into two _Level1Mid instances.
+
+    BFS must traverse 3 levels deep to discover the bug in
+    _AtomicBuggyIdentity via _Level1Mid.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        return {'q': q}
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        q = bb.add(_Level1Mid(), q=q)
+        q = bb.add(_Level1Mid(), q=q)
+        return {'q': q}
+
+
+# --- 4. Domain-constrained / edge-case bloqs ---------------------------------
+
+
+@attrs.frozen
+class _DomainConstrainedBloq(Bloq):
+    """Raises ValueError on odd inputs. Only even inputs are checked.
+
+    n_inputs_checked must be strictly less than total domain size.
+    """
+
+    n: int = 4
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('x', QUInt(self.n))])
+
+    def on_classical_vals(self, x):
+        if x % 2 != 0:
+            raise QCDTypeDomainError(f"Only even inputs allowed, got {x}")
+        return {'x': x}
+
+    def build_composite_bloq(self, bb: BloqBuilder, x: SoquetT) -> dict[str, SoquetT]:
+        return {'x': x}
+
+
+@attrs.frozen
+class _AllRaisingBloq(Bloq):
+    """on_classical_vals raises on ALL inputs.
+
+    The verifier must NOT report 'passed' when nothing was actually
+    verified. Instead it should report 'no_valid_inputs'.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        raise QCDTypeDomainError("No valid inputs")
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        q = bb.add(XGate(), q=q)
+        return {'q': q}
+
+
+@attrs.frozen
+class _TypeErrorInOnClassicalVals(Bloq):
+    """on_classical_vals has a genuine bug: calls len() on an int.
+
+    This is NOT a domain constraint — it's a programming error. The verifier
+    must NOT silently skip it as a "domain-constrained" input. It should
+    propagate as an ERROR.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        return {'q': len(q)}  # Bug: q is an int, not a sequence
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        return {'q': q}
+
+
+@attrs.frozen
+class _KeyErrorInOnClassicalVals(Bloq):
+    """on_classical_vals has a genuine bug: accesses a nonexistent dict key.
+
+    This is NOT a domain constraint — it's a programming error. The verifier
+    must NOT silently skip it.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        d = {}
+        return {'q': d['missing_key']}  # Bug: KeyError
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        return {'q': q}
+
+
+@attrs.frozen
+class _TypeErrorLeafBloq(Bloq):
+    """Atomic leaf bloq with a genuine TypeError bug in on_classical_vals.
+
+    The verifier must NOT mark this LEAF_VERIFIED — the exception is not a
+    domain constraint, it's a real bug.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        return {'q': len(q)}  # Bug: q is an int
+
+    def decompose_bloq(self):
+        raise DecomposeTypeError(f"{self} is atomic")
+
+
+@attrs.frozen
+class _ParentOfBuggyLeaf(Bloq):
+    """Parent that decomposes into _TypeErrorLeafBloq.
+
+    When the verifier runs simulate_via_subbloq_classical_vals on this parent, it invokes
+    _TypeErrorLeafBloq.on_classical_vals, which raises TypeError. With the
+    narrowed except clauses, this TypeError must propagate as ERROR rather
+    than being silently swallowed.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('q', QBit())])
+
+    def on_classical_vals(self, q):
+        return {'q': q}  # Correct identity
+
+    def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+        q = bb.add(_TypeErrorLeafBloq(), q=q)
+        return {'q': q}
+
+
+# --- 5. Shaped- and large-register bloqs ------------------------------------
+
+
+@attrs.frozen
+class _LargeDomainBloq(Bloq):
+    """Uses QUInt(16) — domain size 65,536. Forces random sampling
+    when n_samples is small.
+    """
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('x', QUInt(16))])
+
+    def on_classical_vals(self, x):
+        return {'x': x}
+
+
+@attrs.frozen
+class _ShapedRegBloq(Bloq):
+    """Has a shaped register — shape=(5,) of QBit."""
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('arr', QBit(), shape=(5,))])
+
+    def on_classical_vals(self, arr):
+        return {'arr': arr}
+
+
+@attrs.frozen
+class _MixedRegBloq(Bloq):
+    """Has both scalar (QBit) and shaped (QBit, shape=(3,)) registers."""
+
+    @cached_property
+    def signature(self):
+        return Signature([Register('scalar', QBit()), Register('array', QBit(), shape=(3,))])
+
+    def on_classical_vals(self, scalar, array):
+        return {'scalar': scalar, 'array': array}
+
+
+# ===========================================================================
+# Tests: StrictClassicalSimState
+# ===========================================================================
+
+
+def test_reference_sim_raises_on_missing_on_classical_vals():
+    """StrictClassicalSimState raises MissingClassicalValsError when
+    on_classical_vals is not implemented on a sub-bloq."""
+    bloq = _NoReferenceBloq()
+    with pytest.raises(MissingClassicalValsError):
+        simulate_via_subbloq_classical_vals(bloq, q=0)
+
+
+def test_reference_sim_succeeds_with_reference():
+    """StrictClassicalSimState works when all sub-bloqs have on_classical_vals."""
+    bloq = _DoubleNot()
+    assert simulate_via_subbloq_classical_vals(bloq, q=0) == (0,)
+    assert simulate_via_subbloq_classical_vals(bloq, q=1) == (1,)
+
+
+# ===========================================================================
+# Tests: simulate_via_subbloq_classical_vals
+# ===========================================================================
+
+
+def test_call_no_decomposition_raises():
+    """Bloqs without decomposition raise DecomposeNotImplementedError."""
+    bloq = _IdentityBloq()
+    with pytest.raises(DecomposeNotImplementedError):
+        simulate_via_subbloq_classical_vals(bloq, q=0)
+
+
+
+# ===========================================================================
+# Tests: generate_input_vals
+# ===========================================================================
+
+
+def test_generate_exhaustive_for_small_domain():
+    """When n_samples >= domain size, enumerate exhaustively."""
+    cnot = CNOT()
+    rng = np.random.default_rng(0)
+    vals = generate_input_vals(cnot, n_samples=100, rng=rng)
+    assert len(vals) == 4
+    combos = {(v['ctrl'], v['target']) for v in vals}
+    assert combos == {(0, 0), (0, 1), (1, 0), (1, 1)}
+
+
+def test_generate_random_sampling():
+    """When n_samples < domain size, return exactly n_samples."""
+    from qualtran.bloqs.arithmetic import Add
+
+    add = Add(QUInt(8))
+    rng = np.random.default_rng(42)
+    vals = generate_input_vals(add, n_samples=10, rng=rng)
+    assert len(vals) == 10
+    for v in vals:
+        assert 'a' in v and 'b' in v
+
+
+def test_generate_no_inputs():
+    """Bloqs with no LEFT registers return a single empty dict."""
+    from qualtran.bloqs.bookkeeping import Allocate
+
+    alloc = Allocate(QBit())
+    rng = np.random.default_rng(0)
+    vals = generate_input_vals(alloc, n_samples=10, rng=rng)
+    assert vals == [{}]
+
+
+def test_generate_reproducible_with_same_seed():
+    from qualtran.bloqs.arithmetic import Add
+
+    add = Add(QUInt(4))
+    vals1 = generate_input_vals(add, 5, np.random.default_rng(123))
+    vals2 = generate_input_vals(add, 5, np.random.default_rng(123))
+    assert vals1 == vals2
+
+
+def test_generate_large_domain_values_in_range():
+    """QUInt(16) has domain size 65,536 > n_samples=20, so random
+    sampling is used. All generated values must be valid (0 <= x < 2^16).
+    """
+    bloq = _LargeDomainBloq()
+    rng = np.random.default_rng(42)
+    vals = generate_input_vals(bloq, n_samples=20, rng=rng)
+    assert len(vals) == 20
+    for v in vals:
+        assert 'x' in v
+        assert 0 <= v['x'] < 2**16, f"Value {v['x']} out of range"
+
+
+def test_generate_large_domain_values_are_integers():
+    """Sampled values for QUInt(16) should be integers (not floats)."""
+    bloq = _LargeDomainBloq()
+    rng = np.random.default_rng(42)
+    vals = generate_input_vals(bloq, n_samples=10, rng=rng)
+    for v in vals:
+        assert isinstance(v['x'], (int, np.integer)), f"Expected integer type, got {type(v['x'])}"
+
+
+def test_generate_large_domain_has_variety():
+    """Random sampling should produce variety, not all the same value."""
+    bloq = _LargeDomainBloq()
+    rng = np.random.default_rng(42)
+    vals = generate_input_vals(bloq, n_samples=20, rng=rng)
+    unique_values = {v['x'] for v in vals}
+    assert len(unique_values) > 1, "Random sampling produced only one unique value"
+
+
+def test_generate_shaped_register_correct_shape():
+    """Shaped register (shape=(5,)) should produce NDArrays with shape (5,)."""
+    bloq = _ShapedRegBloq()
+    rng = np.random.default_rng(42)
+    vals = generate_input_vals(bloq, n_samples=10, rng=rng)
+    assert len(vals) == 10
+    for v in vals:
+        assert 'arr' in v
+        arr = v['arr']
+        assert isinstance(arr, np.ndarray), f"Expected ndarray, got {type(arr)}"
+        assert arr.shape == (5,), f"Expected shape (5,), got {arr.shape}"
+
+
+def test_generate_shaped_register_values_in_domain():
+    """Each element of a shaped QBit register should be 0 or 1."""
+    bloq = _ShapedRegBloq()
+    rng = np.random.default_rng(42)
+    vals = generate_input_vals(bloq, n_samples=10, rng=rng)
+    for v in vals:
+        arr = v['arr']
+        for elem in arr.flat:
+            assert elem in (0, 1), f"QBit element {elem} not in {{0, 1}}"
+
+
+def test_generate_shaped_register_forces_sampling():
+    """Shaped registers force random sampling even when n_samples
+    is large. Should return exactly n_samples dicts, not exhaustive.
+    """
+    bloq = _ShapedRegBloq()
+    rng = np.random.default_rng(42)
+    vals = generate_input_vals(bloq, n_samples=50, rng=rng)
+    assert len(vals) == 50
+
+
+def test_generate_mixed_scalar_and_shaped():
+    """A bloq with both scalar QBit and shaped QBit registers.
+
+    The scalar register should be an integer, and the shaped
+    register should be an NDArray with the correct shape.
+    """
+    bloq = _MixedRegBloq()
+    rng = np.random.default_rng(42)
+    vals = generate_input_vals(bloq, n_samples=15, rng=rng)
+    assert len(vals) == 15
+    for v in vals:
+        # Scalar register.
+        assert 'scalar' in v
+        assert isinstance(v['scalar'], (int, np.integer))
+        assert v['scalar'] in (0, 1)
+        # Shaped register.
+        assert 'array' in v
+        arr = v['array']
+        assert isinstance(arr, np.ndarray)
+        assert arr.shape == (3,)
+        for elem in arr.flat:
+            assert elem in (0, 1)
+
+
+def test_generate_mixed_register_forces_sampling():
+    """Presence of shaped register forces random sampling for all."""
+    bloq = _MixedRegBloq()
+    rng = np.random.default_rng(42)
+    vals = generate_input_vals(bloq, n_samples=30, rng=rng)
+    assert len(vals) == 30
+
+
+def test_generate_output_only_bloq_returns_single_empty_dict():
+    """Bloqs with no LEFT registers (only RIGHT) should return [{}]."""
+
+    @attrs.frozen
+    class _OutputOnlyBloq(Bloq):
+        @cached_property
+        def signature(self):
+            return Signature([Register('out', QBit(), side=Side.RIGHT)])
+
+        def on_classical_vals(self):
+            return {'out': 0}
+
+    bloq = _OutputOnlyBloq()
+    rng = np.random.default_rng(42)
+    vals = generate_input_vals(bloq, n_samples=10, rng=rng)
+    assert vals == [{}]
+
+
+# ===========================================================================
+# Tests: _assert_results_equal
+# ===========================================================================
+
+
+def test_assert_equal_scalars():
+    _assert_results_equal((1, 2, 3), (1, 2, 3), _IdentityBloq(), {})
+
+
+def test_assert_unequal_scalars():
+    with pytest.raises(AssertionError, match="Mismatch"):
+        _assert_results_equal((1,), (2,), _IdentityBloq(), {'q': 0})
+
+
+def test_assert_length_mismatch():
+    with pytest.raises(AssertionError, match="length mismatch"):
+        _assert_results_equal((1, 2), (1,), _IdentityBloq(), {})
+
+
+def test_assert_equal_arrays():
+    a = np.array([1, 2, 3])
+    b = np.array([1, 2, 3])
+    _assert_results_equal((a,), (b,), _IdentityBloq(), {})
+
+
+def test_assert_unequal_arrays():
+    a = np.array([1, 2, 3])
+    b = np.array([1, 2, 4])
+    with pytest.raises(AssertionError, match="Mismatch"):
+        _assert_results_equal((a,), (b,), _IdentityBloq(), {'q': 0})
+
+
+def test_assert_nan_scalar_fails():
+    """NaN != NaN, so two results containing NaN should raise.
+
+    float('nan') != float('nan') evaluates to True in Python (meaning
+    they are NOT equal). The comparison function should report a mismatch.
+    """
+    nan = float('nan')
+    with pytest.raises(AssertionError, match='Mismatch'):
+        _assert_results_equal((nan,), (nan,), _IdentityBloq(), {'q': 0})
+
+
+def test_assert_nan_in_array_fails():
+    """NaN in numpy arrays causes comparison failure."""
+    a = np.array([1.0, float('nan')])
+    b = np.array([1.0, float('nan')])
+    with pytest.raises(AssertionError, match='Mismatch'):
+        _assert_results_equal((a,), (b,), _IdentityBloq(), {'q': 0})
+
+
+def test_assert_int_vs_np_int64_equal():
+    """Python int(1) and np.int64(1) should compare equal."""
+    _assert_results_equal((int(1),), (np.int64(1),), _IdentityBloq(), {'q': 1})
+
+
+def test_assert_int_vs_np_int_different_values():
+    """int(1) vs np.int64(0) should fail."""
+    with pytest.raises(AssertionError, match='Mismatch'):
+        _assert_results_equal((int(1),), (np.int64(0),), _IdentityBloq(), {'q': 0})
+
+
+def test_assert_empty_tuples_equal():
+    """Two empty tuples should compare equal (bloq with no RIGHT registers)."""
+    _assert_results_equal((), (), _IdentityBloq(), {})
+
+
+def test_assert_array_vs_scalar_mismatch():
+    """Comparing ndarray vs scalar when shapes differ should fail."""
+    with pytest.raises(AssertionError, match='Mismatch'):
+        _assert_results_equal((np.array([1]),), (1,), _IdentityBloq(), {'q': 0})
+
+
+def test_assert_multi_element_tuple():
+    """Multi-element tuples with mixed types."""
+    _assert_results_equal(
+        (0, np.array([1, 2]), 3), (0, np.array([1, 2]), 3), _IdentityBloq(), {'q': 0}
+    )
+
+
+def test_assert_multi_element_partial_mismatch():
+    """Only one element in a multi-element tuple differs."""
+    with pytest.raises(AssertionError, match='output index 1'):
+        _assert_results_equal(
+            (0, np.array([1, 2]), 3), (0, np.array([1, 9]), 3), _IdentityBloq(), {'q': 0}
+        )
+
+
+# ===========================================================================
+# Tests: verify_structural_induction
+# ===========================================================================
+
+
+def test_verify_passing_bloq():
+    """A correct bloq with decomposition produces 'passed' status."""
+    cases = [ClassicalSimTestCase(bloq=_DoubleNot(), name='double_not')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    statuses = {r.status for r in results}
+    assert VerificationStatus.PASSED in statuses
+
+
+def test_verify_catches_wrong_on_classical_vals():
+    """verify_structural_induction must catch a bloq whose on_classical_vals
+    disagrees with its decomposition.
+
+    _BuggyDoubleNot has on_classical_vals returning NOT, but its decomposition
+    (XX) correctly computes identity. The verifier should detect this mismatch
+    and report status='failed'.
+    """
+    bloq = _BuggyDoubleNot()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='buggy')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    root_result = results[0]
+    assert root_result.bloq.__class__.__name__ == '_BuggyDoubleNot'
+    assert root_result.status == VerificationStatus.FAILED
+    assert root_result.error_message is not None
+    assert 'Mismatch' in root_result.error_message
+
+    # Confirm the mismatch directly: on_classical_vals says NOT,
+    # decomposition says identity.
+    assert bloq.on_classical_vals(q=0) == {'q': 1}
+    assert simulate_via_subbloq_classical_vals(bloq, q=0) == (0,)
+
+
+def test_verify_correct_on_classical_vals_passes():
+    """A bloq whose on_classical_vals agrees with its decomposition should
+    produce status='passed'."""
+    cases = [ClassicalSimTestCase(bloq=_DoubleNot(), name='correct')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    root_result = results[0]
+    assert root_result.bloq.__class__.__name__ == '_DoubleNot'
+    assert root_result.status == VerificationStatus.PASSED
+
+
+def test_verify_no_on_classical_vals_still_cross_checks():
+    """A bloq without on_classical_vals: the parent check should be
+    skipped gracefully, not cause an error."""
+    cases = [ClassicalSimTestCase(bloq=_NoReferenceBloq(), name='no_ref')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    root_result = results[0]
+    # Should be 'missing_classical_vals', not 'error'.
+    assert root_result.status == VerificationStatus.MISSING_CLASSICAL_VALS
+
+
+def test_verify_skips_parent_check_when_no_reference():
+    """When a bloq has a decomposition but no on_classical_vals, the verifier
+    must NOT fall back to call_classically (which would silently use the
+    decomposition, comparing it against itself).
+
+    _DecomposableNoReference decomposes into _DoubleNot (which is correct),
+    but has no on_classical_vals. The verifier should report
+    'missing_classical_vals' — NOT 'passed' from a tautological self-comparison.
+    """
+    cases = [ClassicalSimTestCase(bloq=_DecomposableNoReference(), name='no_ref_parent')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    root_result = results[0]
+    assert root_result.bloq.__class__.__name__ == '_DecomposableNoReference'
+    assert root_result.status == VerificationStatus.MISSING_CLASSICAL_VALS
+
+
+def test_verify_missing_classical_vals():
+    """A bloq whose children lack on_classical_vals → 'missing_classical_vals'."""
+    cases = [ClassicalSimTestCase(bloq=_NoReferenceBloq(), name='no_ref')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    root_result = results[0]
+    assert root_result.status == VerificationStatus.MISSING_CLASSICAL_VALS
+
+
+def test_verify_partial_correctness_caught():
+    """A bloq correct on input 0 but wrong on input 1 must be caught.
+
+    The verifier must test both inputs for QBit (exhaustive enumeration).
+    """
+    bloq = _PartiallyWrongBloq()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='partial_bug')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    root = results[0]
+    assert root.status == VerificationStatus.FAILED, "Verifier should detect the bug on input q=1."
+    assert root.error_message is not None
+    assert 'Mismatch' in root.error_message
+
+    # Confirm partial correctness directly.
+    assert bloq.on_classical_vals(q=0) == {'q': 0}
+    assert simulate_via_subbloq_classical_vals(bloq, q=0) == (0,)
+    assert bloq.on_classical_vals(q=1) == {'q': 0}
+    assert simulate_via_subbloq_classical_vals(bloq, q=1) == (1,)
+
+
+def test_verify_sub_bloq_bug_propagates():
+    """A parent with one correct and one buggy sub-bloq.
+
+    The parent's on_classical_vals is correct (identity). But the
+    decomposition uses a buggy sub-bloq that claims identity instead
+    of NOT. simulate_via_subbloq_classical_vals computes the wrong answer, resulting
+    in a 'failed' status.
+    """
+    bloq = _ParentWithOneBuggySubBloq()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='buggy_sub')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    root = results[0]
+    assert (
+        root.status == VerificationStatus.FAILED
+    ), "Sub-bloq's buggy on_classical_vals should cause parent failure."
+    assert root.error_message is not None
+    assert 'Mismatch' in root.error_message
+
+
+def test_verify_consistent_sub_bloq_bugs_can_mask():
+    """Two consistently-wrong sub-bloqs can mask each other.
+
+    _ParentWithBuggySubBloqs uses two _AtomicBuggyIdentity instances.
+    Each claims identity (wrong — should be NOT), so two identities =
+    identity, matching the parent's reference. The parent passes, but
+    _AtomicBuggyIdentity would fail its own check if it had a decomposition.
+    """
+    bloq = _ParentWithBuggySubBloqs()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='consistent_bugs')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    root = results[0]
+    assert root.status == VerificationStatus.PASSED
+
+
+def test_verify_domain_constrained_n_inputs_checked():
+    """Skipped inputs must NOT count as checked.
+
+    _DomainConstrainedBloq raises on odd inputs. For QUInt(4), roughly
+    half the inputs should be skipped. n_inputs_checked must reflect
+    only the inputs where both sides could be compared.
+    """
+    bloq = _DomainConstrainedBloq(n=4)
+    cases = [ClassicalSimTestCase(bloq=bloq, name='constrained')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=100, log=log)
+    root = results[0]
+    assert root.status == VerificationStatus.PASSED
+    # QUInt(4) has 16 values. With n_samples=100 >= 16, exhaustive.
+    # Only even values (0,2,4,6,8,10,12,14) = 8 pass the domain check.
+    assert root.n_inputs_checked == 8, (
+        f"Expected 8 checked inputs (even values 0-14), " f"got {root.n_inputs_checked}."
+    )
+
+
+def test_verify_deduplication():
+    """The same bloq instance appearing multiple times is verified only once."""
+    cases = [
+        ClassicalSimTestCase(bloq=_DoubleNot(), name='dn1'),
+        ClassicalSimTestCase(bloq=_DoubleNot(), name='dn2'),
+    ]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    bloq_classes = [r.bloq.__class__.__name__ for r in results]
+    assert bloq_classes.count('_DoubleNot') == 1
+
+
+def test_verify_children_populated():
+    """Results for decomposable bloqs have children populated."""
+    cases = [ClassicalSimTestCase(bloq=_DoubleNot(), name='dn')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    dn_result = [r for r in results if r.bloq.__class__.__name__ == '_DoubleNot'][0]
+    assert len(dn_result.children) > 0
+    child_classes = [c.__class__.__name__ for c in dn_result.children]
+    assert 'XGate' in child_classes
+
+
+def test_verify_leaf_bloqs_have_no_children():
+    """Leaf bloqs (no decomposition) have empty children."""
+    cases = [ClassicalSimTestCase(bloq=_DoubleNot(), name='dn')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    leaf_results = [r for r in results if r.status == VerificationStatus.LEAF_VERIFIED]
+    for r in leaf_results:
+        assert r.children == ()
+
+
+def test_verify_diamond_dag_catches_deep_bug():
+    """Diamond DAG with a buggy deep child.
+
+    _DiamondTopBloq decomposes into two _DiamondMid instances, each
+    of which decomposes into _AtomicNot (correct NOT) and
+    _AtomicBuggyIdentity (wrong — identity instead of NOT). The bug
+    causes _DiamondMid's verification to fail.
+    """
+    bloq = _DiamondTopBloq()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='diamond')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+
+    # Find _DiamondMid result — it should fail.
+    mid_results = [r for r in results if r.bloq.__class__.__name__ == '_DiamondMid']
+    assert len(mid_results) == 1, "BFS should discover _DiamondMid"
+    assert (
+        mid_results[0].status == VerificationStatus.FAILED
+    ), "Buggy deep child should cause mid-level bloq to fail."
+    assert mid_results[0].error_message is not None
+    assert 'Mismatch' in mid_results[0].error_message
+
+
+def test_verify_diamond_dag_discovers_all_nodes():
+    """BFS traversal of diamond DAG discovers all unique bloq classes."""
+    bloq = _DiamondTopBloq()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='diamond')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    classes = {r.bloq.__class__.__name__ for r in results}
+    assert '_DiamondTopBloq' in classes
+    assert '_DiamondMid' in classes
+    assert '_AtomicNot' in classes
+    assert '_AtomicBuggyIdentity' in classes
+
+
+def test_verify_diamond_mid_deduplication():
+    """Two instances of _DiamondMid (from x and y paths) should
+    be deduplicated — verified only once."""
+    bloq = _DiamondTopBloq()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='diamond')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    mid_results = [r for r in results if r.bloq.__class__.__name__ == '_DiamondMid']
+    assert len(mid_results) == 1, "Identical _DiamondMid instances should be deduplicated."
+
+
+def test_verify_3_level_deep_bug_discovered():
+    """3-level decomposition with a buggy leaf at the bottom.
+
+    _Level2Top → _Level1Mid → _AtomicNot + _AtomicBuggyIdentity.
+    BFS must discover all 3+ levels and detect that _Level1Mid
+    fails due to the buggy leaf.
+    """
+    bloq = _Level2Top()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='deep')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+
+    # Discover all levels.
+    classes = {r.bloq.__class__.__name__ for r in results}
+    assert '_Level2Top' in classes
+    assert '_Level1Mid' in classes
+    assert '_AtomicNot' in classes
+    assert '_AtomicBuggyIdentity' in classes
+
+    # _Level1Mid should fail due to the buggy leaf.
+    mid_results = [r for r in results if r.bloq.__class__.__name__ == '_Level1Mid']
+    assert len(mid_results) == 1
+    assert mid_results[0].status == VerificationStatus.FAILED
+    assert mid_results[0].error_message is not None
+    assert 'Mismatch' in mid_results[0].error_message
+
+
+def test_verify_n_inputs_checked_for_qbit():
+    """For a QBit bloq with exhaustive enumeration, n_inputs_checked
+    should be exactly 2 (for inputs 0 and 1)."""
+    bloq = _Level2Top()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='deep')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+
+    top = [r for r in results if r.bloq.__class__.__name__ == '_Level2Top'][0]
+    assert top.n_inputs_checked == 2
+
+
+def test_verify_all_raising_reports_no_valid_inputs():
+    """A bloq whose on_classical_vals raises on ALL inputs gets
+    status 'no_valid_inputs' with n_inputs_checked=0.
+
+    The verifier must NOT report 'passed' when nothing was actually
+    verified. Instead it reports 'no_valid_inputs' to flag that the
+    verification was inconclusive.
+    """
+    bloq = _AllRaisingBloq()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='all_raising')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    root = results[0]
+    assert (
+        root.status == VerificationStatus.NO_VALID_INPUTS
+    ), "All inputs raised — should be 'no_valid_inputs', not 'passed'."
+    assert root.n_inputs_checked == 0, "All inputs raised — none should be counted as checked."
+    assert root.error_message is not None
+    assert 'raised on all inputs' in root.error_message
+
+
+def test_verify_multi_level_status_propagation():
+    """Full pipeline with 3-level hierarchy checks status propagation."""
+    bloq = _Level2Top()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='multi_level')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+
+    statuses = {r.bloq.__class__.__name__: r.status for r in results}
+    # Level2Top should pass (identity matches).
+    assert statuses['_Level2Top'] == VerificationStatus.PASSED
+    # Level1Mid should fail (buggy leaf corrupts decomposition).
+    assert statuses['_Level1Mid'] == VerificationStatus.FAILED
+    # Atomic leaf bloqs that raise DecomposeTypeError but are NOT in the ISA
+    # get 'missing_decomposition' — they are custom test bloqs, not standard
+    # Qualtran gates.
+    assert statuses['_AtomicNot'] == VerificationStatus.MISSING_DECOMPOSITION
+    assert statuses['_AtomicBuggyIdentity'] == VerificationStatus.MISSING_DECOMPOSITION
+
+
+def test_verify_constrained_inputs_log():
+    """Domain-constrained bloq produces valid log output."""
+    bloq = _DomainConstrainedBloq(n=4)
+    cases = [ClassicalSimTestCase(bloq=bloq, name='constrained')]
+    log = io.StringIO()
+    verify_structural_induction(cases, n_samples=100, log=log)
+
+    log_text = log.getvalue()
+    assert len(log_text) > 0
+    tab_lines = [l for l in log_text.split('\n') if '\t' in l]
+    assert len(tab_lines) > 0
+
+
+def test_verify_bfs_discovers_all_descendants():
+    """BFS discovers bloqs at all levels of the decomposition tree."""
+    cases = [ClassicalSimTestCase(bloq=_ParentBloq(), name='parent')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    classes = {r.bloq.__class__.__name__ for r in results}
+    assert '_ParentBloq' in classes
+    assert '_DoubleNot' in classes
+    assert 'XGate' in classes
+
+
+def test_verify_default_rng_is_deterministic():
+    """Without explicit rng, results are reproducible."""
+    cases = [ClassicalSimTestCase(bloq=_DoubleNot(), name='dn')]
+    r1 = verify_structural_induction(cases, n_samples=10, log=None)
+    r2 = verify_structural_induction(cases, n_samples=10, log=None)
+    assert len(r1) == len(r2)
+    for a, b in zip(r1, r2):
+        assert a.status == b.status
+        assert a.n_inputs_checked == b.n_inputs_checked
+
+
+def test_verify_log_is_none():
+    """Passing log=None suppresses output without errors."""
+    cases = [ClassicalSimTestCase(bloq=_DoubleNot(), name='dn')]
+    results = verify_structural_induction(cases, n_samples=10, log=None)
+    assert len(results) > 0
+
+
+def test_verify_log_format_tab_separated():
+    """Log output is tab-separated with 4 columns per line."""
+    cases = [ClassicalSimTestCase(bloq=_DoubleNot(), name='dn')]
+    log = io.StringIO()
+    verify_structural_induction(cases, n_samples=10, log=log)
+    log_text = log.getvalue()
+    for line in log_text.rstrip('\n').split('\n'):
+        fields = line.split('\t')
+        assert len(fields) == 4, f"Expected 4 tab-separated fields, got {len(fields)}: {line!r}"
+
+
+def test_verify_log_no_non_ascii():
+    """Log output contains no non-ASCII characters."""
+    cases = [ClassicalSimTestCase(bloq=_DoubleNot(), name='dn')]
+    log = io.StringIO()
+    verify_structural_induction(cases, n_samples=10, log=log)
+    log_text = log.getvalue()
+    for char in log_text:
+        assert ord(char) < 128, f"Non-ASCII character in log: {char!r} (U+{ord(char):04X})"
+
+
+def test_verify_log_contains_objectstring():
+    """Log uses dump_objectstring for bloq identification."""
+    cases = [ClassicalSimTestCase(bloq=_DoubleNot(), name='dn')]
+    log = io.StringIO()
+    verify_structural_induction(cases, n_samples=10, log=log)
+    assert '_DoubleNot' in log.getvalue()
+
+
+# ===========================================================================
+# Tests: VerificationResult (attrs frozen)
+# ===========================================================================
+
+
+def test_verification_result_is_frozen():
+    r = VerificationResult(bloq=_IdentityBloq(), status=VerificationStatus.PASSED)
+    with pytest.raises(attrs.exceptions.FrozenInstanceError):
+        r.status = VerificationStatus.FAILED  # type: ignore[misc]
+
+
+def test_verification_result_defaults():
+    r = VerificationResult(bloq=_IdentityBloq(), status=VerificationStatus.PASSED)
+    assert r.n_inputs_checked == 0
+    assert r.error_message is None
+    assert r.children == ()
+
+
+def test_verification_result_children_is_tuple():
+    r = VerificationResult(
+        bloq=_IdentityBloq(), status=VerificationStatus.PASSED, children=(_IdentityBloq(),)
+    )
+    assert isinstance(r.children, tuple)
+
+
+# ===========================================================================
+# Tests: ClassicalSimTestCase (attrs frozen)
+# ===========================================================================
+
+
+def test_classical_sim_test_case_is_frozen():
+    tc = ClassicalSimTestCase(bloq=_IdentityBloq(), name='test')
+    with pytest.raises(attrs.exceptions.FrozenInstanceError):
+        tc.name = 'other'  # type: ignore[misc]
+
+
+# ===========================================================================
+# Tests: print_verification_summary
+# ===========================================================================
+
+
+def _make_tree_results() -> list[VerificationResult]:
+    """Build a small result set with known structure.
+
+    Structure:
+        _ParentBloq (passed)
+          └─ _DoubleNot (passed)
+               └─ XGate (leaf_verified)
+    """
+    xgate = XGate()
+    double_not = _DoubleNot()
+    parent = _ParentBloq()
+    return [
+        VerificationResult(
+            bloq=parent,
+            status=VerificationStatus.PASSED,
+            n_inputs_checked=4,
+            children=(double_not,),
+        ),
+        VerificationResult(
+            bloq=double_not, status=VerificationStatus.PASSED, n_inputs_checked=2, children=(xgate,)
+        ),
+        VerificationResult(bloq=xgate, status=VerificationStatus.LEAF_VERIFIED, n_inputs_checked=2),
+    ]
+
+
+def test_summary_contains_header():
+    results = _make_tree_results()
+    buf = io.StringIO()
+    print_verification_summary(results, file=buf)
+    assert 'VERIFICATION SUMMARY' in buf.getvalue()
+
+
+def test_summary_uses_class_names():
+    results = _make_tree_results()
+    buf = io.StringIO()
+    print_verification_summary(results, file=buf)
+    text = buf.getvalue()
+    assert '_ParentBloq' in text
+    assert '_DoubleNot' in text
+    assert 'XGate' in text
+
+
+def test_summary_tree_indentation():
+    """Child nodes are indented further than their parents."""
+    results = _make_tree_results()
+    buf = io.StringIO()
+    print_verification_summary(results, file=buf)
+    lines = buf.getvalue().split('\n')
+    parent_line = [l for l in lines if '_ParentBloq' in l][0]
+    child_line = [l for l in lines if '_DoubleNot' in l][0]
+    # The child's class name should start at a greater column offset.
+    assert child_line.index('_DoubleNot') > parent_line.index('_ParentBloq')
+
+
+def test_summary_dag_deduplication_see_above():
+    """When the same class appears under multiple parents, subsequent
+    appearances show '(ClassName) [icon see above]'."""
+    xgate = XGate()
+    dn = _DoubleNot()
+    parent = _ParentBloq()
+
+    @attrs.frozen
+    class _AnotherParent(Bloq):
+        @cached_property
+        def signature(self):
+            return Signature([Register('q', QBit())])
+
+        def on_classical_vals(self, q):
+            return {'q': q}
+
+    another = _AnotherParent()
+
+    results = [
+        VerificationResult(
+            bloq=parent, status=VerificationStatus.PASSED, n_inputs_checked=4, children=(dn,)
+        ),
+        VerificationResult(
+            bloq=another, status=VerificationStatus.PASSED, n_inputs_checked=2, children=(dn,)
+        ),
+        VerificationResult(
+            bloq=dn, status=VerificationStatus.PASSED, n_inputs_checked=2, children=(xgate,)
+        ),
+        VerificationResult(bloq=xgate, status=VerificationStatus.LEAF_VERIFIED, n_inputs_checked=2),
+    ]
+
+    buf = io.StringIO()
+    print_verification_summary(results, file=buf)
+    text = buf.getvalue()
+    assert 'see above' in text
+    assert '(_DoubleNot)' in text
+
+
+def test_summary_omits_leaf_verified_already_printed():
+    """Leaf-verified nodes that have already been printed are completely
+    omitted from subsequent tree appearances (no 'see above' line).
+
+    Non-leaf-verified nodes still show the '(ClassName) [see above]'
+    back-reference when they appear under multiple parents.
+    """
+    xgate = XGate()
+
+    @attrs.frozen
+    class _Parent1(Bloq):
+        @cached_property
+        def signature(self):
+            return Signature([Register('q', QBit())])
+
+        def on_classical_vals(self, q):
+            return {'q': q}
+
+    @attrs.frozen
+    class _Parent2(Bloq):
+        @cached_property
+        def signature(self):
+            return Signature([Register('q', QBit())])
+
+        def on_classical_vals(self, q):
+            return {'q': q}
+
+    p1 = _Parent1()
+    p2 = _Parent2()
+
+    results = [
+        VerificationResult(
+            bloq=p1, status=VerificationStatus.PASSED, n_inputs_checked=2, children=(xgate,)
+        ),
+        VerificationResult(
+            bloq=p2, status=VerificationStatus.PASSED, n_inputs_checked=2, children=(xgate,)
+        ),
+        VerificationResult(bloq=xgate, status=VerificationStatus.LEAF_VERIFIED, n_inputs_checked=2),
+    ]
+
+    buf = io.StringIO()
+    print_verification_summary(results, file=buf)
+    text = buf.getvalue()
+
+    # XGate is leaf_verified: it should appear exactly once (under _Parent1)
+    # and be completely omitted under _Parent2 — no '(XGate)' back-reference.
+    xgate_lines = [l for l in text.split('\n') if 'XGate' in l]
+    assert (
+        len(xgate_lines) == 1
+    ), f"Expected XGate to appear exactly once, got {len(xgate_lines)}: {xgate_lines}"
+    assert (
+        '(XGate)' not in text
+    ), "Leaf-verified XGate should be omitted, not shown as '(XGate) [see above]'"
+
+
+def test_summary_status_totals():
+    """Footer contains correct status counts."""
+    results = _make_tree_results()
+    buf = io.StringIO()
+    print_verification_summary(results, file=buf)
+    text = buf.getvalue()
+    assert 'Total: 3' in text
+    assert 'passed: 2' in text
+    assert 'leaf_verified: 1' in text
+
+
+def test_summary_class_name_deduplication():
+    """Multiple results for the same class merge into one tree node."""
+    xgate = XGate()
+    dn = _DoubleNot()
+
+    results = [
+        VerificationResult(
+            bloq=dn, status=VerificationStatus.PASSED, n_inputs_checked=2, children=(xgate,)
+        ),
+        VerificationResult(bloq=xgate, status=VerificationStatus.LEAF_VERIFIED, n_inputs_checked=2),
+    ]
+
+    buf = io.StringIO()
+    print_verification_summary(results, file=buf)
+    text = buf.getvalue()
+
+    # Filter to tree body lines (exclude header/footer/totals).
+    tree_lines = [
+        l
+        for l in text.split('\n')
+        if l.strip()
+        and not l.startswith('=')
+        and not l.startswith('-')
+        and 'Total' not in l
+        and 'SUMMARY' not in l
+    ]
+    dn_lines = [l for l in tree_lines if '_DoubleNot' in l]
+    xgate_lines = [l for l in tree_lines if 'XGate' in l]
+    assert len(dn_lines) == 1
+    assert len(xgate_lines) == 1
+
+
+def test_summary_worst_status_propagation():
+    """When merging by class name, the worst status wins."""
+    dn1 = _DoubleNot()
+    dn2 = _DoubleNot()
+
+    results = [
+        VerificationResult(bloq=dn1, status=VerificationStatus.PASSED, n_inputs_checked=2),
+        VerificationResult(
+            bloq=dn2,
+            status=VerificationStatus.ERROR,
+            n_inputs_checked=0,
+            error_message='something broke',
+        ),
+    ]
+
+    buf = io.StringIO()
+    print_verification_summary(results, file=buf)
+    text = buf.getvalue()
+    # The merged node should show the worse status.
+    assert '[error]' in text
+
+
+def test_summary_empty_results():
+    """Printing with no results does not crash."""
+    buf = io.StringIO()
+    print_verification_summary([], file=buf)
+    assert 'Total: 0' in buf.getvalue()
+
+
+def test_summary_root_identification():
+    """Bloqs not appearing as children of others are displayed as roots."""
+    dn = _DoubleNot()
+    xgate = XGate()
+
+    results = [
+        VerificationResult(
+            bloq=dn, status=VerificationStatus.PASSED, n_inputs_checked=2, children=(xgate,)
+        ),
+        VerificationResult(bloq=xgate, status=VerificationStatus.LEAF_VERIFIED, n_inputs_checked=2),
+    ]
+
+    buf = io.StringIO()
+    print_verification_summary(results, file=buf)
+    lines = buf.getvalue().split('\n')
+
+    # _DoubleNot is a root: no tree connector before its name.
+    dn_line = [l for l in lines if '_DoubleNot' in l][0]
+    prefix = dn_line.split('_DoubleNot')[0]
+    assert '├' not in prefix
+    assert '└' not in prefix
+
+    # XGate is a child: has a tree connector.
+    xgate_line = [l for l in lines if 'XGate' in l][0]
+    prefix = xgate_line.split('XGate')[0]
+    assert '└' in prefix or '├' in prefix
+
+
+def test_summary_inputs_aggregated():
+    """n_inputs_checked is summed across results of the same class."""
+    dn1 = _DoubleNot()
+    dn2 = _DoubleNot()
+
+    results = [
+        VerificationResult(bloq=dn1, status=VerificationStatus.PASSED, n_inputs_checked=10),
+        VerificationResult(bloq=dn2, status=VerificationStatus.PASSED, n_inputs_checked=15),
+    ]
+
+    buf = io.StringIO()
+    print_verification_summary(results, file=buf)
+    text = buf.getvalue()
+    # Total should be 10 + 15 = 25.
+    assert '(25 inputs)' in text
+
+
+# ===========================================================================
+# Integration test
+# ===========================================================================
+
+
+def test_end_to_end_with_add():
+    """Full pipeline with a real Qualtran bloq (Add)."""
+    from qualtran.bloqs.arithmetic import Add
+
+    add = Add(QUInt(3))
+    cases = [ClassicalSimTestCase(bloq=add, name='add_3bit')]
+    log = io.StringIO()
+    results = verify_structural_induction(
+        cases, n_samples=20, rng=np.random.default_rng(0), log=log
+    )
+
+    # Should have at least the root + some children.
+    assert len(results) >= 1
+
+    # Root should be Add.
+    root = results[0]
+    assert root.bloq.__class__.__name__ == 'Add'
+    assert root.status in (VerificationStatus.PASSED, VerificationStatus.MISSING_CLASSICAL_VALS)
+
+    # Log should be parseable.
+    log_text = log.getvalue()
+    assert len(log_text) > 0
+    for line in log_text.rstrip('\n').split('\n'):
+        assert len(line.split('\t')) == 4
+
+    # Summary should not crash.
+    buf = io.StringIO()
+    print_verification_summary(results, file=buf)
+    summary = buf.getvalue()
+    assert 'VERIFICATION SUMMARY' in summary
+    assert 'Add' in summary
+
+
+# ===========================================================================
+# Tests: broad-except hardening
+# ===========================================================================
+# These tests verify that genuine bugs (TypeError, KeyError, etc.) in
+# on_classical_vals are NOT silently swallowed as "domain-constrained"
+# inputs. Before the fix, these would have been silently skipped.
+
+
+def test_verify_typeerror_in_on_classical_vals_not_swallowed():
+    """A TypeError in on_classical_vals is a real bug, not a domain constraint.
+
+    Before the fix, `except Exception` would skip this input silently.
+    If ALL inputs raise TypeError, the old code would report NO_VALID_INPUTS
+    (misleading). The narrowed catch should let TypeError propagate as ERROR.
+    """
+    bloq = _TypeErrorInOnClassicalVals()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='type_error_bug')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    root = results[0]
+    # Must NOT be PASSED or NO_VALID_INPUTS — those would mean the TypeError
+    # was silently swallowed.
+    assert root.status == VerificationStatus.ERROR, (
+        f"Expected ERROR for TypeError bug, got {root.status}. "
+        f"The broad 'except Exception' would have hidden this."
+    )
+    assert root.error_message is not None
+    assert 'TypeError' in root.error_message
+
+
+def test_verify_keyerror_in_on_classical_vals_not_swallowed():
+    """A KeyError in on_classical_vals is a real bug, not a domain constraint.
+
+    Before the fix, `except Exception` would skip this input silently.
+    """
+    bloq = _KeyErrorInOnClassicalVals()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='key_error_bug')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    root = results[0]
+    assert root.status == VerificationStatus.ERROR, (
+        f"Expected ERROR for KeyError bug, got {root.status}. "
+        f"The broad 'except Exception' would have hidden this."
+    )
+    assert root.error_message is not None
+    assert 'KeyError' in root.error_message
+
+
+def test_verify_typeerror_leaf_not_silently_verified():
+    """A leaf sub-bloq with a TypeError bug must cause its parent to ERROR.
+
+    _ParentOfBuggyLeaf decomposes into _TypeErrorLeafBloq, whose
+    on_classical_vals raises TypeError. When the verifier runs
+    simulate_via_subbloq_classical_vals on the parent, this TypeError propagates.
+
+    Before the fix, the broad `except Exception` on the inner loop would
+    have caught the TypeError and silently skipped the input, potentially
+    reporting PASSED or NO_VALID_INPUTS instead of ERROR.
+    """
+    bloq = _ParentOfBuggyLeaf()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='buggy_leaf_parent')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+
+    parent = [r for r in results if r.bloq.__class__.__name__ == '_ParentOfBuggyLeaf']
+    assert len(parent) == 1
+    assert parent[0].status == VerificationStatus.ERROR, (
+        f"Expected ERROR for TypeError in leaf sub-bloq, got {parent[0].status}. "
+        f"The broad 'except Exception' would have hidden this."
+    )
+    assert parent[0].error_message is not None
+    assert 'TypeError' in parent[0].error_message
+
+
+def test_verify_domain_constraint_error_skipped():
+    """QCDTypeDomainError in on_classical_vals is the canonical way to
+    signal that an input is outside the bloq's valid domain.
+
+    The verifier must skip these inputs gracefully.
+    """
+    bloq = _DomainConstrainedBloq(n=4)
+    cases = [ClassicalSimTestCase(bloq=bloq, name='constrained')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=100, log=log)
+    root = results[0]
+    assert root.status == VerificationStatus.PASSED
+    assert root.n_inputs_checked == 8  # only even values 0-14
+
+
+def test_verify_bare_valueerror_is_not_a_domain_constraint():
+    """Bare ValueError in on_classical_vals is NOT treated as a domain constraint.
+
+    Bloqs must use QCDTypeDomainError for domain validation. A bare ValueError
+    is treated as a real bug and reported as ERROR.
+    """
+
+    @attrs.frozen
+    class _BareValueErrorBloq(Bloq):
+        @cached_property
+        def signature(self):
+            return Signature([Register('q', QBit())])
+
+        def on_classical_vals(self, q):
+            if q == 1:
+                raise ValueError("Not using QCDTypeDomainError")
+            return {'q': q}
+
+        def build_composite_bloq(self, bb: BloqBuilder, q: SoquetT) -> dict[str, SoquetT]:
+            return {'q': q}
+
+    bloq = _BareValueErrorBloq()
+    cases = [ClassicalSimTestCase(bloq=bloq, name='bare_valueerror')]
+    log = io.StringIO()
+    results = verify_structural_induction(cases, n_samples=10, log=log)
+    root = results[0]
+    # Bare ValueError must NOT be silently swallowed — it's a bug.
+    assert root.status == VerificationStatus.ERROR, (
+        f"Expected ERROR for bare ValueError, got {root.status}. "
+        f"Bloqs must use QCDTypeDomainError for domain constraints."
+    )
+
+
+def test_domain_constraint_error_is_a_valueerror():
+    """QCDTypeDomainError subclasses ValueError for backward compatibility."""
+    err = QCDTypeDomainError("test")
+    assert isinstance(err, ValueError)
+    assert isinstance(err, QCDTypeDomainError)
+
+
+def test_should_use_fastsim_env_var(monkeypatch):
+    """Explicitly test _should_use_fastsim evaluation logic across QLT_USE_FASTSIM options."""
+    # Test forcing disable via environment
+    for false_str in ('0', 'false', 'no', 'off', 'FALSE', ' 0 '):
+        monkeypatch.setenv('QLT_USE_FASTSIM', false_str)
+        assert _should_use_fastsim() is False
+
+    # Test forcing enable via environment
+    for true_str in ('1', 'true', 'yes', 'on', 'TRUE', ' 1 '):
+        monkeypatch.setenv('QLT_USE_FASTSIM', true_str)
+        try:
+            assert _should_use_fastsim() is True
+        except ImportError:
+            pass
+
+    # Test invalid boolean environment string
+    monkeypatch.setenv('QLT_USE_FASTSIM', 'not_a_bool')
+    with pytest.raises(ValueError, match="Invalid value for QLT_USE_FASTSIM"):
+        _should_use_fastsim()
+
+    # Test unset variable falls back to testing import rsqualtran
+    monkeypatch.delenv('QLT_USE_FASTSIM', raising=False)
+    try:
+        import rsqualtran  # noqa: F401
+        assert _should_use_fastsim() is True
+    except ImportError:
+        assert _should_use_fastsim() is False
+
+
+@pytest.mark.parametrize('qlt_use_fastsim', ['0', '1'], indirect=True)
+def test_verify_structural_induction_engine_code_paths(qlt_use_fastsim, capsys):
+    """Explicitly verify structural induction under both Python (0) and Rust fastsim (1) engines.
+
+    Ensures that real arithmetic bloqs execute and produce PASSED verification results
+    under both exact simulation code paths (`simulate_via_subbloq_classical_vals` vs
+    `QLTFastsim.call_classically`), and verifying that the active engine style is reported to stderr.
+    """
+    if qlt_use_fastsim == '1':
+        try:
+            import rsqualtran  # noqa: F401
+        except ImportError:
+            pytest.skip("rsqualtran (`QLTFastsim`) is not installed in this environment.")
+
+    from qualtran.bloqs.arithmetic.bitwise import Xor
+
+    bloq = Xor(QUInt(3))
+    cases = [ClassicalSimTestCase(bloq=bloq, name='xor_test')]
+    log = io.StringIO()
+
+    results = verify_structural_induction(cases, n_samples=20, log=log)
+    assert results[0].status == VerificationStatus.PASSED
+
+    captured = capsys.readouterr()
+    expected_style = (
+        "QLTFastsim (Rust)" if qlt_use_fastsim == '1' else "Python (simulate_via_subbloq_classical_vals)"
+    )
+    assert f"[verify_structural_induction] Simulation style: {expected_style}" in captured.err


### PR DESCRIPTION
Adds a structural induction verification framework to verify that a bloq's quantum decomposition (`decompose_bloq`) is functionally equivalent to its declared classical behavior (`on_classical_vals`).

- Verifies circuits hierarchically by cross-checking each parent bloq against its immediate children.
- Strict Simulation: Prevents tautological passes by ensuring sub-bloq simulations only use explicit, hand-written `on_classical_vals` implementations.
- Automatic input generation from `QDType` domains, support for both Python and Rust (`rsqualtran`) simulation backends, and a `do-classical-verification` driver script.

on_classical_vals authors should raise the new specific `QCDTypeDomainError` to signal the specific error case of "while this is a valid classical val for the QCDType, it's not an appropriate input for this bloq." for example in uncomputation bloqs. 

---

As a simple initial example, tests are included for `Negate` and its callees.
