### PR TITLE
Make nightly workflow use 1/2 number of available CPUs

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -52,9 +52,14 @@ jobs:
         id: pytest-full
         env:
           # Adding xtrace makes Bash commands & scripts run with "-x".
-          SHELLOPTS: ${{runner.debug && 'xtrace'}}
+          SHELLOPTS: ${{runner.debug == '1' && 'xtrace'}}
         run: |
-          # Start continuous memory information printing.
-          free -hv -s 1 &
+          if [[ "${{runner.debug}}" == "1" ]]; then
+            # When debugging, print memory information continuously.
+            free -hv -s 1 &
+          fi
+          # Get available CPU cores (fallback to 2 if nproc is unavailable).
+          num_cpus=$(nproc 2>/dev/null || echo 2)
+          num_procs=$(( num_cpus > 1 ? num_cpus / 2 : 1 ))
           # Use only 1/2 as many runners as cores, to avoid using too much RAM.
-          uv run --no-sync check/pytest-full --instafail --durations 10 -n 8
+          uv run --no-sync check/pytest-full --instafail --durations 10 -n "${num_procs}"


### PR DESCRIPTION
Changes:

* Rather than hardcoding the number of workers, this uses 1/2 of the number of available CPUs. This will be more robust in case the runner size is changed in the future.

* Print free memory only if debugging is on.
