### PR TITLE
Add implementation for SelectTHC bloq

### DIFF
--- a/dev_tools/qualtran_dev_tools/notebook_specs.py
+++ b/dev_tools/qualtran_dev_tools/notebook_specs.py
@@ -310,6 +310,7 @@ CHEMISTRY: list[NotebookSpecV2] = [
             qualtran.bloqs.chemistry.thc.prepare._THC_UNI_PREP,
             qualtran.bloqs.chemistry.thc.prepare._THC_PREPARE,
             qualtran.bloqs.chemistry.thc.select_bloq._THC_SELECT,
+            qualtran.bloqs.chemistry.thc.select_bloq._THC_ROTATIONS,
         ],
         directory=f'{SOURCE_DIR}/bloqs/chemistry/thc',
     ),

--- a/qualtran/bloqs/chemistry/resource_estimation.ipynb
+++ b/qualtran/bloqs/chemistry/resource_estimation.ipynb
@@ -279,7 +279,7 @@
    "source": [
     "from qualtran.bloqs.chemistry.thc.select_bloq import THCRotations\n",
     "\n",
-    "bloq = THCRotations(num_mu, num_spin_orb, num_bits_theta, kr1=16, kr2=16)\n",
+    "bloq = THCRotations(num_mu, num_spin_orb, num_bits_theta, block_size=16)\n",
     "graph, sigma = bloq.call_graph()\n",
     "show_call_graph(graph)\n",
     "print(f\"rotation cost = {108 * 14}, qrom cost = {402}\")"

--- a/qualtran/bloqs/chemistry/thc/select_bloq.py
+++ b/qualtran/bloqs/chemistry/thc/select_bloq.py
@@ -41,6 +41,7 @@ from qualtran.bloqs.chemistry.quad_fermion.givens_bloq import RealGivensRotation
 from qualtran.bloqs.data_loading.qroam_clean import QROAMClean
 from qualtran.bloqs.multiplexers.select_base import SelectOracle
 from qualtran.bloqs.rotations.phase_gradient import PhaseGradientState
+from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 def _leaf_tensor_to_givens_rotations(eta: np.ndarray, num_bits_theta: int) -> np.ndarray:
@@ -206,13 +207,21 @@ class THCRotations(Bloq):
             )
 
         target_bitsizes = (self.num_bits_theta,) * num_angles
-        log_block_size = (block_size - 1).bit_length() if block_size > 1 else 0
+        log_block_size = (int(block_size) - 1).bit_length()
         return QROAMClean(
             data_or_shape=[np.array(col) for col in angles_data],
             target_bitsizes=target_bitsizes,
             selection_bitsizes=(self.selection_bitsize,),
             log_block_sizes=(log_block_size,),
         )
+
+    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
+        if self.num_angles <= 0:
+            return {}
+        qroam = self._build_qroam(self.num_angles, self.block_size)
+        pg = PhaseGradientState(self.num_bits_theta)
+        givens = RealGivensRotationByPhaseGradient(self.num_bits_theta)
+        return {qroam: 1, pg: 1, givens: self.num_angles, pg.adjoint(): 1}
 
     def build_composite_bloq(
         self, bb: 'BloqBuilder', data: 'SoquetT', sel: 'SoquetT', trg: 'SoquetT'
@@ -225,6 +234,11 @@ class THCRotations(Bloq):
         sel_res = bb.add_d(qroam, selection=sel)
         sel = sel_res['selection']
         targets = [sel_res[f'target{i}_'] for i in range(self.num_angles)]
+        for i in range(self.num_angles):
+            junk = sel_res.get(f'junk_target{i}_')
+            if junk is not None:
+                for soq in np.asarray(junk).flat:
+                    bb.free(soq)
 
         pg = bb.add(PhaseGradientState(self.num_bits_theta))
         q_trg = bb.split(trg)

--- a/qualtran/bloqs/chemistry/thc/select_bloq.py
+++ b/qualtran/bloqs/chemistry/thc/select_bloq.py
@@ -139,14 +139,20 @@ class THCRotations(Bloq):
     )
 
     @classmethod
