### PR TITLE
Try different approach to printing info in nightly tests

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -54,14 +54,16 @@ jobs:
           # Adding xtrace makes Bash commands & scripts run with "-x".
           SHELLOPTS: ${{runner.debug && 'xtrace'}}
         run: |
+          # Start continuous memory information printing.
+          free -hvl -s 1 &
           # Get available CPU cores (fallback to 2 if nproc is unavailable).
           num_cpus=$(nproc 2>/dev/null || echo 2)
           # Calculate 1 less than total CPUs (ensuring at least 1 worker).
           num_procs=$(( num_cpus > 1 ? num_cpus - 1 : 1 ))
           uv run --no-sync check/pytest-full --instafail --durations 10 -n "${num_procs}"
 
-      - name: Print diagnostics if test failed or was terminated
-        if: (failure() || cancelled()) && steps.pytest-full.outcome != 'skipped'
+      - name: Print system resource info
+        if: always()
         run: |
           echo -e "\n--- RAM & SWAP USAGE ---"
           free -h


### PR DESCRIPTION
The previous final step didn't work after all. This changes the final print step to be unconditional, and also adds a backgrounded call to `free`.