### PR TITLE
Extend the classical action on SelectedMajoranaFermion.

### DIFF
--- a/qualtran/bloqs/multiplexers/selected_majorana_fermion.py
+++ b/qualtran/bloqs/multiplexers/selected_majorana_fermion.py
@@ -146,8 +146,10 @@ class SelectedMajoranaFermion(UnaryIterationGate):
                 return vals
         selection = 0
         for selection_register in self.selection_registers:
-            selection = (selection*(selection_register.dtype.iteration_length_or_zero())
-                         + vals[selection_register.name])
+            selection = (
+                selection * (selection_register.dtype.iteration_length_or_zero())
+                + vals[selection_register.name]
+            )
 
         # When target_gate == cirq.X, flip the selection-th bit in target. The ith bit of a
         # size N regirster is addressed with the unsigned integer 2^(N - 1 - i) in our big
@@ -167,8 +169,10 @@ class SelectedMajoranaFermion(UnaryIterationGate):
                 return 1
         selection = 0
         for selection_register in self.selection_registers:
-            selection = (selection*(selection_register.dtype.iteration_length_or_zero())
-                         + vals[selection_register.name])
+            selection = (
+                selection * (selection_register.dtype.iteration_length_or_zero())
+                + vals[selection_register.name]
+            )
 
         target = vals['target']
         max_selection = total_bits(self.target_registers) - 1

--- a/qualtran/bloqs/multiplexers/selected_majorana_fermion.py
+++ b/qualtran/bloqs/multiplexers/selected_majorana_fermion.py
@@ -141,51 +141,51 @@ class SelectedMajoranaFermion(UnaryIterationGate):
     def on_classical_vals(self, **vals) -> Dict[str, 'ClassicalValT']:
         if self.target_gate != cirq.X and self.target_gate != cirq.Z:
             return NotImplemented
-        if len(self.control_registers) != 1 or len(self.selection_registers) != 1:
-            return NotImplemented
-        control_name = self.control_registers[0].name
-        control = vals[control_name]
-        selection_name = self.selection_registers[0].name
-        selection = vals[selection_name]
-        target = vals['target']
+        for control_register in self.control_registers:
+            if vals[control_register.name] == 0:
+                return vals
+        selection = 0
+        for selection_register in self.selection_registers:
+            selection = (selection*(selection_register.dtype.iteration_length_or_zero())
+                         + vals[selection_register.name])
 
         # When target_gate == cirq.X, flip the selection-th bit in target. The ith bit of a
         # size N regirster is addressed with the unsigned integer 2^(N - 1 - i) in our big
         # endian convention.
-        if control and self.target_gate == cirq.X:
-            max_selection = self.selection_registers[0].dtype.iteration_length_or_zero() - 1
-            target = (2 ** (max_selection - selection)) ^ target
+        if self.target_gate == cirq.X:
+            max_selection = total_bits(self.target_registers) - 1
+            vals['target'] = (2 ** (max_selection - selection)) ^ vals['target']
         # When target_gate == cirq.Z, the action is only in the phase.
 
-        return {control_name: control, selection_name: selection, 'target': target}
+        return vals
 
     def basis_state_phase(self, **vals) -> Union[complex, None]:
         if self.target_gate != cirq.X and self.target_gate != cirq.Z:
             return None
-        if len(self.control_registers) != 1 or len(self.selection_registers) != 1:
-            return None
-        control_name = self.control_registers[0].name
-        control = vals[control_name]
-        selection_name = self.selection_registers[0].name
-        selection = vals[selection_name]
+        for control_register in self.control_registers:
+            if vals[control_register.name] == 0:
+                return 1
+        selection = 0
+        for selection_register in self.selection_registers:
+            selection = (selection*(selection_register.dtype.iteration_length_or_zero())
+                         + vals[selection_register.name])
+
         target = vals['target']
