### PR TITLE
Adjoint, Controlled, And __str__

### DIFF
--- a/qualtran/_infra/adjoint.py
+++ b/qualtran/_infra/adjoint.py
@@ -179,8 +179,7 @@ class Adjoint(GateWithRegisters):
         return counts
 
     def __str__(self) -> str:
-        """Delegate to subbloq's `__str__` method."""
-        return f'{str(self.subbloq)}†'
+        return f'Adj({self.subbloq!s})'
 
     @classmethod
     def _pkg_(cls) -> str:

--- a/qualtran/_infra/adjoint_test.py
+++ b/qualtran/_infra/adjoint_test.py
@@ -28,9 +28,7 @@ from qualtran.drawing import LarrowTextBox, RarrowTextBox, Text
 
 def test_serial_combo_adjoint():
     # The normal decomposition is three `TestAtom` tagged atom{0,1,2}.
-    assert (
-        TestSerialCombo().decompose_bloq().debug_text()
-        == """\
+    assert TestSerialCombo().decompose_bloq().debug_text() == """\
 TestAtom('atom0')<0>
   LeftDangle.reg -> q
   q -> TestAtom('atom1')<1>.q
@@ -42,24 +40,20 @@ TestAtom('atom1')<1>
 TestAtom('atom2')<2>
   TestAtom('atom1')<1>.q -> q
   q -> RightDangle.reg"""
-    )
 
     # The adjoint reverses the order to atom{2,1,0} and wraps each in `Adjoint`.
-    assert (
-        TestSerialCombo().adjoint().decompose_bloq().debug_text()
-        == """\
-TestAtom('atom2')†<0>
+    assert TestSerialCombo().adjoint().decompose_bloq().debug_text() == """\
+Adj(TestAtom('atom2'))<0>
   LeftDangle.reg -> q
-  q -> TestAtom('atom1')†<1>.q
+  q -> Adj(TestAtom('atom1'))<1>.q
 --------------------
-TestAtom('atom1')†<1>
-  TestAtom('atom2')†<0>.q -> q
-  q -> TestAtom('atom0')†<2>.q
+Adj(TestAtom('atom1'))<1>
+  Adj(TestAtom('atom2'))<0>.q -> q
+  q -> Adj(TestAtom('atom0'))<2>.q
 --------------------
-TestAtom('atom0')†<2>
-  TestAtom('atom1')†<1>.q -> q
+Adj(TestAtom('atom0'))<2>
+  Adj(TestAtom('atom1'))<1>.q -> q
   q -> RightDangle.reg"""
-    )
 
 
 def test_cbloq_adjoint_function():
@@ -69,21 +63,18 @@ def test_cbloq_adjoint_function():
     assert isinstance(adj_cbloq, CompositeBloq)
     qlt_testing.assert_valid_cbloq(adj_cbloq)
 
