### PR TITLE
Add pytest-randomly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ test = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
+    "pytest-randomly",
     "pytest-xdist",
 
     # test executing notebooks
@@ -272,4 +273,3 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "dev_tools.qualtran_dev_tools.bloq_report_card"
 ignore_errors = true
-


### PR DESCRIPTION
[pytest-randomly](https://pypi.org/project/pytest-randomly/) is a Pytest plugin that helps find hidden order dependencies in test suites by randomly shuffling tests and resetting Python's random seed. It prevents bugs where one test unintentionally relies on the state left behind by a previous test.

This is generally a good practice. No Qualtran test failures currently happen from adding to the set of pytest plugins used.