### PR TITLE
Add `merge_group` trigger to pr.yaml to allow use of merge queues

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,6 +18,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
 
 concurrency:
   cancel-in-progress: true


### PR DESCRIPTION
This adds a `merge_group` trigger, which in combination with changes to the repository settings, will enable the use of merge queues.