### PR TITLE
Make corrections to miscellaneous links in some Markdown files

### DIFF
--- a/.github/problem-matchers/README.md
+++ b/.github/problem-matchers/README.md
@@ -8,19 +8,19 @@ summary page. Using Problem Matchers allows information to be displayed more
 prominently in the GitHub user interface.
 
 This directory contains Problem Matchers used by the GitHub Actions workflows
-in the [`workflows`](./workflows) subdirectory.
+in the [`workflows`](../workflows) directory.
 
 The following problem matcher JSON files found in this directory were copied
 from the [Home Assistant](https://github.com/home-assistant/core) project on
 GitHub. The Home Assistant project is licensed under the Apache 2.0 open-source
 license. The versions of the file at the time it was copied was 2025.1.2.
 
-- [`pylint.json`](https://github.com/home-assistant/core/blob/dev/.github/workflows/matchers/pylint.json)
-- [`mypy.json`](https://github.com/home-assistant/core/blob/dev/.github/workflows/matchers/pypy.json)
+*   [`pylint.json`](https://github.com/home-assistant/core/blob/dev/.github/workflows/matchers/pylint.json)
+*   [`mypy.json`](https://github.com/home-assistant/core/blob/dev/.github/workflows/matchers/mypy.json)
 
 The following problem matcher for Black came from a fork of the
 [MLflow](https://github.com/mlflow/mlflow) project by user Sumanth077 on
 GitHub. The MLflow project is licensed under the Apache 2.0 open-source
 license. The version of the file copied was dated 2022-05-29.
 
-- [`black.json`](https://github.com/Sumanth077/mlflow/blob/problem-matcher-for-black/.github/workflows/matchers/black.json)
+*   [`black.json`](https://github.com/Sumanth077/mlflow/blob/problem-matcher-for-black/.github/workflows/matchers/black.json)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,8 @@ the code of conduct.
 
 All submissions, including submissions by project members, require review. We
 use the tools provided by GitHub for [pull
-requests](https://help.github.com/articles/about-pull-requests/) for this
-purpose. The preferred manner for submitting pull requests is to fork the
+requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
+for this purpose. The preferred manner for submitting pull requests is to fork the
 Qualtran [repository](https://github.com/quantumlib/Qualtran), create a [git
 branch](https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell)
 in this fork to do your work, and when ready, create a pull request from this
@@ -101,8 +101,8 @@ locally during development. Wrapper scripts are located in the
     ```
 
     If git reports conflicts during one or both of these merge processes, you
-    may need to [resolve the merge conflicts](
-    https://docs.github.com/articles/about-merge-conflicts) before continuing.
+    may need to [resolve the merge conflicts](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/about-merge-conflicts)
+    before continuing.
 
 1.  Finally, push your changes to your fork of the Qualtran repo on GitHub:
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can stay on top of Qualtran news using the approach that best suits your nee
     *   *Via RSS from PyPI*: subscribe to the [PyPI releases feed] for Qualtran.
 
 [`qualtran-announce`]: https://groups.google.com/g/qualtran-announce
-[repository notifications]: https://docs.github.com/github/managing-subscriptions-and-notifications-on-github/configuring-notifications
+[repository notifications]: https://docs.github.com/en/subscriptions-and-notifications/get-started/configuring-notifications
 [Qualtran releases feed]: https://github.com/quantumlib/Qualtran/releases.atom
 [PyPI releases feed]: https://pypi.org/rss/project/qualtran/releases.xml
 
@@ -115,7 +115,7 @@ You can stay on top of Qualtran news using the approach that best suits your nee
 
 [Open an issue on GitHub]: https://github.com/quantumlib/Qualtran/issues/new/choose
 [contribution guidelines]: https://github.com/quantumlib/Qualtran/blob/main/CONTRIBUTING.md
-[pull request]: https://help.github.com/articles/about-pull-requests
+[pull request]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
 
 ## Citation<a name="how-to-cite"></a>
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -21,7 +21,7 @@ issue tracker.
 _Qualtran Cynq_ is our biweekly virtual meeting of contributors to discuss
 everything from issues to ongoing efforts, as well as to ask questions. Join the
 [`qualtran-dev` Google
-Group](https://groups.google.com/forum/#!forum/qualtran-dev) to get an automatic
+Group](https://groups.google.com/g/qualtran-dev) to get an automatic
 meeting invitation.
 
 ## Contact the maintainers


### PR DESCRIPTION
A few Markdown files contained some links that had typos in them or pointed to deprecated URLs. This PR updates the URLs.