### PR TITLE
Update nightly CI workflow to use Ubuntu 24 instead of 22

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -44,10 +44,12 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --frozen --no-dev --group test
+        run: |
+          uv sync --frozen --no-dev --group test
+          uv pip install pytest-instafail
 
       - name: Run the full Pytest suite
         env:
           # Adding xtrace makes Bash commands & scripts run with "-x".
           SHELLOPTS: ${{runner.debug && 'xtrace'}}
-        run: uv run --no-sync check/pytest-full --durations 10 -v
+        run: uv run --no-sync check/pytest-full --instafail --durations 10 -v

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -39,7 +39,7 @@ env:
 
 jobs:
   pytest:
-    runs-on: ubuntu-22.04-x64-8-core
+    runs-on: ubuntu-24.04-x64-8-core
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -31,15 +31,15 @@ jobs:
     runs-on: ubuntu-24.04-x64-8-core
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: ts-graphviz/setup-graphviz@c001ccfb5aff62e28bda6a6c39b59a7e061be5b9 # v1
+      - uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c # v2.0.2
 
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -57,18 +57,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --no-dev --group test
 
-      - name: Continuously monitor memory and disk space during execution
-        run: |
-          while true; do
-            printf '%0.s-' {1..80}
-            free -h
-            echo
-            df -h .
-            printf '%0.s-' {1..80}
-            echo
-            sleep 10
-          done &
-
       - name: Run the full Pytest suite
         env:
           # Adding xtrace makes Bash commands & scripts run with "-x".

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,29 +16,18 @@ run-name: Nightly CI full tests
 on:
   schedule:
     - cron: "0 11 * * 1-5"  # Mon-Fri at 11:00 AM UTC
-
-  # Allow manual invocation – useful for debugging.
   workflow_dispatch:
-    inputs:
-      processes:
-        description: 'Value of "-n" option passed to pytest'
-        type: string
-        default: ""
 
 concurrency:
-  # Cancel any previously-started but still active runs on the same branch.
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
 
-# Declare default permissions as read only.
-permissions: read-all
-
-env:
-  # Default value for "-n" argument to pytest with pytest-xdist plugin.
-  pytest-n: ${{inputs.processes || 'auto'}}
+permissions: {}
 
 jobs:
   pytest:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04-x64-8-core
     timeout-minutes: 120
     steps:
@@ -61,4 +50,4 @@ jobs:
         env:
           # Adding xtrace makes Bash commands & scripts run with "-x".
           SHELLOPTS: ${{runner.debug && 'xtrace'}}
-        run: uv run --no-sync check/pytest-full --durations 10 -v -n ${{env.pytest-n}}
+        run: uv run --no-sync check/pytest-full --durations 10 -v


### PR DESCRIPTION
This updates the nightly workflow to use Ubuntu 24, as part of a continuing effort to solve the mysterious, unexplained terminations.

Additional changes:

* Remove the memory & disk monitoring background process. For some reason, even though it works in my Bash shell locally, it doesn't seem to work in the GitHub workflows.

* Remove some constructs that are deemed unsafe by Google's recently-enabled workflow scanner.

* Install pytest-instafail and add `--instafail` to the pytest options, to make it print any errors as they happen instead of at the end of the run. Maybe there are errors during execution that we currently never see because of the abrupt termination.