-    assert (
-        adj_cbloq.debug_text()
-        == """\
-TestAtom('atom2')†<0>
+    assert adj_cbloq.debug_text() == """\
+Adj(TestAtom('atom2'))<0>
   LeftDangle.reg -> q
-  q -> TestAtom('atom1')†<1>.q
+  q -> Adj(TestAtom('atom1'))<1>.q
 --------------------
-TestAtom('atom1')†<1>
-  TestAtom('atom2')†<0>.q -> q
-  q -> TestAtom('atom0')†<2>.q
+Adj(TestAtom('atom1'))<1>
+  Adj(TestAtom('atom2'))<0>.q -> q
+  q -> Adj(TestAtom('atom0'))<2>.q
 --------------------
-TestAtom('atom0')†<2>
-  TestAtom('atom1')†<1>.q -> q
+Adj(TestAtom('atom0'))<2>
+  Adj(TestAtom('atom1'))<1>.q -> q
   q -> RightDangle.reg"""
-    )
 
 
 def test_adjoint_signature():
@@ -139,7 +130,7 @@ def test_names():
     assert cast(Text, atom.wire_symbol(reg=None)).text == "TestAtom"
 
     adj_atom = Adjoint(atom)
-    assert str(adj_atom) == "TestAtom†"
+    assert str(adj_atom) == "Adj(TestAtom)"
     assert cast(Text, adj_atom.wire_symbol(reg=None)).text == "TestAtom†"
 
 

--- a/qualtran/_infra/controlled.py
+++ b/qualtran/_infra/controlled.py
@@ -549,9 +549,7 @@ class _ControlledBase(GateWithRegisters, metaclass=abc.ABCMeta):
         return self.ctrl_spec.wire_symbol(i, reg, idx)
 
     def __str__(self) -> str:
-        num_ctrls = self.ctrl_spec.num_bits
-        ctrl_string = 'C' if num_ctrls == 1 else f'C[{num_ctrls}]'
-        return f'{ctrl_string}[{self.subbloq}]'
+        return f'C({self.subbloq!s})'
 
     def as_cirq_op(
         self, qubit_manager: 'cirq.QubitManager', **cirq_quregs: 'CirqQuregT'

--- a/qualtran/_infra/controlled_test.py
+++ b/qualtran/_infra/controlled_test.py
@@ -237,21 +237,21 @@ def test_controlled_serial():
     bloq = Controlled(subbloq=TestSerialCombo(), ctrl_spec=CtrlSpec())
     cbloq = qlt_testing.assert_valid_bloq_decomposition(bloq)
     assert cbloq.debug_text() == """\
-C[TestAtom('atom0')]<0>
+C(TestAtom('atom0'))<0>
   LeftDangle.ctrl -> ctrl
   LeftDangle.reg -> q
-  ctrl -> C[TestAtom('atom1')]<1>.ctrl
-  q -> C[TestAtom('atom1')]<1>.q
+  ctrl -> C(TestAtom('atom1'))<1>.ctrl
+  q -> C(TestAtom('atom1'))<1>.q
 --------------------
-C[TestAtom('atom1')]<1>
-  C[TestAtom('atom0')]<0>.ctrl -> ctrl
-  C[TestAtom('atom0')]<0>.q -> q
-  ctrl -> C[TestAtom('atom2')]<2>.ctrl
-  q -> C[TestAtom('atom2')]<2>.q
+C(TestAtom('atom1'))<1>
+  C(TestAtom('atom0'))<0>.ctrl -> ctrl
+  C(TestAtom('atom0'))<0>.q -> q
+  ctrl -> C(TestAtom('atom2'))<2>.ctrl
+  q -> C(TestAtom('atom2'))<2>.q
 --------------------
-C[TestAtom('atom2')]<2>
-  C[TestAtom('atom1')]<1>.ctrl -> ctrl
-  C[TestAtom('atom1')]<1>.q -> q
+C(TestAtom('atom2'))<2>
+  C(TestAtom('atom1'))<1>.ctrl -> ctrl
+  C(TestAtom('atom1'))<1>.q -> q
   ctrl -> RightDangle.ctrl
   q -> RightDangle.reg"""
 
@@ -262,39 +262,39 @@ def test_controlled_parallel():
     assert cbloq.debug_text() == """\
 Split<0>
   LeftDangle.reg -> reg
-  reg[0] -> C[TestAtom]<1>.q
-  reg[1] -> C[TestAtom]<2>.q
-  reg[2] -> C[TestAtom]<3>.q
+  reg[0] -> C(TestAtom)<1>.q
+  reg[1] -> C(TestAtom)<2>.q
+  reg[2] -> C(TestAtom)<3>.q
 --------------------
-C[TestAtom]<1>
+C(TestAtom)<1>
   LeftDangle.ctrl -> ctrl
   Split<0>.reg[0] -> q
-  ctrl -> C[TestAtom]<2>.ctrl
+  ctrl -> C(TestAtom)<2>.ctrl
   q -> Join<4>.reg[0]
 --------------------
-C[TestAtom]<2>
-  C[TestAtom]<1>.ctrl -> ctrl
+C(TestAtom)<2>
+  C(TestAtom)<1>.ctrl -> ctrl
   Split<0>.reg[1] -> q
-  ctrl -> C[TestAtom]<3>.ctrl
+  ctrl -> C(TestAtom)<3>.ctrl
   q -> Join<4>.reg[1]
 --------------------
-C[TestAtom]<3>
-  C[TestAtom]<2>.ctrl -> ctrl
+C(TestAtom)<3>
+  C(TestAtom)<2>.ctrl -> ctrl
   Split<0>.reg[2] -> q
   q -> Join<4>.reg[2]
   ctrl -> RightDangle.ctrl
 --------------------
 Join<4>
-  C[TestAtom]<1>.q -> reg[0]
-  C[TestAtom]<2>.q -> reg[1]
-  C[TestAtom]<3>.q -> reg[2]
+  C(TestAtom)<1>.q -> reg[0]
+  C(TestAtom)<2>.q -> reg[1]
+  C(TestAtom)<3>.q -> reg[2]
   reg -> RightDangle.reg"""
 
 
 def test_doubly_controlled():
     bloq = Controlled(Controlled(TestAtom(), ctrl_spec=CtrlSpec()), ctrl_spec=CtrlSpec())
     assert bloq.as_composite_bloq().debug_text() == """\
-C[C[TestAtom]]<0>
+C(C(TestAtom))<0>
   LeftDangle.ctrl2 -> ctrl2
   LeftDangle.ctrl -> ctrl
   LeftDangle.q -> q

--- a/qualtran/bloqs/mcmt/and_bloq.py
+++ b/qualtran/bloqs/mcmt/and_bloq.py
@@ -186,8 +186,9 @@ class And(GateWithRegisters):
         return Circle(filled)
 
     def __str__(self):
-        dag = '†' if self.uncompute else ''
-        return f'And{dag}'
+        cvs = '' if (self.cv1, self.cv2) == (1, 1) else f'{self.cv1}{self.cv2}'
+        suffix = '_adj' if self.uncompute else ''
+        return f'And{cvs}{suffix}'
 
     def decompose_from_registers(
         self,

--- a/qualtran/drawing/flame_graph_test.py
+++ b/qualtran/drawing/flame_graph_test.py
@@ -96,7 +96,7 @@ def test_get_flame_graph_data_prep_uniform():
             'PrepareUniformSuperposition[12][0](T:124);LessThanConstant[2][3](T:8);And(T:4)\t4',
             'PrepareUniformSuperposition[12][0](T:124);Rz(1.2309594173407745)(T:52)\t52',
             'PrepareUniformSuperposition[12][0](T:124);Rz(1.2309594173407745)(T:52)\t52',
-            'PrepareUniformSuperposition[12][0](T:124);And(T:4)\t4',
+            'PrepareUniformSuperposition[12][0](T:124);And00(T:4)\t4',
         ]
     )
     assert len(data) == len(should_be)


### PR DESCRIPTION
stick to a more consistent format for bloq __str__. This needs to strike a balance between disambiguating the particular bloq object, being concise, and being useful as a bloq_key for the *.qlt ir. This PR removes special characters from Adjoint, Controlled, and And