### PR TITLE
Nightly CI: don't use all CPUs & print diagnostics if terminated

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -48,22 +48,17 @@ jobs:
           uv sync --frozen --no-dev --group test
           uv pip install pytest-instafail
 
-      - name: Determine number of workers to use
-        id: calc-concurrency
-        run: |
-          # Get available CPU cores (fallback to 2 if nproc is unavailable).
-          NUM_CPUS=$(nproc 2>/dev/null || echo 2)
-          # Calculate 1 less than total CPUs (ensuring at least 1 worker).
-          NUM_PROCS=$(( NUM_CPUS > 1 ? NUM_CPUS - 1 : 1 ))
-          echo "num_workers=$NUM_PROCS" >> "$GITHUB_ENV"
-
       - name: Run the full Pytest suite
         id: pytest-full
         env:
           # Adding xtrace makes Bash commands & scripts run with "-x".
           SHELLOPTS: ${{runner.debug && 'xtrace'}}
-        run: uv run --no-sync check/pytest-full \
-            --instafail --durations 10 -n "${{env.num_workers}}"
+        run: |
+          # Get available CPU cores (fallback to 2 if nproc is unavailable).
+          num_cpus=$(nproc 2>/dev/null || echo 2)
+          # Calculate 1 less than total CPUs (ensuring at least 1 worker).
+          num_procs=$(( num_cpus > 1 ? num_cpus - 1 : 1 ))
+          uv run --no-sync check/pytest-full --instafail --durations 10 -n "${num_procs}"
 
       - name: Print diagnostics if test failed or was terminated
         if: (failure() || cancelled()) && steps.pytest-full.outcome != 'skipped'

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -48,8 +48,29 @@ jobs:
           uv sync --frozen --no-dev --group test
           uv pip install pytest-instafail
 
+      - name: Determine number of workers to use
+        id: calc-concurrency
+        run: |
+          # Get available CPU cores (fallback to 2 if nproc is unavailable).
+          NUM_CPUS=$(nproc 2>/dev/null || echo 2)
+          # Calculate 1 less than total CPUs (ensuring at least 1 worker).
+          NUM_PROCS=$(( NUM_CPUS > 1 ? NUM_CPUS - 1 : 1 ))
+          echo "num_workers=$NUM_PROCS" >> "$GITHUB_ENV"
+
       - name: Run the full Pytest suite
+        id: pytest-full
         env:
           # Adding xtrace makes Bash commands & scripts run with "-x".
           SHELLOPTS: ${{runner.debug && 'xtrace'}}
-        run: uv run --no-sync check/pytest-full --instafail --durations 10 -v
+        run: uv run --no-sync check/pytest-full \
+            --instafail --durations 10 -n "${{env.num_workers}}"
+
+      - name: Print diagnostics if test failed or was terminated
+        if: (failure() || cancelled()) && steps.pytest-full.outcome != 'skipped'
+        run: |
+          echo -e "\n--- RAM & SWAP USAGE ---"
+          free -h
+          echo -e "\n--- DISK SPACE USAGE ---"
+          df -h
+          echo -e "\n--- KERNEL & OOM KILLER LOGS ---"
+          sudo dmesg -T | grep -i -E 'oom|killed|memory|143|sigterm' | tail -n 100 || true


### PR DESCRIPTION
Continuing efforts to determine the cause of the abrupt termination of the nightly pytest runs, this sets the number of pytest workers to 1 less than the number of CPUs, and adds a step to print some diagnostic info if the pytest step errors out.