-    def from_thc_leaf_tensor(
-        cls, eta: np.ndarray, num_bits_theta: int, block_size: int = 1, two_body_only: bool = False
+    def from_hamiltonian_coeffs(
+        cls,
+        eta: np.ndarray,
+        num_bits_theta: int,
+        tpq: Optional[np.ndarray] = None,
+        block_size: int = 1,
+        two_body_only: bool = False,
     ) -> 'THCRotations':
-        r"""Construct THCRotations from a THC leaf tensor $\eta$.
+        r"""Construct THCRotations from Hamiltonian coefficients.
 
         Args:
-            eta: THC vectors of shape (M, N/2).
+            eta: THC leaf tensor of shape (M, N/2).
             num_bits_theta: Number of bits of precision for the rotation angles ($\beth$).
+            tpq: Optional modified one-body Hamiltonian of shape (N/2, N/2) or (N/2,).
             block_size: Block size for QROAM loading.
             two_body_only: Whether to only apply the two body Hamiltonian.
 
@@ -155,7 +161,19 @@ class THCRotations(Bloq):
         """
         num_mu, num_spatial = eta.shape
         num_spin_orb = 2 * num_spatial
-        angles_data = _leaf_tensor_to_givens_rotations(eta, num_bits_theta=num_bits_theta)
+        thetas_2body = _leaf_tensor_to_givens_rotations(eta, num_bits_theta=num_bits_theta)
+        if two_body_only:
+            angles_data = thetas_2body
+        else:
+            if tpq is not None:
+                _, u = np.linalg.eigh(tpq)
+                thetas_1body = _leaf_tensor_to_givens_rotations(u.T, num_bits_theta=num_bits_theta)
+            else:
+                # pad with zeros
+                num_angles = num_spatial - 1
+                thetas_1body = np.zeros((num_angles, num_spatial), dtype=int)
+            angles_data = np.concatenate([thetas_2body, thetas_1body], axis=1)
+
         return cls(
             num_mu=num_mu,
             num_spin_orb=num_spin_orb,
@@ -179,18 +197,23 @@ class THCRotations(Bloq):
 
     @property
     def num_terms(self) -> int:
-        return self.num_mu
+        if self.two_body_only:
+            return self.num_mu
+        return self.num_mu + self.num_spatial
 
     @cached_property
     def selection_bitsize(self) -> int:
-        return self.num_mu.bit_length()
+        if self.two_body_only:
+            return self.num_mu.bit_length()
+        return self.num_mu.bit_length() + 1
 
     @cached_property
     def signature(self) -> Signature:
         return Signature(
             [
+                Register("nu_eq_mp1", QBit()),
                 Register("data", QAny(bitsize=self.data_bitsize)),
-                Register("sel", QAny(bitsize=self.selection_bitsize)),
+                Register("sel", QAny(bitsize=self.num_mu.bit_length())),
                 Register("trg", QAny(bitsize=self.num_spatial)),
             ]
         )
@@ -229,15 +252,31 @@ class THCRotations(Bloq):
         return {qroam: 1, pg: 1, givens: self.num_angles, pg.adjoint(): 1}
 
     def build_composite_bloq(
-        self, bb: 'BloqBuilder', data: 'SoquetT', sel: 'SoquetT', trg: 'SoquetT'
+        self,
+        bb: 'BloqBuilder',
+        nu_eq_mp1: 'SoquetT',
+        data: 'SoquetT',
+        sel: 'SoquetT',
+        trg: 'SoquetT',
     ) -> Dict[str, 'SoquetT']:
         if self.num_angles <= 0:
-            return {'data': data, 'sel': sel, 'trg': trg}
+            return {'nu_eq_mp1': nu_eq_mp1, 'data': data, 'sel': sel, 'trg': trg}
 
         bb.free(data)
         qroam = self._build_qroam()
-        sel_res = bb.add_d(qroam, selection=sel)
-        sel = sel_res['selection']
+        if not self.two_body_only:
+            qroam_sel: 'SoquetT' = bb.join(np.array([nu_eq_mp1, *bb.split(sel)]))
+        else:
+            qroam_sel = sel
+
+        sel_res = bb.add_d(qroam, selection=qroam_sel)
+        if not self.two_body_only:
+            soqs_split = bb.split(sel_res['selection'])
+            nu_eq_mp1 = soqs_split[0]
+            sel = bb.join(soqs_split[1:])
+        else:
+            sel = sel_res['selection']
+
         targets = [sel_res[f'target{i}_'] for i in range(self.num_angles)]
         for i in range(self.num_angles):
             junk = sel_res.get(f'junk_target{i}_')
@@ -258,7 +297,7 @@ class THCRotations(Bloq):
 
         bb.add(PhaseGradientState(self.num_bits_theta).adjoint(), phase_grad=pg)
         data = bb.join(np.concatenate([bb.split(tgt) for tgt in targets]))
-        return {'data': data, 'sel': sel, 'trg': bb.join(q_trg)}
+        return {'nu_eq_mp1': nu_eq_mp1, 'data': data, 'sel': sel, 'trg': bb.join(q_trg)}
 
 
 @frozen
@@ -305,6 +344,11 @@ class SelectTHC(SelectOracle):
     kr2: int = 1
     control_val: Optional[int] = None
     eta: Optional[np.ndarray] = field(
+        default=None,
+        eq=lambda x: None if x is None else (x.shape, x.dtype, x.tobytes()),
+        repr=False,
+    )
+    tpq: Optional[np.ndarray] = field(
         default=None,
         eq=lambda x: None if x is None else (x.shape, x.dtype, x.tobytes()),
         repr=False,
@@ -358,8 +402,12 @@ class SelectTHC(SelectOracle):
         data_bitsize = n_angles * self.num_bits_theta
         data = bb.allocate(data_bitsize)
         if self.eta is not None:
-            thc_rot = THCRotations.from_thc_leaf_tensor(
-                self.eta, self.num_bits_theta, block_size=self.kr1, two_body_only=False
+            thc_rot = THCRotations.from_hamiltonian_coeffs(
+                self.eta,
+                self.num_bits_theta,
+                tpq=self.tpq,
+                block_size=self.kr1,
+                two_body_only=False,
             )
         else:
             thc_rot = THCRotations(
@@ -369,7 +417,9 @@ class SelectTHC(SelectOracle):
                 block_size=self.kr1,
                 two_body_only=False,
             )
-        data, mu, sys_a = bb.add(thc_rot, data=data, sel=mu, trg=sys_a)
+        nu_eq_mp1, data, mu, sys_a = bb.add(
+            thc_rot, nu_eq_mp1=nu_eq_mp1, data=data, sel=mu, trg=sys_a
+        )
         # Controlled Z_0
         (succ,), sys_b = bb.add(
             ApplyControlledZs(cvs=(1,), bitsize=self.num_spin_orb // 2),
@@ -377,7 +427,9 @@ class SelectTHC(SelectOracle):
             system=sys_b,
         )
         # Undo rotations
-        data, mu, sys_a = bb.add(thc_rot.adjoint(), data=data, sel=mu, trg=sys_a)
+        nu_eq_mp1, data, mu, sys_a = bb.add(
+            thc_rot.adjoint(), nu_eq_mp1=nu_eq_mp1, data=data, sel=mu, trg=sys_a
+        )
         plus_b, sys_a, sys_b = bb.add(CSwap(self.num_spin_orb // 2), ctrl=plus_b, x=sys_a, y=sys_b)
 
         plus_mn = bb.add(XGate(), q=plus_mn)
@@ -393,8 +445,8 @@ class SelectTHC(SelectOracle):
 
         # Rotations
         if self.eta is not None:
-            thc_rot_two_body = THCRotations.from_thc_leaf_tensor(
-                self.eta, self.num_bits_theta, block_size=self.kr2, two_body_only=True
+            thc_rot_two_body = THCRotations.from_hamiltonian_coeffs(
+                self.eta, self.num_bits_theta, tpq=self.tpq, block_size=self.kr2, two_body_only=True
             )
         else:
             thc_rot_two_body = THCRotations(
@@ -404,7 +456,9 @@ class SelectTHC(SelectOracle):
                 block_size=self.kr2,
                 two_body_only=True,
             )
-        data, mu, sys_a = bb.add(thc_rot_two_body, data=data, sel=mu, trg=sys_a)
+        nu_eq_mp1, data, mu, sys_a = bb.add(
+            thc_rot_two_body, nu_eq_mp1=nu_eq_mp1, data=data, sel=mu, trg=sys_a
+        )
         # Controlled Z_0
         (succ, nu_eq_mp1), sys_b = bb.add(
             ApplyControlledZs(cvs=(1, 0), bitsize=self.num_spin_orb // 2),
@@ -412,7 +466,9 @@ class SelectTHC(SelectOracle):
             system=sys_b,
         )
         # Undo rotations
-        data, mu, sys_a = bb.add(thc_rot_two_body.adjoint(), data=data, sel=mu, trg=sys_a)
+        nu_eq_mp1, data, mu, sys_a = bb.add(
+            thc_rot_two_body.adjoint(), nu_eq_mp1=nu_eq_mp1, data=data, sel=mu, trg=sys_a
+        )
 
         # Clean up
         plus_b, sys_a, sys_b = bb.add(CSwap(self.num_spin_orb // 2), ctrl=plus_b, x=sys_a, y=sys_b)
@@ -452,7 +508,9 @@ class SelectTHC(SelectOracle):
 def _thc_rotations() -> THCRotations:
     rng = np.random.default_rng(42)
     eta = rng.normal(size=(2, 4))
-    thc_rotations = THCRotations.from_thc_leaf_tensor(eta, num_bits_theta=12)
+    tpq = rng.normal(size=(4, 4))
+    tpq = 0.5 * (tpq + tpq.T)
+    thc_rotations = THCRotations.from_hamiltonian_coeffs(eta, num_bits_theta=12, tpq=tpq)
     return thc_rotations
 
 

--- a/qualtran/bloqs/chemistry/thc/select_bloq.py
+++ b/qualtran/bloqs/chemistry/thc/select_bloq.py
@@ -15,7 +15,7 @@
 """SELECT for the molecular tensor hypercontraction (THC) hamiltonian"""
 
 from functools import cached_property
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 from attrs import evolve, field, frozen
@@ -41,7 +41,9 @@ from qualtran.bloqs.chemistry.quad_fermion.givens_bloq import RealGivensRotation
 from qualtran.bloqs.data_loading.qroam_clean import QROAMClean
 from qualtran.bloqs.multiplexers.select_base import SelectOracle
 from qualtran.bloqs.rotations.phase_gradient import PhaseGradientState
-from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
+
+if TYPE_CHECKING:
+    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
 
 
 def _leaf_tensor_to_givens_rotations(eta: np.ndarray, num_bits_theta: int) -> np.ndarray:
@@ -107,6 +109,7 @@ class THCRotations(Bloq):
         num_spin_orb: number of spin orbitals $N$ (number of spatial orbitals = $N/2$).
         num_bits_theta: Number of bits of precision for the rotations. Called
             $\beth$ in the reference.
+        block_size: Block size for QROAM loading.
         two_body_only: Whether to only apply the two body Hamiltonian. This reduces the QROM size.
         is_adjoint: Whether to dagger this bloq or not.
         angles_data: Optional tuple of tuples of integer-quantized angles.
@@ -144,7 +147,7 @@ class THCRotations(Bloq):
         Args:
             eta: THC vectors of shape (M, N/2).
             num_bits_theta: Number of bits of precision for the rotation angles ($\beth$).
-            block_size: Block size for QROM loading.
+            block_size: Block size for QROAM loading.
             two_body_only: Whether to only apply the two body Hamiltonian.
 
         Returns:
@@ -195,9 +198,9 @@ class THCRotations(Bloq):
     def __str__(self) -> str:
         return "In_mu-R"
 
-    def _build_qroam(self, num_angles: int, block_size: int) -> QROAMClean:
-        target_bitsizes = (self.num_bits_theta,) * num_angles
-        log_block_size = max(0, int(int(block_size) - 1).bit_length())
+    def _build_qroam(self) -> QROAMClean:
+        target_bitsizes = (self.num_bits_theta,) * self.num_angles
+        log_block_size = max(0, int(int(self.block_size) - 1).bit_length())
         if self.angles_data is None:
             return QROAMClean.build_from_bitsize(
                 (self.num_terms,),
@@ -220,7 +223,7 @@ class THCRotations(Bloq):
     def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
         if self.num_angles <= 0:
             return {}
-        qroam = self._build_qroam(self.num_angles, self.block_size)
+        qroam = self._build_qroam()
         pg = PhaseGradientState(self.num_bits_theta)
         givens = RealGivensRotationByPhaseGradient(self.num_bits_theta)
         return {qroam: 1, pg: 1, givens: self.num_angles, pg.adjoint(): 1}
@@ -232,7 +235,7 @@ class THCRotations(Bloq):
             return {'data': data, 'sel': sel, 'trg': trg}
 
         bb.free(data)
-        qroam = self._build_qroam(self.num_angles, self.block_size)
+        qroam = self._build_qroam()
         sel_res = bb.add_d(qroam, selection=sel)
         sel = sel_res['selection']
         targets = [sel_res[f'target{i}_'] for i in range(self.num_angles)]

--- a/qualtran/bloqs/chemistry/thc/select_bloq.py
+++ b/qualtran/bloqs/chemistry/thc/select_bloq.py
@@ -18,7 +18,7 @@ from functools import cached_property
 from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
-from attrs import evolve, frozen
+from attrs import evolve, field, frozen
 
 from qualtran import (
     AddControlledT,
@@ -30,16 +30,63 @@ from qualtran import (
     CtrlSpec,
     QAny,
     QBit,
+    QFxp,
     Register,
     Signature,
     SoquetT,
 )
-from qualtran.bloqs.basic_gates import CSwap, Toffoli, XGate
+from qualtran.bloqs.basic_gates import CSwap, XGate
 from qualtran.bloqs.chemistry.black_boxes import ApplyControlledZs
+from qualtran.bloqs.chemistry.quad_fermion.givens_bloq import RealGivensRotationByPhaseGradient
+from qualtran.bloqs.data_loading.qroam_clean import QROAMClean
 from qualtran.bloqs.multiplexers.select_base import SelectOracle
+from qualtran.bloqs.rotations.phase_gradient import PhaseGradientState
 
-if TYPE_CHECKING:
-    from qualtran.resource_counting import BloqCountDictT, SympySymbolAllocator
+
+def _leaf_tensor_to_givens_rotations(eta: np.ndarray, num_bits_theta: int) -> np.ndarray:
+    r"""Compute Givens rotation angles for transformation from orbital basis to THC
+
+    Given the THC leaf tensor $\eta$ of shape $(M, N/2)$, this function computes the
+    $N/2 - 1$ Givens rotation angles, $\theta$, that rotate from the standard basis to
+    the THC basis for each $\mu \in [0, M-1]$.
+
+    Args:
+        eta: THC leaf tensor of shape (M, N/2).
+        num_bits_theta: Precision $\beth$ (in bits) for the rotation angles.
+
+    Returns:
+        thetas: Integer array of shape (N/2 - 1,) containing angles $\theta$.
+
+    References:
+        [Quantum computing enhanced computational catalysis](https://arxiv.org/abs/2007.14460).
+            Burg, Low, et al. 2021. Eq. 57
+    """
+    assert len(eta.shape) == 2
+    num_mu, num_spatial = eta.shape
+    num_angles = num_spatial - 1
+    if num_angles <= 0:
+        return np.zeros((0, num_mu), dtype=int)
+    thetas = np.zeros((num_angles, num_mu), dtype=int)
+    dtype = QFxp(num_bits_theta, num_bits_theta, signed=False)
+    fpi = 4 * np.pi
+    for mu in range(num_mu):
+        eta_mu = eta[mu]
+        norm = np.linalg.norm(eta_mu)
+        if norm < 1e-12:
+            continue
+        u = eta_mu / norm
+
+        # solve for first theta
+        theta_first = (np.arctan2(u[num_angles], u[num_angles - 1]) + 2 * np.pi) % (2 * np.pi)
+        thetas[num_angles - 1, mu] = dtype.to_fixed_width_int(theta_first / fpi)
+        hypot = u[-1] ** 2 + u[-2] ** 2
+
+        # solve for remaining thetas
+        for i in range(num_angles - 2, -1, -1):
+            theta_next = np.arctan2(np.sqrt(hypot), u[i])
+            thetas[i, mu] = dtype.to_fixed_width_int(theta_next / fpi)
+            hypot += u[i] ** 2
+    return thetas
 
 
 @frozen
@@ -47,22 +94,27 @@ class THCRotations(Bloq):
     r"""Bloq for rotating into THC basis through Givens rotation network.
 
     This is accounting for In-data:rot and In-R in Fig. 7 of the THC paper (Ref.
-    1). In practice this bloq is made up of a QROM load of the angles followed
-    by controlled rotations. Equivalently it can be built from a modified
-    version of the ProgrammableRotationGateArray from implemented in qualtran
-    from Ref. 2. This is a placeholder waiting for an actual implementation.
-    See https://github.com/quantumlib/Qualtran/issues/386.
+    1).
+
+    The bloq loads $N/2 - 1$ Givens rotation angles from the selection register
+    using QROAM, prepares a phase gradient state, applies $N/2 - 1$ real
+    Givens rotations between spatial orbitals using `RealGivensRotationByPhaseGradient`,
+    and uncomputes the phase gradient state.
 
     Args:
         num_mu: THC auxiliary index dimension $M$
-        num_spin_orb: number of spin orbitals $N$
+        num_spin_orb: number of spin orbitals $N$ (number of spatial orbitals = $N/2$).
         num_bits_theta: Number of bits of precision for the rotations. Called
             $\beth$ in the reference.
-        kr1: block sizes for QROM erasure for outputting rotation angles. See Eq 34.
-        kr2: block sizes for QROM erasure for outputting rotation angles. This
-            is for the second QROM (eq 35)
         two_body_only: Whether to only apply the two body Hamiltonian. This reduces the QROM size.
         is_adjoint: Whether to dagger this bloq or not.
+        angles_data: Optional tuple of tuples of integer-quantized angles.
+            If None, default (zero) angle data is used.
+
+    Registers:
+        data: Register storing the loaded rotation angle data.
+        sel: Selection register indexing $\mu$ (or one-body orbital).
+        trg: Target spatial orbitals register of size $N/2$.
 
     References:
         [Even more efficient quantum computations of chemistry through
@@ -74,51 +126,120 @@ class THCRotations(Bloq):
     num_mu: int
     num_spin_orb: int
     num_bits_theta: int
-    kr1: int = 1
-    kr2: int = 1
+    block_size: int = 1
     two_body_only: bool = False
-    is_adjoint: bool = False
+    angles_data: Optional[Tuple[Tuple[int, ...], ...]] = field(
+        default=None,
+        repr=False,
+        converter=lambda d: None if d is None else tuple(tuple(int(x) for x in row) for row in d),
+    )
+
+    @classmethod
+    def from_thc_leaf_tensor(
+        cls, eta: np.ndarray, num_bits_theta: int, block_size: int = 1, two_body_only: bool = False
+    ) -> 'THCRotations':
+        r"""Construct THCRotations from a THC leaf tensor $\eta$.
+
+        Args:
+            eta: THC vectors of shape (M, N/2).
+            num_bits_theta: Number of bits of precision for the rotation angles ($\beth$).
+            block_size: Block size for QROM loading.
+            two_body_only: Whether to only apply the two body Hamiltonian.
+
+        Returns:
+            Constructed THCRotations object.
+        """
+        num_mu, num_spatial = eta.shape
+        num_spin_orb = 2 * num_spatial
+        angles_data = _leaf_tensor_to_givens_rotations(eta, num_bits_theta=num_bits_theta)
+        return cls(
+            num_mu=num_mu,
+            num_spin_orb=num_spin_orb,
+            num_bits_theta=num_bits_theta,
+            block_size=block_size,
+            two_body_only=two_body_only,
+            angles_data=tuple(tuple(int(x) for x in row) for row in angles_data),
+        )
+
+    @property
+    def num_spatial(self) -> int:
+        return self.num_spin_orb // 2
+
+    @property
+    def num_angles(self) -> int:
+        return self.num_spatial - 1
+
+    @property
+    def data_bitsize(self) -> int:
+        return self.num_angles * self.num_bits_theta
+
+    @property
+    def num_terms(self) -> int:
+        return self.num_mu
+
+    @cached_property
+    def selection_bitsize(self) -> int:
+        return self.num_mu.bit_length()
 
     @cached_property
     def signature(self) -> Signature:
         return Signature(
             [
-                Register("nu_eq_mp1", QBit()),
-                Register("data", QAny(bitsize=self.num_bits_theta)),
-                Register("sel", QAny(bitsize=self.num_mu.bit_length())),
-                Register("trg", QAny(bitsize=self.num_spin_orb // 2)),
+                Register("data", QAny(bitsize=self.data_bitsize)),
+                Register("sel", QAny(bitsize=self.selection_bitsize)),
+                Register("trg", QAny(bitsize=self.num_spatial)),
             ]
         )
 
-    def adjoint(self) -> 'Bloq':
-        return evolve(self, is_adjoint=not self.is_adjoint)
-
     def __str__(self) -> str:
-        dag = '†' if self.is_adjoint else ''
-        return f"In_mu-R{dag}"
+        return "In_mu-R"
 
-    def build_call_graph(self, ssa: 'SympySymbolAllocator') -> 'BloqCountDictT':
-        # from listings on page 17 of Ref. [1]
-        num_data_sets = self.num_mu + self.num_spin_orb // 2
-        if self.is_adjoint:
-            if self.two_body_only:
-                toff_cost_qrom = (
-                    int(np.ceil(self.num_mu / self.kr1))
-                    + int(np.ceil(self.num_spin_orb / (2 * self.kr1)))
-                    + self.kr1
-                )
-            else:
-                toff_cost_qrom = int(np.ceil(self.num_mu / self.kr2)) + self.kr2
+    def _build_qroam(self, num_angles: int, block_size: int) -> QROAMClean:
+        if self.angles_data is None:
+            # NOTE: using an array of zeros effectively skips QROAM so this will throw off the cost
+            angles_data = tuple(tuple(0 for _ in range(self.num_terms)) for _ in range(num_angles))
         else:
-            toff_cost_qrom = num_data_sets - 2
-            if self.two_body_only:
-                # we don't need the only body bit for the second application of the
-                # rotations for the nu register.
-                toff_cost_qrom -= self.num_spin_orb // 2
-        # xref https://github.com/quantumlib/Qualtran/issues/370, the cost below
-        # assume a phase gradient.
-        rot_cost = self.num_spin_orb * (self.num_bits_theta - 2)
-        return {Toffoli(): (rot_cost + toff_cost_qrom)}
+            angles_data = self.angles_data
+            # pad angles array if necessary for one electron terms
+            angles_data = tuple(
+                col + (0,) * max(0, self.num_terms - len(col)) for col in self.angles_data
+            )
+
+        target_bitsizes = (self.num_bits_theta,) * num_angles
+        log_block_size = (block_size - 1).bit_length() if block_size > 1 else 0
+        return QROAMClean(
+            data_or_shape=[np.array(col) for col in angles_data],
+            target_bitsizes=target_bitsizes,
+            selection_bitsizes=(self.selection_bitsize,),
+            log_block_sizes=(log_block_size,),
+        )
+
+    def build_composite_bloq(
+        self, bb: 'BloqBuilder', data: 'SoquetT', sel: 'SoquetT', trg: 'SoquetT'
+    ) -> Dict[str, 'SoquetT']:
+        if self.num_angles <= 0:
+            return {'data': data, 'sel': sel, 'trg': trg}
+
+        bb.free(data)
+        qroam = self._build_qroam(self.num_angles, self.block_size)
+        sel_res = bb.add_d(qroam, selection=sel)
+        sel = sel_res['selection']
+        targets = [sel_res[f'target{i}_'] for i in range(self.num_angles)]
+
+        pg = bb.add(PhaseGradientState(self.num_bits_theta))
+        q_trg = bb.split(trg)
+        for k in range(self.num_angles):
+            q_trg[k], q_trg[k + 1], targets[k], pg = bb.add(
+                RealGivensRotationByPhaseGradient(self.num_bits_theta),
+                target_i=q_trg[k],
+                target_j=q_trg[k + 1],
+                rom_data=targets[k],
+                phase_gradient=pg,
+            )
+
+        bb.add(PhaseGradientState(self.num_bits_theta).adjoint(), phase_grad=pg)
+        data = bb.join(np.concatenate([bb.split(tgt) for tgt in targets]))
+        return {'data': data, 'sel': sel, 'trg': bb.join(q_trg)}
 
 
 @frozen
@@ -130,24 +251,26 @@ class SelectTHC(SelectOracle):
         num_spin_orb: number of spin orbitals $N$
         num_bits_theta: Number of bits of precision for the rotations. Called
             $\beth$ in the reference.
+        keep_bitsize: number of bits for keep register for coherent alias
+            sampling. This can be determined from the PrepareTHC bloq. See
+            https://github.com/quantumlib/Qualtran/issues/549
         kr1: block sizes for QROM erasure for outputting rotation angles. See Eq 34.
         kr2: block sizes for QROM erasure for outputting rotation angles. This
             is for the second QROM (eq 35)
         control_val: A control bit for the entire gate.
-        keep_bitsize: number of bits for keep register for coherent alias
-        sampling. This can be determined from the PrepareTHC bloq. See
-        https://github.com/quantumlib/Qualtran/issues/549
+        eta: Optional THC leaf tensor of shape (M, N/2).
 
     Registers:
         succ: success flag qubit from uniform state preparation
-        nu_eq_mp1: flag for if $nu = M+1$
+        nu_eq_mp1: flag for if $\nu = M+1$
         mu: $\mu$ register.
         nu: $\nu$ register.
-        theta: sign register.
         plus_mn: Flag controlling swaps between mu and nu. Note that as per the
             Reference, the swaps are NOT performed as part of SELECT as they're
-            acounted for during Prepare.
+            accounted for during Prepare.
         plus_a / plus_b: plus state for controlled swaps on spins.
+        sigma: ancilla register for alias sampling.
+        rot: ancilla register for uniform superposition rotation.
         sys_a / sys_b : System registers for (a)lpha/(b)eta orbitals.
 
     References:
@@ -162,6 +285,11 @@ class SelectTHC(SelectOracle):
     kr1: int = 1
     kr2: int = 1
     control_val: Optional[int] = None
+    eta: Optional[np.ndarray] = field(
+        default=None,
+        eq=lambda x: None if x is None else (x.shape, x.dtype, x.tobytes()),
+        repr=False,
+    )
 
     @cached_property
     def control_registers(self) -> Tuple[Register, ...]:
@@ -206,20 +334,23 @@ class SelectTHC(SelectOracle):
         sys_b = soqs['sys_b']
         plus_b, sys_a, sys_b = bb.add(CSwap(self.num_spin_orb // 2), ctrl=plus_b, x=sys_a, y=sys_b)
         # Rotations
-        data = bb.allocate(self.num_bits_theta)
-        nu_eq_mp1, data, mu, sys_a = bb.add(
-            THCRotations(
+        n_spatial = self.num_spin_orb // 2
+        n_angles = n_spatial - 1
+        data_bitsize = n_angles * self.num_bits_theta
+        data = bb.allocate(data_bitsize)
+        if self.eta is not None:
+            thc_rot = THCRotations.from_thc_leaf_tensor(
+                self.eta, self.num_bits_theta, block_size=self.kr1, two_body_only=False
+            )
+        else:
+            thc_rot = THCRotations(
                 num_mu=self.num_mu,
                 num_spin_orb=self.num_spin_orb,
                 num_bits_theta=self.num_bits_theta,
-                kr1=self.kr1,
-                kr2=self.kr2,
-            ),
-            nu_eq_mp1=nu_eq_mp1,
-            data=data,
-            sel=mu,
-            trg=sys_a,
-        )
+                block_size=self.kr1,
+                two_body_only=False,
+            )
+        data, mu, sys_a = bb.add(thc_rot, data=data, sel=mu, trg=sys_a)
         # Controlled Z_0
         (succ,), sys_b = bb.add(
             ApplyControlledZs(cvs=(1,), bitsize=self.num_spin_orb // 2),
@@ -227,20 +358,7 @@ class SelectTHC(SelectOracle):
             system=sys_b,
         )
         # Undo rotations
-        nu_eq_mp1, data, mu, sys_a = bb.add(
-            THCRotations(
-                num_mu=self.num_mu,
-                num_spin_orb=self.num_spin_orb,
-                num_bits_theta=self.num_bits_theta,
-                kr1=self.kr1,
-                kr2=self.kr2,
-                is_adjoint=True,
-            ),
-            nu_eq_mp1=nu_eq_mp1,
-            data=data,
-            sel=mu,
-            trg=sys_a,
-        )
+        data, mu, sys_a = bb.add(thc_rot.adjoint(), data=data, sel=mu, trg=sys_a)
         plus_b, sys_a, sys_b = bb.add(CSwap(self.num_spin_orb // 2), ctrl=plus_b, x=sys_a, y=sys_b)
 
         plus_mn = bb.add(XGate(), q=plus_mn)
@@ -255,20 +373,19 @@ class SelectTHC(SelectOracle):
         plus_b, sys_a, sys_b = bb.add(CSwap(self.num_spin_orb // 2), ctrl=plus_b, x=sys_a, y=sys_b)
 
         # Rotations
-        nu_eq_mp1, data, mu, sys_a = bb.add(
-            THCRotations(
+        if self.eta is not None:
+            thc_rot_two_body = THCRotations.from_thc_leaf_tensor(
+                self.eta, self.num_bits_theta, block_size=self.kr2, two_body_only=True
+            )
+        else:
+            thc_rot_two_body = THCRotations(
                 num_mu=self.num_mu,
                 num_spin_orb=self.num_spin_orb,
                 num_bits_theta=self.num_bits_theta,
-                kr1=self.kr1,
-                kr2=self.kr2,
+                block_size=self.kr2,
                 two_body_only=True,
-            ),
-            nu_eq_mp1=nu_eq_mp1,
-            data=data,
-            sel=mu,
-            trg=sys_a,
-        )
+            )
+        data, mu, sys_a = bb.add(thc_rot_two_body, data=data, sel=mu, trg=sys_a)
         # Controlled Z_0
         (succ, nu_eq_mp1), sys_b = bb.add(
             ApplyControlledZs(cvs=(1, 0), bitsize=self.num_spin_orb // 2),
@@ -276,21 +393,7 @@ class SelectTHC(SelectOracle):
             system=sys_b,
         )
         # Undo rotations
-        nu_eq_mp1, data, mu, sys_a = bb.add(
-            THCRotations(
-                num_mu=self.num_mu,
-                num_spin_orb=self.num_spin_orb,
-                num_bits_theta=self.num_bits_theta,
-                kr1=self.kr1,
-                kr2=self.kr2,
-                two_body_only=True,
-                is_adjoint=True,
-            ),
-            nu_eq_mp1=nu_eq_mp1,
-            data=data,
-            sel=mu,
-            trg=sys_a,
-        )
+        data, mu, sys_a = bb.add(thc_rot_two_body.adjoint(), data=data, sel=mu, trg=sys_a)
 
         # Clean up
         plus_b, sys_a, sys_b = bb.add(CSwap(self.num_spin_orb // 2), ctrl=plus_b, x=sys_a, y=sys_b)
@@ -327,8 +430,16 @@ class SelectTHC(SelectOracle):
 
 
 @bloq_example
+def _thc_rotations() -> THCRotations:
+    thc_rotations = THCRotations(num_mu=10, num_spin_orb=8, num_bits_theta=12)
+    return thc_rotations
+
+
+_THC_ROTATIONS = BloqDocSpec(bloq_cls=THCRotations, examples=(_thc_rotations,))
+
+
+@bloq_example
 def _thc_sel() -> SelectTHC:
-    num_mu = 8
     num_mu = 10
     num_spin_orb = 2 * 4
     thc_sel = SelectTHC(

--- a/qualtran/bloqs/chemistry/thc/select_bloq.py
+++ b/qualtran/bloqs/chemistry/thc/select_bloq.py
@@ -15,7 +15,7 @@
 """SELECT for the molecular tensor hypercontraction (THC) hamiltonian"""
 
 from functools import cached_property
-from typing import Dict, Optional, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple
 
 import numpy as np
 from attrs import evolve, field, frozen

--- a/qualtran/bloqs/chemistry/thc/select_bloq.py
+++ b/qualtran/bloqs/chemistry/thc/select_bloq.py
@@ -196,20 +196,22 @@ class THCRotations(Bloq):
         return "In_mu-R"
 
     def _build_qroam(self, num_angles: int, block_size: int) -> QROAMClean:
+        target_bitsizes = (self.num_bits_theta,) * num_angles
+        log_block_size = max(0, int(int(block_size) - 1).bit_length())
         if self.angles_data is None:
-            # NOTE: using an array of zeros effectively skips QROAM so this will throw off the cost
-            angles_data = tuple(tuple(0 for _ in range(self.num_terms)) for _ in range(num_angles))
-        else:
-            angles_data = self.angles_data
-            # pad angles array if necessary for one electron terms
-            angles_data = tuple(
-                col + (0,) * max(0, self.num_terms - len(col)) for col in self.angles_data
+            return QROAMClean.build_from_bitsize(
+                (self.num_terms,),
+                target_bitsizes=target_bitsizes,
+                selection_bitsizes=(self.selection_bitsize,),
+                log_block_sizes=(log_block_size,),
             )
 
-        target_bitsizes = (self.num_bits_theta,) * num_angles
-        log_block_size = (int(block_size) - 1).bit_length()
+        # pad angles array if necessary for one electron terms
+        angles_data = tuple(
+            col + (0,) * max(0, self.num_terms - len(col)) for col in self.angles_data
+        )
         return QROAMClean(
-            data_or_shape=[np.array(col) for col in angles_data],
+            data_or_shape=angles_data,
             target_bitsizes=target_bitsizes,
             selection_bitsizes=(self.selection_bitsize,),
             log_block_sizes=(log_block_size,),
@@ -445,7 +447,9 @@ class SelectTHC(SelectOracle):
 
 @bloq_example
 def _thc_rotations() -> THCRotations:
-    thc_rotations = THCRotations(num_mu=10, num_spin_orb=8, num_bits_theta=12)
+    rng = np.random.default_rng(42)
+    eta = rng.normal(size=(2, 4))
+    thc_rotations = THCRotations.from_thc_leaf_tensor(eta, num_bits_theta=12)
     return thc_rotations
 
 

--- a/qualtran/bloqs/chemistry/thc/select_bloq_test.py
+++ b/qualtran/bloqs/chemistry/thc/select_bloq_test.py
@@ -69,12 +69,10 @@ def test_leaf_tensor_to_givens_rotations():
 
 
 @pytest.mark.parametrize(
-    "num_mu, num_spatial, num_bits_theta", ((2, 4, 12), (4, 8, 15), (8, 16, 15))
+    "num_mu, num_spatial, num_bits_theta, kr1, kr2",
+    ((2, 4, 12, 1, 1), (4, 8, 15, 2, 2), (8, 16, 15, 2, 2)),
 )
-def test_thc_select_cost(num_mu, num_spatial, num_bits_theta):
-    kr1 = 1
-    kr2 = 1
-
+def test_thc_select_cost(num_mu, num_spatial, num_bits_theta, kr1, kr2):
     num_spin_orb = num_spatial * 2
     rng = np.random.default_rng(42)
     eta = rng.normal(size=(num_mu, num_spatial))  # THC vectors
@@ -95,8 +93,8 @@ def test_thc_select_cost(num_mu, num_spatial, num_bits_theta):
 
     # Toffoli cost according to the formula in the paper
     paper_cost_toffoli = num_spin_orb  # swaps controlled on spin (doubled for mu/nu)
-    paper_cost_toffoli += num_mu - 2  # QROM load mu
-    paper_cost_toffoli += num_mu - 2  # QROM load nu
+    paper_cost_toffoli += np.ceil(num_mu / kr1) - 2  # QROM load mu
+    paper_cost_toffoli += np.ceil(num_mu / kr2) - 2  # QROM load nu
     paper_cost_toffoli += 2 * num_spin_orb * (num_bits_theta - 2)  # rotations (doubled for mu/nu)
     paper_cost_toffoli += (
         2 * num_spin_orb * (num_bits_theta - 2)
@@ -115,9 +113,10 @@ def test_thc_select_cost(num_mu, num_spatial, num_bits_theta):
     cost_correction += rotation_correct - rotation_incorrect
 
     # correction - QROAM load breaks early when traversing binary tree and finding a zero
-    load_mu_term_correct = bin(num_mu).count("1") - 1
-    load_mu_term_incorrect = 0
-    cost_correction += load_mu_term_correct - load_mu_term_incorrect
+    b = (num_spatial - 1) * num_bits_theta
+    load_mu_term_correct = (kr1 - 1) * b + bin(num_mu).count("1") - 1
+    load_nu_term_correct = (kr2 - 1) * b + bin(num_mu).count("1") - 1
+    cost_correction += load_mu_term_correct + load_nu_term_correct
 
     # correction - QROAM erase always uses the optimal batch size
     k1 = int(np.round(0.5 * np.log2(num_mu)))

--- a/qualtran/bloqs/chemistry/thc/select_bloq_test.py
+++ b/qualtran/bloqs/chemistry/thc/select_bloq_test.py
@@ -76,6 +76,8 @@ def test_thc_select_cost(num_mu, num_spatial, num_bits_theta, kr1, kr2):
     num_spin_orb = num_spatial * 2
     rng = np.random.default_rng(42)
     eta = rng.normal(size=(num_mu, num_spatial))  # THC vectors
+    tpq = rng.normal(size=(num_spatial, num_spatial))
+    tpq = 0.5 * (tpq + tpq.T)
 
     thc_sel = SelectTHC(
         num_mu=num_mu,
@@ -85,6 +87,7 @@ def test_thc_select_cost(num_mu, num_spatial, num_bits_theta, kr1, kr2):
         kr1=kr1,
         kr2=kr2,
         eta=eta,
+        tpq=tpq,
     )
 
     binned_counts_t = classify_t_count_by_bloq_type(thc_sel.decompose_bloq())
@@ -93,13 +96,13 @@ def test_thc_select_cost(num_mu, num_spatial, num_bits_theta, kr1, kr2):
 
     # Toffoli cost according to the formula in the paper
     paper_cost_toffoli = num_spin_orb  # swaps controlled on spin (doubled for mu/nu)
-    paper_cost_toffoli += np.ceil(num_mu / kr1) - 2  # QROM load mu
+    paper_cost_toffoli += np.ceil((num_mu + num_spatial) / kr1) - 2  # QROM load mu
     paper_cost_toffoli += np.ceil(num_mu / kr2) - 2  # QROM load nu
     paper_cost_toffoli += 2 * num_spin_orb * (num_bits_theta - 2)  # rotations (doubled for mu/nu)
     paper_cost_toffoli += (
         2 * num_spin_orb * (num_bits_theta - 2)
     )  # invert rotations (doubled for mu/nu)
-    paper_cost_toffoli += np.ceil(1.0 * num_mu / kr1) + kr1  # QROM erase mu
+    paper_cost_toffoli += np.ceil(1.0 * (num_mu + num_spatial) / kr1) + kr1  # QROM erase mu
     paper_cost_toffoli += np.ceil(1.0 * num_mu / kr2) + kr2  # QROM erase nu
     paper_cost_toffoli += num_spin_orb  # swaps controlled by ancilla (doubled for mu/nu)
     paper_cost_toffoli += 2  # extra gates (CSwap on plus_a, plus_b and controlled Z)
@@ -112,20 +115,20 @@ def test_thc_select_cost(num_mu, num_spatial, num_bits_theta, kr1, kr2):
     rotation_incorrect = 4 * num_spin_orb * (num_bits_theta - 2)
     cost_correction += rotation_correct - rotation_incorrect
 
-    # correction - QROAM load breaks early when traversing binary tree and finding a zero
+    # correction - QROAM load costs are slightly different according to docstrings
     b = (num_spatial - 1) * num_bits_theta
-    load_mu_term_correct = (kr1 - 1) * b + bin(num_mu).count("1") - 1
-    load_nu_term_correct = (kr2 - 1) * b + bin(num_mu).count("1") - 1
+    load_mu_term_correct = (kr1 - 1) * b
+    load_nu_term_correct = (kr2 - 1) * b
     cost_correction += load_mu_term_correct + load_nu_term_correct
 
     # correction - QROAM erase always uses the optimal batch size
-    k1 = int(np.round(0.5 * np.log2(num_mu)))
+    k1 = int(np.round(0.5 * np.log2(num_mu + num_spatial)))
     k2 = int(np.round(0.5 * np.log2(num_mu)))
     kr1_optimal = 2**k1
     kr2_optimal = 2**k2
-    erase_mu_incorrect = np.ceil(1.0 * num_mu / kr1) + kr1
+    erase_mu_incorrect = np.ceil(1.0 * (num_mu + num_spatial) / kr1) + kr1
     erase_nu_incorrect = np.ceil(1.0 * num_mu / kr2) + kr2
-    erase_mu_correct = max(0, np.ceil(num_mu / kr1_optimal) + (kr1_optimal - 4))
+    erase_mu_correct = max(0, np.ceil((num_mu + num_spatial) / kr1_optimal) + (kr1_optimal - 4))
     erase_nu_correct = max(0, np.ceil(num_mu / kr2_optimal) + (kr2_optimal - 4))
     cost_correction += erase_mu_correct - erase_mu_incorrect
     cost_correction += erase_nu_correct - erase_nu_incorrect
@@ -137,12 +140,13 @@ def test_thc_select_cost(num_mu, num_spatial, num_bits_theta, kr1, kr2):
     assert tot_counts_toffoli == corrected_paper_cost_toffoli
 
 
-def test_thc_rotations_from_leaf_tensor():
+def test_thc_rotations_from_hamiltonian_coeffs():
     rng = np.random.default_rng(42)
     num_mu = 6
     num_spatial = 4
     eta = rng.normal(size=(num_mu, num_spatial))
-    bloq = THCRotations.from_thc_leaf_tensor(eta, num_bits_theta=10)
+    tpq = rng.normal(size=(num_spatial, num_spatial))
+    bloq = THCRotations.from_hamiltonian_coeffs(eta, tpq=tpq, num_bits_theta=10)
     assert bloq.num_mu == num_mu
     assert bloq.num_spin_orb == 2 * num_spatial
     assert bloq.num_bits_theta == 10

--- a/qualtran/bloqs/chemistry/thc/select_bloq_test.py
+++ b/qualtran/bloqs/chemistry/thc/select_bloq_test.py
@@ -12,8 +12,143 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from qualtran.bloqs.chemistry.thc.select_bloq import _thc_sel
+import numpy as np
+import pytest
+
+import qualtran.testing as qlt_testing
+from qualtran import QFxp
+from qualtran.bloqs.chemistry.thc.select_bloq import (
+    _leaf_tensor_to_givens_rotations,
+    _thc_rotations,
+    _thc_sel,
+    SelectTHC,
+    THCRotations,
+)
+from qualtran.resource_counting.classify_bloqs import classify_t_count_by_bloq_type
 
 
-def test_thc_uniform_prep(bloq_autotester):
+def test_thc_rotations_autotester(bloq_autotester):
+    bloq_autotester(_thc_rotations)
+
+
+def test_thc_select_autotester(bloq_autotester):
     bloq_autotester(_thc_sel)
+
+
+def test_leaf_tensor_to_givens_rotations():
+    """Tests that the computed thetas rotate from basis set to THC basis."""
+    num_mu = 5
+    num_spatial = 4
+    num_bits_theta = 25
+
+    rng = np.random.default_rng(42)
+    eta = rng.normal(size=(num_mu, num_spatial))
+
+    dtype = QFxp(num_bits_theta, num_bits_theta, signed=False)
+    thetas = _leaf_tensor_to_givens_rotations(eta, num_bits_theta)
+
+    for mu in range(num_mu):
+        U = np.eye(num_spatial)
+        eta_mu = eta[mu]
+        u = eta_mu / np.linalg.norm(eta_mu)
+        # build full rotation operator from Givens rotations angles
+        for k, theta in enumerate(thetas[:, mu]):
+            theta_f = dtype.float_from_fixed_width_int(theta) * 4 * np.pi
+            G_2d = np.array(
+                [[np.cos(theta_f), -np.sin(theta_f)], [np.sin(theta_f), np.cos(theta_f)]]
+            )
+            G_full = np.eye(num_spatial)
+            G_full[k : k + 2, k : k + 2] = G_2d
+            U = G_full @ U
+
+        # test U * (1,0,0...) = eta/norm(eta)
+        testvec = np.zeros(num_spatial)
+        testvec[0] = 1.0
+        result = U @ testvec - u
+        assert np.allclose(result, np.zeros(num_spatial), atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "num_mu, num_spatial, num_bits_theta", ((2, 4, 12), (4, 8, 15), (8, 16, 15))
+)
+def test_thc_select_cost(num_mu, num_spatial, num_bits_theta):
+    kr1 = 1
+    kr2 = 1
+
+    num_spin_orb = num_spatial * 2
+    rng = np.random.default_rng(42)
+    eta = rng.normal(size=(num_mu, num_spatial))  # THC vectors
+
+    thc_sel = SelectTHC(
+        num_mu=num_mu,
+        num_spin_orb=num_spin_orb,
+        num_bits_theta=num_bits_theta,
+        keep_bitsize=10,
+        kr1=kr1,
+        kr2=kr2,
+        eta=eta,
+    )
+
+    binned_counts_t = classify_t_count_by_bloq_type(thc_sel.decompose_bloq())
+    binned_counts_toffoli = {k: v / 4 for k, v in binned_counts_t.items()}
+    tot_counts_toffoli = sum(binned_counts_toffoli.values())
+
+    # Toffoli cost according to the formula in the paper
+    paper_cost_toffoli = num_spin_orb  # swaps controlled on spin (doubled for mu/nu)
+    paper_cost_toffoli += num_mu - 2  # QROM load mu
+    paper_cost_toffoli += num_mu - 2  # QROM load nu
+    paper_cost_toffoli += 2 * num_spin_orb * (num_bits_theta - 2)  # rotations (doubled for mu/nu)
+    paper_cost_toffoli += (
+        2 * num_spin_orb * (num_bits_theta - 2)
+    )  # invert rotations (doubled for mu/nu)
+    paper_cost_toffoli += np.ceil(1.0 * num_mu / kr1) + kr1  # QROM erase mu
+    paper_cost_toffoli += np.ceil(1.0 * num_mu / kr2) + kr2  # QROM erase nu
+    paper_cost_toffoli += num_spin_orb  # swaps controlled by ancilla (doubled for mu/nu)
+    paper_cost_toffoli += 2  # extra gates (CSwap on plus_a, plus_b and controlled Z)
+
+    # Corrections for the implementation in qualtran, not in the paper
+    cost_correction = 0
+
+    # correction - rotations include phase gradient state preparation
+    rotation_correct = 4 * (num_spin_orb - 2) * (num_bits_theta - 1) + 22 * num_bits_theta - 64
+    rotation_incorrect = 4 * num_spin_orb * (num_bits_theta - 2)
+    cost_correction += rotation_correct - rotation_incorrect
+
+    # correction - QROAM load breaks early when traversing binary tree and finding a zero
+    load_mu_term_correct = bin(num_mu).count("1") - 1
+    load_mu_term_incorrect = 0
+    cost_correction += load_mu_term_correct - load_mu_term_incorrect
+
+    # correction - QROAM erase always uses the optimal batch size
+    k1 = int(np.round(0.5 * np.log2(num_mu)))
+    k2 = int(np.round(0.5 * np.log2(num_mu)))
+    kr1_optimal = 2**k1
+    kr2_optimal = 2**k2
+    erase_mu_incorrect = np.ceil(1.0 * num_mu / kr1) + kr1
+    erase_nu_incorrect = np.ceil(1.0 * num_mu / kr2) + kr2
+    erase_mu_correct = max(0, np.ceil(num_mu / kr1_optimal) + (kr1_optimal - 4))
+    erase_nu_correct = max(0, np.ceil(num_mu / kr2_optimal) + (kr2_optimal - 4))
+    cost_correction += erase_mu_correct - erase_mu_incorrect
+    cost_correction += erase_nu_correct - erase_nu_incorrect
+
+    # correction - CSwap between mu and nu
+    cost_correction += num_mu.bit_length()
+
+    corrected_paper_cost_toffoli = paper_cost_toffoli + cost_correction
+    assert tot_counts_toffoli == corrected_paper_cost_toffoli
+
+
+def test_thc_rotations_from_leaf_tensor():
+    rng = np.random.default_rng(42)
+    num_mu = 6
+    num_spatial = 4
+    eta = rng.normal(size=(num_mu, num_spatial))
+    bloq = THCRotations.from_thc_leaf_tensor(eta, num_bits_theta=10)
+    assert bloq.num_mu == num_mu
+    assert bloq.num_spin_orb == 2 * num_spatial
+    assert bloq.num_bits_theta == 10
+    assert bloq.angles_data is not None
+    assert len(bloq.angles_data) == num_spatial - 1
+    assert hash(bloq) == hash(bloq)
+    qlt_testing.assert_valid_bloq_decomposition(bloq)
+    qlt_testing.assert_valid_bloq_decomposition(bloq.adjoint())

--- a/qualtran/bloqs/chemistry/thc/thc.ipynb
+++ b/qualtran/bloqs/chemistry/thc/thc.ipynb
@@ -475,21 +475,21 @@
     " - `num_mu`: THC auxiliary index dimension $M$\n",
     " - `num_spin_orb`: number of spin orbitals $N$\n",
     " - `num_bits_theta`: Number of bits of precision for the rotations. Called $\\beth$ in the reference.\n",
+    " - `keep_bitsize`: number of bits for keep register for coherent alias sampling. This can be determined from the PrepareTHC bloq. See https://github.com/quantumlib/Qualtran/issues/549\n",
     " - `kr1`: block sizes for QROM erasure for outputting rotation angles. See Eq 34.\n",
     " - `kr2`: block sizes for QROM erasure for outputting rotation angles. This is for the second QROM (eq 35)\n",
     " - `control_val`: A control bit for the entire gate.\n",
-    " - `keep_bitsize`: number of bits for keep register for coherent alias\n",
-    " - `sampling. This can be determined from the PrepareTHC bloq. See`: \n",
-    " - `https`: //github.com/quantumlib/Qualtran/issues/549 \n",
+    " - `eta`: Optional THC leaf tensor of shape (M, N/2). \n",
     "\n",
     "#### Registers\n",
     " - `succ`: success flag qubit from uniform state preparation\n",
-    " - `nu_eq_mp1`: flag for if $nu = M+1$\n",
+    " - `nu_eq_mp1`: flag for if $\\nu = M+1$\n",
     " - `mu`: $\\mu$ register.\n",
     " - `nu`: $\\nu$ register.\n",
-    " - `theta`: sign register.\n",
-    " - `plus_mn`: Flag controlling swaps between mu and nu. Note that as per the Reference, the swaps are NOT performed as part of SELECT as they're acounted for during Prepare.\n",
+    " - `plus_mn`: Flag controlling swaps between mu and nu. Note that as per the Reference, the swaps are NOT performed as part of SELECT as they're accounted for during Prepare.\n",
     " - `plus_a / plus_b`: plus state for controlled swaps on spins.\n",
+    " - `sigma`: ancilla register for alias sampling.\n",
+    " - `rot`: ancilla register for uniform superposition rotation.\n",
     " - `sys_a / sys_b`: System registers for (a)lpha/(b)eta orbitals. \n",
     "\n",
     "#### References\n",
@@ -527,7 +527,6 @@
    },
    "outputs": [],
    "source": [
-    "num_mu = 8\n",
     "num_mu = 10\n",
     "num_spin_orb = 2 * 4\n",
     "thc_sel = SelectTHC(\n",
@@ -601,6 +600,124 @@
    "source": [
     "from qualtran.drawing import show_flame_graph\n",
     "show_flame_graph(thc_sel)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5dd91d19",
+   "metadata": {
+    "cq.autogen": "THCRotations.bloq_doc.md"
+   },
+   "source": [
+    "## `THCRotations`\n",
+    "Bloq for rotating into THC basis through Givens rotation network.\n",
+    "\n",
+    "This is accounting for In-data:rot and In-R in Fig. 7 of the THC paper (Ref.\n",
+    "1).\n",
+    "\n",
+    "The bloq loads $N/2 - 1$ Givens rotation angles from the selection register\n",
+    "using QROAM, prepares a phase gradient state, applies $N/2 - 1$ real\n",
+    "Givens rotations between spatial orbitals using `RealGivensRotationByPhaseGradient`,\n",
+    "and uncomputes the phase gradient state.\n",
+    "\n",
+    "#### Parameters\n",
+    " - `num_mu`: THC auxiliary index dimension $M$\n",
+    " - `num_spin_orb`: number of spin orbitals $N$ (number of spatial orbitals = $N/2$).\n",
+    " - `num_bits_theta`: Number of bits of precision for the rotations. Called $\\beth$ in the reference.\n",
+    " - `two_body_only`: Whether to only apply the two body Hamiltonian. This reduces the QROM size.\n",
+    " - `is_adjoint`: Whether to dagger this bloq or not.\n",
+    " - `angles_data`: Optional tuple of tuples of integer-quantized angles. If None, default (zero) angle data is used. \n",
+    "\n",
+    "#### Registers\n",
+    " - `data`: Register storing the loaded rotation angle data.\n",
+    " - `sel`: Selection register indexing $\\mu$ (or one-body orbital).\n",
+    " - `trg`: Target spatial orbitals register of size $N/2$. \n",
+    "\n",
+    "#### References\n",
+    " - [Even more efficient quantum computations of chemistry through     tensor hypercontraction](https://arxiv.org/pdf/2011.03494.pdf). Fig. 7. [Quantum computing enhanced computational catalysis](https://arxiv.org/abs/2007.14460).     Burg, Low, et al. 2021. Eq. 73\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46c736f6",
+   "metadata": {
+    "cq.autogen": "THCRotations.bloq_doc.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.bloqs.chemistry.thc import THCRotations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4072e7f3",
+   "metadata": {
+    "cq.autogen": "THCRotations.example_instances.md"
+   },
+   "source": [
+    "### Example Instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ead60f95",
+   "metadata": {
+    "cq.autogen": "THCRotations.thc_rotations"
+   },
+   "outputs": [],
+   "source": [
+    "thc_rotations = THCRotations(num_mu=10, num_spin_orb=8, num_bits_theta=12)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbd82cfc",
+   "metadata": {
+    "cq.autogen": "THCRotations.graphical_signature.md"
+   },
+   "source": [
+    "#### Graphical Signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69cf8a81",
+   "metadata": {
+    "cq.autogen": "THCRotations.graphical_signature.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.drawing import show_bloqs\n",
+    "show_bloqs([thc_rotations],\n",
+    "           ['`thc_rotations`'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "106fea06",
+   "metadata": {
+    "cq.autogen": "THCRotations.call_graph.md"
+   },
+   "source": [
+    "### Call Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29ae0734",
+   "metadata": {
+    "cq.autogen": "THCRotations.call_graph.py"
+   },
+   "outputs": [],
+   "source": [
+    "from qualtran.resource_counting.generalizers import ignore_split_join\n",
+    "thc_rotations_g, thc_rotations_sigma = thc_rotations.call_graph(max_depth=1, generalizer=ignore_split_join)\n",
+    "show_call_graph(thc_rotations_g)\n",
+    "show_counts_sigma(thc_rotations_sigma)"
    ]
   }
  ],

--- a/qualtran/bloqs/chemistry/thc/thc.ipynb
+++ b/qualtran/bloqs/chemistry/thc/thc.ipynb
@@ -671,7 +671,9 @@
    "source": [
     "rng = np.random.default_rng(42)\n",
     "eta = rng.normal(size=(2, 4))\n",
-    "thc_rotations = THCRotations.from_thc_leaf_tensor(eta, num_bits_theta=12)"
+    "tpq = rng.normal(size=(4, 4))\n",
+    "tpq = 0.5 * (tpq + tpq.T)\n",
+    "thc_rotations = THCRotations.from_hamiltonian_coeffs(eta, num_bits_theta=12, tpq=tpq)"
    ]
   },
   {

--- a/qualtran/bloqs/chemistry/thc/thc.ipynb
+++ b/qualtran/bloqs/chemistry/thc/thc.ipynb
@@ -624,6 +624,7 @@
     " - `num_mu`: THC auxiliary index dimension $M$\n",
     " - `num_spin_orb`: number of spin orbitals $N$ (number of spatial orbitals = $N/2$).\n",
     " - `num_bits_theta`: Number of bits of precision for the rotations. Called $\\beth$ in the reference.\n",
+    " - `block_size`: Block size for QROAM loading.\n",
     " - `two_body_only`: Whether to only apply the two body Hamiltonian. This reduces the QROM size.\n",
     " - `is_adjoint`: Whether to dagger this bloq or not.\n",
     " - `angles_data`: Optional tuple of tuples of integer-quantized angles. If None, default (zero) angle data is used. \n",
@@ -668,7 +669,9 @@
    },
    "outputs": [],
    "source": [
-    "thc_rotations = THCRotations(num_mu=10, num_spin_orb=8, num_bits_theta=12)"
+    "rng = np.random.default_rng(42)\n",
+    "eta = rng.normal(size=(2, 4))\n",
+    "thc_rotations = THCRotations.from_thc_leaf_tensor(eta, num_bits_theta=12)"
    ]
   },
   {

--- a/qualtran/serialization/resolver_dict.py
+++ b/qualtran/serialization/resolver_dict.py
@@ -82,6 +82,7 @@ import qualtran.bloqs.chemistry.pbc.first_quantization.projectile.select_uv
 import qualtran.bloqs.chemistry.pbc.first_quantization.select_and_prepare
 import qualtran.bloqs.chemistry.pbc.first_quantization.select_t
 import qualtran.bloqs.chemistry.pbc.first_quantization.select_uv
+import qualtran.bloqs.chemistry.quad_fermion.givens_bloq
 import qualtran.bloqs.chemistry.sf.prepare
 import qualtran.bloqs.chemistry.sf.select_bloq
 import qualtran.bloqs.chemistry.sf.single_factorization
@@ -329,6 +330,8 @@ RESOLVER_DICT = {
     "qualtran.bloqs.chemistry.pbc.first_quantization.select_t.SelectTFirstQuantization": qualtran.bloqs.chemistry.pbc.first_quantization.select_t.SelectTFirstQuantization,
     "qualtran.bloqs.chemistry.pbc.first_quantization.select_uv.ApplyNuclearPhase": qualtran.bloqs.chemistry.pbc.first_quantization.select_uv.ApplyNuclearPhase,
     "qualtran.bloqs.chemistry.pbc.first_quantization.select_uv.SelectUVFirstQuantization": qualtran.bloqs.chemistry.pbc.first_quantization.select_uv.SelectUVFirstQuantization,
+    "qualtran.bloqs.chemistry.quad_fermion.givens_bloq.ComplexGivensRotationByPhaseGradient": qualtran.bloqs.chemistry.quad_fermion.givens_bloq.ComplexGivensRotationByPhaseGradient,
+    "qualtran.bloqs.chemistry.quad_fermion.givens_bloq.RealGivensRotationByPhaseGradient": qualtran.bloqs.chemistry.quad_fermion.givens_bloq.RealGivensRotationByPhaseGradient,
     "qualtran.bloqs.chemistry.sf.prepare.InnerPrepareSingleFactorization": qualtran.bloqs.chemistry.sf.prepare.InnerPrepareSingleFactorization,
     "qualtran.bloqs.chemistry.sf.prepare.OuterPrepareSingleFactorization": qualtran.bloqs.chemistry.sf.prepare.OuterPrepareSingleFactorization,
     "qualtran.bloqs.chemistry.sf.select_bloq.SelectSingleFactorization": qualtran.bloqs.chemistry.sf.select_bloq.SelectSingleFactorization,


### PR DESCRIPTION
Fixes #386. This adds the underlying QROAM and RealGivensRotationByPhaseGradient 
bloqs to implement the SelectTHC bloq. Differences in Toffoli costs vs. the paper were
documented in a test.