-        if control:
-            max_selection = self.selection_registers[0].dtype.iteration_length_or_zero() - 1
-            # This gate applies Z in positions 0 through (selection - 1). The effect is
-            # a phase of plus or minus 1 depending on the parity of the number of ones
-            # in those positions. For an N-bit big endian integer, the first j bits can
-            # be isolated by shifting right by N - j.
-            #
-            # The target gate X has no additional phase, so calculate as in the
-            # previous paragraph.
-            if self.target_gate == cirq.X:
-                num_phases = (target >> (max_selection - selection + 1)).bit_count()
-            # The target gate Z is applied in position selection, so consider the full
-            # range 0 through selection.
-            else:
-                num_phases = (target >> (max_selection - selection)).bit_count()
-            return 1 if (num_phases % 2) == 0 else -1
-        return 1
+        max_selection = total_bits(self.target_registers) - 1
+        # This gate applies Z in positions 0 through (selection - 1). The effect is
+        # a phase of plus or minus 1 depending on the parity of the number of ones
+        # in those positions. For an N-bit big endian integer, the first j bits can
+        # be isolated by shifting right by N - j.
+        #
+        # The target gate X has no additional phase, so calculate as in the
+        # previous paragraph.
+        if self.target_gate == cirq.X:
+            num_phases = (target >> (max_selection - selection + 1)).bit_count()
+        # The target gate Z is applied in position selection, so consider the full
+        # range 0 through selection.
+        else:
+            num_phases = (target >> (max_selection - selection)).bit_count()
+        return 1 if (num_phases % 2) == 0 else -1
 
     def __str__(self):
         return f'SelectedMajoranaFermion({self.target_gate})'

--- a/qualtran/bloqs/multiplexers/selected_majorana_fermion_test.py
+++ b/qualtran/bloqs/multiplexers/selected_majorana_fermion_test.py
@@ -16,7 +16,7 @@ import cirq
 import numpy as np
 import pytest
 
-from qualtran import BQUInt, QUInt, Register
+from qualtran import BQUInt, QBit, QUInt, Register
 from qualtran._infra.gate_with_registers import get_named_qubits, total_bits
 from qualtran.bloqs.multiplexers.selected_majorana_fermion import SelectedMajoranaFermion
 from qualtran.cirq_interop.testing import GateHelper
@@ -163,14 +163,23 @@ def test_selected_majorana_fermion_classical_action(selection_bitsize, target_bi
         gate, selection=range(target_bitsize), target=range(2**target_bitsize), control=range(2)
     )
 
-def test_selected_majorana_fermion_classical_action_multiple_selection():
+
+def test_selected_majorana_fermion_classical_action_multiple_selections():
     gate = SelectedMajoranaFermion(
-        (
-            Register('selection1', BQUInt(2, 3)),
-            Register('selection2', BQUInt(1, 2)),
-        ),
-        target_gate=cirq.X
+        (Register('selection1', BQUInt(2, 3)), Register('selection2', BQUInt(1, 2))),
+        target_gate=cirq.X,
     )
     assert_consistent_phased_classical_action(
         gate, selection1=range(3), selection2=range(2), target=range(2**6), control=range(2)
+    )
+
+
+def test_selected_majorana_fermion_classical_action_multiple_controls():
+    gate = SelectedMajoranaFermion(
+        selection_regs=Register('selection', BQUInt(2, 4)),
+        control_regs=(Register('control1', QBit()), Register('control2', QBit())),
+        target_gate=cirq.X,
+    )
+    assert_consistent_phased_classical_action(
+        gate, selection=range(4), target=range(2**4), control1=range(2), control2=range(2)
     )

--- a/qualtran/bloqs/multiplexers/selected_majorana_fermion_test.py
+++ b/qualtran/bloqs/multiplexers/selected_majorana_fermion_test.py
@@ -162,3 +162,15 @@ def test_selected_majorana_fermion_classical_action(selection_bitsize, target_bi
     assert_consistent_phased_classical_action(
         gate, selection=range(target_bitsize), target=range(2**target_bitsize), control=range(2)
     )
+
+def test_selected_majorana_fermion_classical_action_multiple_selection():
+    gate = SelectedMajoranaFermion(
+        (
+            Register('selection1', BQUInt(2, 3)),
+            Register('selection2', BQUInt(1, 2)),
+        ),
+        target_gate=cirq.X
+    )
+    assert_consistent_phased_classical_action(
+        gate, selection1=range(3), selection2=range(2), target=range(2**6), control=range(2)
+    )


### PR DESCRIPTION
Handle multiple selection and/or control registers (while still restricting to target gate X or Z).
Fixes #1699 .